### PR TITLE
0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popsure/dirty-swan",
-  "version": "0.17.0",
+  "version": "0.17.1-alpha.1",
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popsure/dirty-swan",
-  "version": "0.17.1-alpha.1",
+  "version": "0.18.0-alpha.1",
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,7 @@ export {
   CardWithLeftIcon,
   CardWithTopIcon,
   InfoCard,
+  Button,
 } from './lib';
 
 export type { DownloadRingDownloadStatus } from './lib';

--- a/src/lib/components/button/icons/index.ts
+++ b/src/lib/components/button/icons/index.ts
@@ -1,0 +1,14 @@
+import purpleSendImage from './send-purple.svg';
+import whiteSendImage from './send-white.svg';
+
+const purpleSend = {
+  src: purpleSendImage,
+  alt: 'Paper plane',
+};
+
+const whiteSend = {
+  src: whiteSendImage,
+  alt: 'Paper plane',
+};
+
+export { purpleSend, whiteSend };

--- a/src/lib/components/button/icons/send-purple.svg
+++ b/src/lib/components/button/icons/send-purple.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.3334 1.66667L9.16675 10.8333" stroke="#8E8CEE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.3334 1.66667L12.5001 18.3333L9.16675 10.8333L1.66675 7.5L18.3334 1.66667Z" stroke="#8E8CEE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/lib/components/button/icons/send-white.svg
+++ b/src/lib/components/button/icons/send-white.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.3334 1.66667L9.16675 10.8333" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.3334 1.66667L12.5001 18.3333L9.16675 10.8333L1.66675 7.5L18.3334 1.66667Z" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/lib/components/button/index.stories.mdx
+++ b/src/lib/components/button/index.stories.mdx
@@ -1,0 +1,83 @@
+import { Meta, Preview } from '@storybook/addon-docs/blocks';
+
+import Button from '.';
+import { purpleSend, whiteSend } from './icons';
+
+<Meta title="JSX/Button" />
+
+# Button
+
+Buttons allow users to take actions, and make choices, with a single tap. Buttons communicate actions that users can take.
+
+You are looking at the JSX definition of the Button component, if you want you can use the [css alternative](?path=/story/css-components-button--page)
+
+<Preview>
+  <iframe
+    width="100%"
+    height="450"
+    src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FMKs4cbojdVOBKUxv7okb93%2FDirty-Swan-Pattern-Library%3Fnode-id%3D251%253A26"
+    allowfullscreen
+  ></iframe>
+</Preview>
+
+| attribute   | unit                                       | description                                             | default value | required |
+| ----------- | ------------------------------------------ | ------------------------------------------------------- | ------------- | -------- |
+| buttonTitle | string                                     | The title text that needs to be displayed               | n/a           | true     |
+| buttonType  | 'primary' 'secondary'                      | Button type will influence the look of the button       | 'primary'     | false    |
+| leftIcon    | [Icon](?path=/story/jsx-button--page#icon) | Icon displayed left side of the button (w:20px, h:20px) | n/a           | false    |
+| loading     | boolean                                    | Wether the button should display a loading spinner      | false         | false    |
+
+<Preview>
+  <>
+    <h1 className="p-h1">Primary button</h1>
+    <h4 className="p-h4 mt24">Default</h4>
+    <Button className="wmn3 mt8" buttonTitle="Click me" />
+    <h4 className="p-h4 mt24">Loading</h4>
+    <Button className="wmn3 mt8" buttonTitle="Click me" loading={true} />
+    <h4 className="p-h4 mt24">Disabled</h4>
+    <Button className="wmn3 mt8" buttonTitle="Click me" disabled={true} />
+    <h4 className="p-h4 mt24">With left icon</h4>
+    <Button className="wmn3 mt8" buttonTitle="Click me" leftIcon={whiteSend} />
+    <h1 className="p-h1 mt32">Secondary button</h1>
+    <h4 className="p-h4 mt24">Default</h4>
+    <Button
+      className="wmn3 mt8"
+      buttonTitle="Click me"
+      buttonType="secondary"
+    />
+    <h4 className="p-h4 mt24">Loading</h4>
+    <Button
+      className="wmn3 mt8"
+      buttonTitle="Click me"
+      buttonType="secondary"
+      loading={true}
+    />
+    <h4 className="p-h4 mt24">Disabled</h4>
+    <Button
+      className="wmn3 mt8"
+      buttonTitle="Click me"
+      buttonType="secondary"
+      disabled={true}
+    />
+    <h4 className="p-h4 mt24">With left icon</h4>
+    <Button
+      className="wmn3 mt8"
+      buttonTitle="Click me"
+      buttonType="secondary"
+      leftIcon={purpleSend}
+    />
+  </>
+</Preview>
+
+# Models
+
+## Icon
+
+The icon object is defined with the following poperties
+
+```typescript
+export interface Icon {
+  src: string; // source of the image
+  alt: string; // alternate text if the image can't be displayed
+}
+```

--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import styles from './styles.module.scss';
+
+type ButtonType = 'primary' | 'secondary';
+
+interface Icon {
+  src: string;
+  alt: string;
+}
+
+type InputProps = {
+  buttonTitle: string;
+  buttonType?: ButtonType;
+  leftIcon?: Icon;
+  loading?: boolean;
+} & Omit<JSX.IntrinsicElements['button'], 'children'>;
+
+export default React.forwardRef(
+  ({
+    className,
+    loading = false,
+    buttonTitle,
+    buttonType = 'primary',
+    leftIcon,
+    type,
+    ...props
+  }: InputProps) => {
+    const buttonClassName =
+      buttonType === 'primary' ? 'p-btn--primary' : 'p-btn--secondary';
+    const loadingClassName = loading ? 'p-btn--loading' : '';
+    return (
+      <button
+        className={`${buttonClassName} ${loadingClassName} ${className ?? ''}`}
+        {...props}
+      >
+        {leftIcon ? (
+          <div className={styles['content-container']}>
+            <img
+              width="20px"
+              height="20px"
+              className="mr8"
+              src={leftIcon.src}
+              alt={leftIcon.alt}
+            />
+            <div>{buttonTitle}</div>
+          </div>
+        ) : (
+          <>{buttonTitle}</>
+        )}
+      </button>
+    );
+  }
+);

--- a/src/lib/components/button/styles.module.scss
+++ b/src/lib/components/button/styles.module.scss
@@ -1,0 +1,5 @@
+.content-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/lib/components/modal/regularModal/style.module.scss
+++ b/src/lib/components/modal/regularModal/style.module.scss
@@ -67,6 +67,7 @@
   border-radius: 8px;
 
   max-width: 592px;
+  width: fit-content;
 
   animation-name: appear-in;
   animation-duration: 0.4s;

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -17,6 +17,7 @@ import {
   CardWithTopIcon,
   InfoCard,
 } from './components/cards';
+import Button from './components/button';
 
 export {
   DateSelector,
@@ -34,6 +35,7 @@ export {
   CardWithLeftIcon,
   CardWithTopIcon,
   InfoCard,
+  Button,
 };
 
 export type { DownloadRingDownloadStatus } from './models/downloadRing';

--- a/src/lib/scss/private/components/button.stories.mdx
+++ b/src/lib/scss/private/components/button.stories.mdx
@@ -6,6 +6,8 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 
 Buttons allow users to take actions, and make choices, with a single tap. Buttons communicate actions that users can take.
 
+You are looking at the css definition of the Button component, if you want you can use the [pure JSX alternative](?path=/story/jsx-button--page)
+
 ## Primary button
 
 ### Default


### PR DESCRIPTION
In this release `0.18.0` we're introducing a new way to create button directly in JSX. This allow us to more easily set `loading` and `disabled` states. We're also adding the possibility to add a left-icon to the button.

We've also adjusted the way the `RegularModal` works with its child content. The `width` is now set to `fit-content`.