### PR TITLE
[NoTicket] Add focus styles to p-a component

### DIFF
--- a/src/lib/scss/private/base/_typography.scss
+++ b/src/lib/scss/private/base/_typography.scss
@@ -95,7 +95,7 @@ body {
 .p-a {
   color: $ds-primary-500;
   text-decoration: none;
-  &:hover {
+  &:hover, &:focus {
     color: $ds-primary-700;
   }
 }


### PR DESCRIPTION
To have better accessibility, this PR adds a `focus` style to the p-a component