### PR TITLE
[CHA-2428] add className prop to Modal component

### DIFF
--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -4,10 +4,18 @@ import { Props } from '..';
 import styles from './style.module.scss';
 
 import imageClose from './img/close.svg';
+import useOnClose from '../hooks/useOnClose';
 
-export default ({ title, isOpen, children, onClose }: Props) => {
+export default ({
+  title,
+  isOpen,
+  children,
+  onClose,
+  className = '',
+}: Props) => {
   const [containerXOffset, setContainerXOffset] = useState(0);
-  const [isClosing, setIsClosing] = useState(false);
+  const { isClosing, handleContainerClick, handleOnClose } =
+    useOnClose(onClose);
 
   const containerRef = useCallback((node: HTMLDivElement) => {
     if (node !== null) {
@@ -24,20 +32,18 @@ export default ({ title, isOpen, children, onClose }: Props) => {
     return <></>;
   }
 
-  const handleOnClose = () => {
-    setIsClosing(true);
-    setTimeout(() => {
-      onClose();
-      setIsClosing(false);
-    }, 300);
-  };
-
   return (
-    <div className={isClosing ? styles['overlay--close'] : styles.overlay}>
+    <div
+      className={isClosing ? styles['overlay--close'] : styles.overlay}
+      onClick={handleOnClose}
+    >
       <div
-        className={isClosing ? styles['container--close'] : styles.container}
+        className={`${
+          isClosing ? styles['container--close'] : styles.container
+        } ${className}`}
         ref={containerRef}
         style={{ top: `${containerXOffset}px` }}
+        onClick={handleContainerClick}
       >
         <div className={styles.header}>
           <div className={`p-h4 ${styles.title}`}>{title}</div>

--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+const useOnClose = (onClose: () => void) => {
+  const [isClosing, setIsClosing] = useState(false);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleEscKey);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscKey);
+    };
+  }, []);
+
+  const handleOnClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      onClose();
+      setIsClosing(false);
+    }, 300);
+  };
+
+  const handleEscKey = (e: KeyboardEvent) => {
+    if (e.code !== 'Escape') return;
+
+    handleOnClose();
+  };
+
+  const handleContainerClick = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    e.stopPropagation();
+  };
+
+  return { isClosing, handleContainerClick, handleOnClose };
+};
+
+export default useOnClose;

--- a/src/lib/components/modal/index.stories.mdx
+++ b/src/lib/components/modal/index.stories.mdx
@@ -25,6 +25,7 @@ Modals are dialog overlays that prevent the user from interacting with the rest 
 | isOpen    | boolean               | When set to `true`, the modal is displayed. When set to `false` the modal gets removed | n/a           | true     |
 | onClose   | `function () => void` | Callback when the user close the modal                                                 | n/a           | true     |
 | children  | React.jsx             | The content that gets displayed on the modal                                           | n/a           | true     |
+| className | string                | Any additional className                                                               | n/a           | false    |
 
 export const RegularModalStory = () => {
   const [display, setDisplay] = useState(false);

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -7,6 +7,7 @@ export interface Props {
   isOpen: boolean;
   children: React.ReactNode;
   onClose: () => void;
+  className?: string;
 }
 
 export { BottomModal, RegularModal, BottomOrRegularModal };

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -17,10 +17,16 @@ export default ({
     useOnClose(onClose);
 
   useEffect(() => {
-    document.body.style.overflow = isOpen ? 'hidden' : 'auto';
+    const handleWheelEvent = (e: Event) => (isOpen ? e.preventDefault() : null);
+
+    if (isOpen) {
+      window.addEventListener('wheel', handleWheelEvent, { passive: false });
+    } else {
+      window.removeEventListener('wheel', handleWheelEvent);
+    }
 
     return () => {
-      document.body.style.overflow = 'auto';
+      window.removeEventListener('wheel', handleWheelEvent);
     };
   }, [isOpen]);
 

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -1,12 +1,20 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 import { Props } from '..';
 import styles from './style.module.scss';
 
 import imageClose from './img/close.svg';
+import useOnClose from '../hooks/useOnClose';
 
-export default ({ title, isOpen, children, onClose }: Props) => {
-  const [isClosing, setIsClosing] = useState(false);
+export default ({
+  title,
+  isOpen,
+  children,
+  onClose,
+  className = '',
+}: Props) => {
+  const { isClosing, handleContainerClick, handleOnClose } =
+    useOnClose(onClose);
 
   useEffect(() => {
     document.body.style.overflow = isOpen ? 'hidden' : 'auto';
@@ -16,22 +24,20 @@ export default ({ title, isOpen, children, onClose }: Props) => {
     };
   }, [isOpen]);
 
-  const handleOnClose = () => {
-    setIsClosing(true);
-    setTimeout(() => {
-      onClose();
-      setIsClosing(false);
-    }, 300);
-  };
-
   if (!isOpen) {
     return <></>;
   }
 
   return (
-    <div className={isClosing ? styles['overlay--close'] : styles.overlay}>
+    <div
+      className={isClosing ? styles['overlay--close'] : styles.overlay}
+      onClick={handleOnClose}
+    >
       <div
-        className={isClosing ? styles['container--close'] : styles.container}
+        className={`${
+          isClosing ? styles['container--close'] : styles.container
+        } ${className}`}
+        onClick={handleContainerClick}
       >
         <div className={styles.header}>
           <div className={`p-h2 ${styles.title}`}>{title}</div>


### PR DESCRIPTION
This PR solves [CHA-2428](https://linear.app/feather-insurance/issue/CHA-2428/fix-spacing-in-the-price-details-modal)

**What changed?**
- The Modal component now has a `className` prop to allow more style flexibility
- The scroll is being blocked by an event and not by hiding the scrollbar. This was done to prevent a jump when the modal was open:

Before:
![before](https://user-images.githubusercontent.com/9904702/125956962-2f11a10e-bc50-408b-aaad-739babb0e928.gif)
After:
![after](https://user-images.githubusercontent.com/9904702/125956988-2a6eee8e-faf0-4fa4-bed9-bccd943e58ed.gif)


**Caveats:**
- This new implementation only prevents the mouse wheel event. So scrolling with keyboards (space, up, and down keys) is still possible. We can go further and prevent scrolling using the keyboard but I feel that it's not necessary at this point.
- If the modal is bigger than the window, scrolling is not possible.