### PR TITLE
Use github-action for creating new releases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,9 @@
 name: Deploy
+
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy-storybook-to-gh-pages:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  release:
+    branches:
+      - main
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: yarn install
+        run: |
+          yarn install
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" | sed 's/v//' >> $GITHUB_ENV
+      - name: Configure GitHub
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Build new version
+        run: yarn build
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@popsure'
+      - name: Publish new version
+        run: yarn publish --new-version $RELEASE_VERSION --no-git-tag-version --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Push new package.json version
+        run: |
+          git commit -am "Bumped package.json to $RELEASE_VERSION"
+          git push origin HEAD:main

--- a/Readme.md
+++ b/Readme.md
@@ -10,12 +10,8 @@ See our official website for installation and usage [dirtyswan.design](http://di
 
 ## Contributing
 
-### Releasing a new version using yarn
+### Releasing a new version
 
-You can release a new version by using the following command:
+To release a new version, use "Draft a new release" on GitHub (please refer to [Managing a release in a repository](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/managing-releases-in-a-repository)). You'll need to specify a correct "Tag version" that is following [Semantic Versioning](https://semver.org) (or semver).
 
-```bash
-yarn release
-```
-
-You will get asked to specify the new version number. We are using [Semantic Versioning](https://semver.org) (or semver) for that.
+GitHub Action will then automatically pick it up from there and release the new version for you.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popsure/dirty-swan",
-  "version": "0.20.8",
+  "version": "1.0.0-0",
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,
@@ -40,7 +40,6 @@
     "test": "react-scripts test",
     "test:ci": "CI=true react-scripts test",
     "eject": "react-scripts eject",
-    "release": "yarn build && yarn publish --access public",
     "storybook": "start-storybook -p 9009 -s public,storybook-assets",
     "build-storybook": "build-storybook -s public,storybook-assets",
     "deploy-storybook": "storybook-to-ghpages"


### PR DESCRIPTION
This PR will update the way we're doing deployments moving forwards:
- No more master branch, it’s now renamed to main
- No more yarn release from your individual computers. You use the “draft a new release” feature from GitHub and beep boop, everything will be taken over by the CI 🤖 
- ⚠️  make sure the version is correctly set when creating a new release, i.e. `v2.0.1` (don’t forget the v). And for an alpha version that will be `v2.0.1-0` , `v2.0.1-1`…