### PR TITLE
[NoTicket] Created release workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,9 @@
 name: Deploy
+
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy-storybook-to-gh-pages:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  release:
+    branches:
+      - main
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: yarn install
+        run: |
+          yarn install
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" | sed 's/v//' >> $GITHUB_ENV
+      - name: Configure GitHub
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Build new version
+          run: yarn build
+      - name: Publish new version
+        run: yarn publish --new-version $RELEASE_VERSION --no-git-tag-version --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_CI_TOKEN }}
+      - name: Push new package.json version
+        run: |
+          git commit -am "Bumped package.json to $RELEASE_VERSION"
+          git push origin HEAD:main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
       - name: Build new version
-          run: yarn build
+        run: yarn build
       - name: Publish new version
         run: yarn publish --new-version $RELEASE_VERSION --no-git-tag-version --access public
         env:


### PR DESCRIPTION
This PR adds the following:
- Moving away from the `master` branch to the `main` branch (migration pending, will be done after merge)
- We can now directly release dirty-swan from GitHub by creating a "New Release" and tagging it accordingly. Personal NPMJS access will be also removed.