### PR TITLE
Cha 2204 extend card component

### DIFF
--- a/src/lib/components/cards/cardWithTopIcon/index.stories.mdx
+++ b/src/lib/components/cards/cardWithTopIcon/index.stories.mdx
@@ -26,9 +26,11 @@ import { featherLogo } from '../icons';
       rightIcon="arrow"
       topIcon={featherLogo}
     >
-      Praesent euismod porta odio at tempus.{' '}
-      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
-      eros at, rhoncus imperdiet nunc
+      <p className="p-p mt16 tc-grey-700">
+        Praesent euismod porta odio at tempus.{' '}
+        <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+        eros at, rhoncus imperdiet nunc
+      </p>
     </CardWithTopIcon>
     <h4 className="p-h4 mt24">Medium title</h4>
     <CardWithTopIcon
@@ -38,9 +40,11 @@ import { featherLogo } from '../icons';
       rightIcon="arrow"
       topIcon={featherLogo}
     >
-      Praesent euismod porta odio at tempus.{' '}
-      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
-      eros at, rhoncus imperdiet nunc
+      <p className="p-p mt16 tc-grey-700">
+        Praesent euismod porta odio at tempus.{' '}
+        <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+        eros at, rhoncus imperdiet nunc
+      </p>
     </CardWithTopIcon>
     <h4 className="p-h4 mt24">Big title</h4>
     <CardWithTopIcon
@@ -50,9 +54,11 @@ import { featherLogo } from '../icons';
       rightIcon="arrow"
       topIcon={featherLogo}
     >
-      Praesent euismod porta odio at tempus.{' '}
-      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
-      eros at, rhoncus imperdiet nunc
+      <p className="p-p mt16 tc-grey-700">
+        Praesent euismod porta odio at tempus.{' '}
+        <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+        eros at, rhoncus imperdiet nunc
+      </p>
     </CardWithTopIcon>
     <h4 className="p-h4 mt24">Muted</h4>
     <CardWithTopIcon
@@ -62,9 +68,11 @@ import { featherLogo } from '../icons';
       topIcon={featherLogo}
       state="muted"
     >
-      Praesent euismod porta odio at tempus.{' '}
-      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
-      eros at, rhoncus imperdiet nunc
+      <p className="p-p mt16 tc-grey-700">
+        Praesent euismod porta odio at tempus.{' '}
+        <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+        eros at, rhoncus imperdiet nunc
+      </p>
     </CardWithTopIcon>
     <h4 className="p-h4 mt24">No right icon</h4>
     <CardWithTopIcon
@@ -73,9 +81,11 @@ import { featherLogo } from '../icons';
       titleSize="small"
       className="wmx6 mt8"
     >
-      Praesent euismod porta odio at tempus.{' '}
-      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
-      eros at, rhoncus imperdiet nunc
+      <p className="p-p mt16 tc-grey-700">
+        Praesent euismod porta odio at tempus.{' '}
+        <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+        eros at, rhoncus imperdiet nunc
+      </p>
     </CardWithTopIcon>
     <h4 className="p-h4 mt24">No dropshadow</h4>
     <CardWithTopIcon
@@ -85,9 +95,11 @@ import { featherLogo } from '../icons';
       className="wmx6 mt8"
       dropshadow={false}
     >
-      Praesent euismod porta odio at tempus.{' '}
-      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
-      eros at, rhoncus imperdiet nunc
+      <p className="p-p mt16 tc-grey-700">
+        Praesent euismod porta odio at tempus.{' '}
+        <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+        eros at, rhoncus imperdiet nunc
+      </p>
     </CardWithTopIcon>
   </>
 </Preview>

--- a/src/lib/components/cards/cardWithTopIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopIcon/index.tsx
@@ -32,8 +32,8 @@ export default ({
       {...props}
     >
       <img
-        width={topIconSize?.width}
-        height={topIconSize?.height}
+        width={topIconSize.width}
+        height={topIconSize.height}
         alt={topIcon.alt}
         src={topIcon.src}
       />

--- a/src/lib/components/cards/cardWithTopIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopIcon/index.tsx
@@ -32,8 +32,8 @@ export default ({
       {...props}
     >
       <img
-        width={topIconSize?.width ? `${topIconSize?.width}px` : '48xp'}
-        height={topIconSize?.height ? `${topIconSize?.height}px` : '48xp'}
+        width={topIconSize ? `${topIconSize?.width}px` : '48xp'}
+        height={topIconSize ? `${topIconSize?.height}px` : '48xp'}
         alt={topIcon.alt}
         src={topIcon.src}
       />

--- a/src/lib/components/cards/cardWithTopIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopIcon/index.tsx
@@ -13,14 +13,14 @@ export default ({
   titleSize = 'medium',
   children,
   topIcon,
-  topIconSize,
+  topIconSize = { width: 48, height: 48 },
   rightIcon,
   state = 'actionable',
   dropshadow = true,
   ...props
 }: CardProps & {
   topIcon: Icon;
-  topIconSize?: IconSize;
+  topIconSize: IconSize;
   titleSize?: 'small' | 'medium' | 'big';
   rightIcon?: 'arrow' | Icon;
 }) => (
@@ -32,8 +32,8 @@ export default ({
       {...props}
     >
       <img
-        width={topIconSize ? `${topIconSize?.width}px` : '48xp'}
-        height={topIconSize ? `${topIconSize?.height}px` : '48xp'}
+        width={topIconSize?.width}
+        height={topIconSize?.height}
         alt={topIcon.alt}
         src={topIcon.src}
       />

--- a/src/lib/components/cards/cardWithTopIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopIcon/index.tsx
@@ -3,7 +3,7 @@ import {
   CardProps,
   headingForTitleSize,
 } from '..';
-import { Icon, arrowRight } from '../icons';
+import { Icon, arrowRight, IconSize } from '../icons';
 
 import styles from './style.module.scss';
 
@@ -13,12 +13,14 @@ export default ({
   titleSize = 'medium',
   children,
   topIcon,
+  topIconSize,
   rightIcon,
   state = 'actionable',
   dropshadow = true,
   ...props
 }: CardProps & {
   topIcon: Icon;
+  topIconSize?: IconSize;
   titleSize?: 'small' | 'medium' | 'big';
   rightIcon?: 'arrow' | Icon;
 }) => (
@@ -29,7 +31,12 @@ export default ({
       } ${className ?? ''}`}
       {...props}
     >
-      <img width="48xp" height="48px" alt={topIcon.alt} src={topIcon.src} />
+      <img
+        width={topIconSize?.width ? `${topIconSize?.width}px` : '48xp'}
+        height={topIconSize?.height ? `${topIconSize?.height}px` : '48xp'}
+        alt={topIcon.alt}
+        src={topIcon.src}
+      />
       <div className="d-flex mt16">
         <div className={headingForTitleSize(titleSize)}>{title}</div>
         {rightIcon && (
@@ -42,7 +49,7 @@ export default ({
           />
         )}
       </div>
-      <p className="p-p mt16 tc-grey-700">{children}</p>
+      {children}
     </div>
   </>
 );

--- a/src/lib/components/cards/icons/index.ts
+++ b/src/lib/components/cards/icons/index.ts
@@ -7,6 +7,11 @@ export interface Icon {
   alt: string;
 }
 
+export interface IconSize {
+  width: number;
+  height: number;
+}
+
 const arrowRight: Icon = {
   src: arrowRightImage,
   alt: 'arrow pointing right',


### PR DESCRIPTION
This PR is for a new variation of the `CardWithTopIcon` component.
There's a breaking change where the description of the component is now updated to solely React `children` components without any styles - this gives more freedom to style it at a higher level.

[See component in Figma](https://www.figma.com/file/582xiOgwHGIl4y5kGHrQ69/App?node-id=2277%3A0)