### PR TITLE
[CHA-2147] Add xsmall size to top left icon card component

### DIFF
--- a/src/lib/components/cards/a.stories.mdx
+++ b/src/lib/components/cards/a.stories.mdx
@@ -21,10 +21,6 @@ Cards are interactive elements that can be used to display an action that a user
 
 The card title can be set with the following properties: `xsmall`, `small`, `medium`, `big`.
 
-## Title Size (medium, big)
-
-The card title can be set with the following properties: `medium`, `big`.
-
 ## Card State
 
 The card state is an string literral type with the following properties:

--- a/src/lib/components/cards/a.stories.mdx
+++ b/src/lib/components/cards/a.stories.mdx
@@ -1,13 +1,5 @@
 import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
-import {
-  CardWithLeftIcon,
-  CardWithTopIcon,
-  CardWithTopLeftIcon,
-  InfoCard,
-} from '.';
-import { featherLogo } from './icons';
-
 <Meta title="JSX/Cards/Intro" />
 
 # Cards
@@ -19,15 +11,15 @@ Cards are interactive elements that can be used to display an action that a user
     width="100%"
     height="450"
     src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FMKs4cbojdVOBKUxv7okb93%2FDirty-Swan-Pattern-Library%3Fnode-id%3D358%253A19"
-    allowfullscreen
-  ></iframe>
+    allowFullScreen
+  />
 </Preview>
 
 # Models
 
-## Title Size (small, medium, big)
+## Title Size (xsmall, small, medium, big)
 
-The card title can be set with the following properties: `small`, `medium`, `big`.
+The card title can be set with the following properties: `xsmall`, `small`, `medium`, `big`.
 
 ## Title Size (medium, big)
 

--- a/src/lib/components/cards/cardWithTopLeftIcon/index.stories.mdx
+++ b/src/lib/components/cards/cardWithTopLeftIcon/index.stories.mdx
@@ -7,18 +7,42 @@ import { featherLogo } from '../icons';
 
 # Card with top left icon
 
-| attribute  | unit                                                                         | description                                      | default value | required |
-| ---------- | ---------------------------------------------------------------------------- | ------------------------------------------------ | ------------- | -------- |
-| title      | string                                                                       | The title text that needs to be displayed        | n/a           | true     |
-| titleSize  | [Title Size (m,b)](?path=/story/jsx-cards-intro--page#title-size-medium-big) | Size of the title                                | medium        | false    |
-| topIcon    | [Icon](?path=/story/jsx-cards-intro--page#icon)                              | Icon displayed on the left of the title          | n/a           | false    |
-| rightIcon  | [Icon](?path=/story/jsx-cards-intro--page#icon)                              | Icon displayed on the right of the title         | n/a           | false    |
-| state      | [Card State](?path=/story/jsx-cards-intro--page#card-state)                  | State that describe the interation with the card | actionable    | false    |
-| dropshadow | boolean                                                                      | If the card should have a box-shadow or not      | true          | false    |
+| attribute  | unit                                                                              | description                                      | default value | required |
+| ---------- | --------------------------------------------------------------------------------- | ------------------------------------------------ | ------------- | -------- |
+| title      | string                                                                            | The title text that needs to be displayed        | n/a           | true     |
+| titleSize  | [Title Size (xs,s,m,b)](?path=/story/jsx-cards-intro--page#title-size-medium-big) | Size of the title                                | medium        | false    |
+| topIcon    | [Icon](?path=/story/jsx-cards-intro--page#icon)                                   | Icon displayed on the left of the title          | n/a           | false    |
+| rightIcon  | [Icon](?path=/story/jsx-cards-intro--page#icon)                                   | Icon displayed on the right of the title         | n/a           | false    |
+| state      | [Card State](?path=/story/jsx-cards-intro--page#card-state)                       | State that describe the interation with the card | actionable    | false    |
+| dropshadow | boolean                                                                           | If the card should have a box-shadow or not      | true          | false    |
 
 <Preview>
   <>
-    <h4 className="p-h4">Medium title</h4>
+    <h4 className="p-h4">Extra small title</h4>
+    <CardWithTopLeftIcon
+      title="Lorem ipsum"
+      titleSize="xsmall"
+      className="wmx6 mt8"
+      rightIcon="arrow"
+      leftIcon={featherLogo}
+    >
+      Praesent euismod porta odio at tempus.{' '}
+      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+      eros at, rhoncus imperdiet nunc
+    </CardWithTopLeftIcon>
+    <h4 className="p-h4 mt24">Small title</h4>
+    <CardWithTopLeftIcon
+      title="Lorem ipsum"
+      titleSize="small"
+      className="wmx6 mt8"
+      rightIcon="arrow"
+      leftIcon={featherLogo}
+    >
+      Praesent euismod porta odio at tempus.{' '}
+      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+      eros at, rhoncus imperdiet nunc
+    </CardWithTopLeftIcon>
+    <h4 className="p-h4 mt24">Medium title</h4>
     <CardWithTopLeftIcon
       title="Lorem ipsum"
       titleSize="medium"

--- a/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
@@ -18,14 +18,16 @@ export default ({
   dropshadow = true,
   ...props
 }: CardProps & {
-  titleSize?: 'medium' | 'big';
+  titleSize?: 'xsmall' | 'small' | 'medium' | 'big';
   leftIcon?: 'logo' | Icon;
   rightIcon?: 'arrow' | Icon;
 }) => (
   <div
     className={`${associatedClassForCardState(state, dropshadow)} ${
       styles.container
-    } ${className ?? ''}`}
+    }
+    ${titleSize === 'xsmall' ? styles['container--xsmall'] : ''}
+    ${className ?? ''}`}
     {...props}
   >
     <div className={styles['title-container']}>
@@ -49,6 +51,12 @@ export default ({
         />
       )}
     </div>
-    <p className="p-p mt16 tc-grey-700">{children}</p>
+    <p
+      className={`p-p tc-grey-700 ${
+        titleSize === 'xsmall' ? styles.indent : 'mt16'
+      }`}
+    >
+      {children}
+    </p>
   </div>
 );

--- a/src/lib/components/cards/cardWithTopLeftIcon/style.module.scss
+++ b/src/lib/components/cards/cardWithTopLeftIcon/style.module.scss
@@ -1,5 +1,9 @@
 .container {
   padding: 24px;
+
+  &--xsmall {
+    padding: 16px 24px;
+  }
 }
 
 .title-container {
@@ -10,4 +14,8 @@
 
 .right-icon {
   margin-left: auto;
+}
+
+.indent {
+  margin-left: 36px;
 }

--- a/src/lib/components/cards/index.tsx
+++ b/src/lib/components/cards/index.tsx
@@ -13,9 +13,10 @@ export type CardProps = {
 } & JSX.IntrinsicElements['div'];
 
 export const headingForTitleSize = (
-  titleSize: 'small' | 'medium' | 'big'
+  titleSize: 'xsmall' | 'small' | 'medium' | 'big'
 ): string => {
   switch (titleSize) {
+    case 'xsmall':
     case 'small':
       return 'p-h4';
     case 'medium':

--- a/src/lib/scss/public/colors/default.scss
+++ b/src/lib/scss/public/colors/default.scss
@@ -1,10 +1,14 @@
 // TODO: Reference colors
+$ds-primary-25: #fcfcff !default;
+$ds-primary-50: #f7f7ff !default;
 $ds-primary-100: #e6e5ff !default;
 $ds-primary-300: #b1b0f5 !default;
 $ds-primary-500: #8e8cee !default;
 $ds-primary-700: #6160a2 !default;
 $ds-primary-900: #2e2e4c !default;
 
+$ds-purple-25: #fcfcff;
+$ds-purple-50: #f7f7ff;
 $ds-purple-100: #e6e5ff;
 $ds-purple-300: #b1b0f5;
 $ds-purple-500: #8e8cee;
@@ -49,11 +53,15 @@ $colors: (
   'blue-500': $ds-blue-500,
   'blue-700': $ds-blue-700,
   'blue-900': $ds-blue-900,
+  'purple-25': $ds-purple-25,
+  'purple-50': $ds-purple-50,
   'purple-100': $ds-purple-100,
   'purple-300': $ds-purple-300,
   'purple-500': $ds-purple-500,
   'purple-700': $ds-purple-700,
   'purple-900': $ds-purple-900,
+  'primary-25': $ds-primary-25,
+  'primary-50': $ds-primary-50,
   'primary-100': $ds-primary-100,
   'primary-300': $ds-primary-300,
   'primary-500': $ds-primary-500,

--- a/src/lib/scss/public/demo.tsx
+++ b/src/lib/scss/public/demo.tsx
@@ -27,6 +27,16 @@ const colors = [
     hex: '#2d394a',
   },
   {
+    name: 'Primary 25',
+    code: 'primary-25',
+    hex: '#fcfcff',
+  },
+  {
+    name: 'Primary 50',
+    code: 'primary-50',
+    hex: '#f7f7ff',
+  },
+  {
     name: 'Primary 100',
     code: 'primary-100',
     hex: '#e6e5ff',


### PR DESCRIPTION
This PR adds a new `xsmall` version of the top left card component [specified here](https://www.figma.com/file/MKs4cbojdVOBKUxv7okb93/Dirty-Swan-Design-System?node-id=358%3A19) and used inside the comparison table component.

**I'm not entirely sure if I have to do the PR to the new `main` branch or `master`.*