### PR TITLE
[CHA-2532] add required prop to allow closing the

### DIFF
--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -12,13 +12,13 @@ export default ({
   children,
   onClose,
   className = '',
-  required = false,
+  dismissable = true,
 }: Props) => {
   const [containerXOffset, setContainerXOffset] = useState(0);
   const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
     onClose,
     isOpen,
-    required
+    dismissable
   );
 
   const containerRef = useCallback((node: HTMLDivElement) => {
@@ -51,7 +51,7 @@ export default ({
       >
         <div className={styles.header}>
           <div className={`p-h4 ${styles.title}`}>{title}</div>
-          {!required && (
+          {dismissable && (
             <button
               type="button"
               className={styles.close}

--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -12,10 +12,14 @@ export default ({
   children,
   onClose,
   className = '',
+  required = false,
 }: Props) => {
   const [containerXOffset, setContainerXOffset] = useState(0);
-  const { isClosing, handleContainerClick, handleOnClose } =
-    useOnClose(onClose);
+  const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
+    onClose,
+    isOpen,
+    required
+  );
 
   const containerRef = useCallback((node: HTMLDivElement) => {
     if (node !== null) {
@@ -47,13 +51,15 @@ export default ({
       >
         <div className={styles.header}>
           <div className={`p-h4 ${styles.title}`}>{title}</div>
-          <button
-            type="button"
-            className={styles.close}
-            onClick={handleOnClose}
-          >
-            <img src={imageClose} alt="Close" />
-          </button>
+          {!required && (
+            <button
+              type="button"
+              className={styles.close}
+              onClick={handleOnClose}
+            >
+              <img src={imageClose} alt="Close" />
+            </button>
+          )}
         </div>
         <div className={styles.content}>{children}</div>
       </div>

--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 const useOnClose = (
   onClose: () => void,
   isOpen: boolean,
-  required: boolean
+  dismissable: boolean
 ) => {
   const [isClosing, setIsClosing] = useState(false);
 
@@ -13,7 +13,7 @@ const useOnClose = (
     return () => {
       window.removeEventListener('keydown', handleEscKey);
     };
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const handleWheelEvent = (e: Event) => (isOpen ? e.preventDefault() : null);
@@ -36,7 +36,7 @@ const useOnClose = (
   }, [isOpen]);
 
   const handleOnClose = () => {
-    if (required) return null;
+    if (!dismissable) return null;
 
     setIsClosing(true);
     setTimeout(() => {

--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 
-const useOnClose = (onClose: () => void) => {
+const useOnClose = (
+  onClose: () => void,
+  isOpen: boolean,
+  required: boolean
+) => {
   const [isClosing, setIsClosing] = useState(false);
 
   useEffect(() => {
@@ -11,7 +15,29 @@ const useOnClose = (onClose: () => void) => {
     };
   }, []);
 
+  useEffect(() => {
+    const handleWheelEvent = (e: Event) => (isOpen ? e.preventDefault() : null);
+
+    /**
+     * If we add an event listener with identical options,
+     * the event listener will be discarded.
+     * So we can safely add the event inside a useEffect function
+     * that will excecute multiple times.
+     *
+     * More info: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#multiple_identical_event_listeners
+     */
+    window.addEventListener('touchmove', handleWheelEvent, { passive: false }); // mobile
+    window.addEventListener('wheel', handleWheelEvent, { passive: false }); // desktop
+
+    return () => {
+      window.removeEventListener('touchmove', handleWheelEvent);
+      window.removeEventListener('wheel', handleWheelEvent);
+    };
+  }, [isOpen]);
+
   const handleOnClose = () => {
+    if (required) return null;
+
     setIsClosing(true);
     setTimeout(() => {
       onClose();

--- a/src/lib/components/modal/index.stories.mdx
+++ b/src/lib/components/modal/index.stories.mdx
@@ -26,6 +26,7 @@ Modals are dialog overlays that prevent the user from interacting with the rest 
 | onClose   | `function () => void` | Callback when the user close the modal                                                 | n/a           | true     |
 | children  | React.jsx             | The content that gets displayed on the modal                                           | n/a           | true     |
 | className | string                | Any additional className                                                               | n/a           | false    |
+| required  | boolean               | Prevent the user from closing the modal                                                | false         | false    |
 
 export const RegularModalStory = () => {
   const [display, setDisplay] = useState(false);
@@ -260,3 +261,10 @@ export default () => {
 ## Bottom or Regular modal
 
 Bottom or Regular modal will automatically choose what’s best to display based on the users screen width.
+
+## Required modal
+
+Passing the `required` prop to the modal will hide the close button and prevent the user from closing it using the escape key or clicking outside.
+This prop can be useful if we don't want the user to dismiss the modal and close it after direct interaction.
+
+**Warning:** a modal with the `required` prop can only be closed by setting the `isOpen` prop to `false`.

--- a/src/lib/components/modal/index.stories.mdx
+++ b/src/lib/components/modal/index.stories.mdx
@@ -19,14 +19,14 @@ Modals are dialog overlays that prevent the user from interacting with the rest 
   ></iframe>
 </Preview>
 
-| attribute | unit                  | description                                                                            | default value | required |
-| --------- | --------------------- | -------------------------------------------------------------------------------------- | ------------- | -------- |
-| title     | string                | The title that needs to be displayed on the modal                                      | n/a           | true     |
-| isOpen    | boolean               | When set to `true`, the modal is displayed. When set to `false` the modal gets removed | n/a           | true     |
-| onClose   | `function () => void` | Callback when the user close the modal                                                 | n/a           | true     |
-| children  | React.jsx             | The content that gets displayed on the modal                                           | n/a           | true     |
-| className | string                | Any additional className                                                               | n/a           | false    |
-| required  | boolean               | Prevent the user from closing the modal                                                | false         | false    |
+| attribute   | unit                  | description                                                                            | default value | required |
+| ----------- | --------------------- | -------------------------------------------------------------------------------------- | ------------- | -------- |
+| title       | string                | The title that needs to be displayed on the modal                                      | n/a           | true     |
+| isOpen      | boolean               | When set to `true`, the modal is displayed. When set to `false` the modal gets removed | n/a           | true     |
+| onClose     | `function () => void` | Callback when the user close the modal                                                 | n/a           | true     |
+| children    | React.jsx             | The content that gets displayed on the modal                                           | n/a           | true     |
+| className   | string                | Any additional className                                                               | n/a           | false    |
+| dismissable | boolean               | When set to `false` prevents the user from closing the modal                     | true          | false    |
 
 export const RegularModalStory = () => {
   const [display, setDisplay] = useState(false);

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -8,7 +8,7 @@ export interface Props {
   children: React.ReactNode;
   onClose: () => void;
   className?: string;
-  required?: boolean;
+  dismissable?: boolean;
 }
 
 export { BottomModal, RegularModal, BottomOrRegularModal };

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -8,6 +8,7 @@ export interface Props {
   children: React.ReactNode;
   onClose: () => void;
   className?: string;
+  required?: boolean;
 }
 
 export { BottomModal, RegularModal, BottomOrRegularModal };

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -13,12 +13,12 @@ export default ({
   children,
   onClose,
   className = '',
-  required = false,
+  dismissable = true,
 }: Props) => {
   const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
     onClose,
     isOpen,
-    required
+    dismissable
   );
 
   if (!isOpen) {
@@ -38,7 +38,7 @@ export default ({
       >
         <div className={styles.header}>
           <div className={`p-h2 ${styles.title}`}>{title}</div>
-          {!required && (
+          {dismissable && (
             <button
               type="button"
               className={styles.close}

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { Props } from '..';
+import useOnClose from '../hooks/useOnClose';
+
 import styles from './style.module.scss';
 
 import imageClose from './img/close.svg';
-import useOnClose from '../hooks/useOnClose';
 
 export default ({
   title,
@@ -12,23 +13,13 @@ export default ({
   children,
   onClose,
   className = '',
+  required = false,
 }: Props) => {
-  const { isClosing, handleContainerClick, handleOnClose } =
-    useOnClose(onClose);
-
-  useEffect(() => {
-    const handleWheelEvent = (e: Event) => (isOpen ? e.preventDefault() : null);
-
-    if (isOpen) {
-      window.addEventListener('wheel', handleWheelEvent, { passive: false });
-    } else {
-      window.removeEventListener('wheel', handleWheelEvent);
-    }
-
-    return () => {
-      window.removeEventListener('wheel', handleWheelEvent);
-    };
-  }, [isOpen]);
+  const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
+    onClose,
+    isOpen,
+    required
+  );
 
   if (!isOpen) {
     return <></>;
@@ -47,13 +38,15 @@ export default ({
       >
         <div className={styles.header}>
           <div className={`p-h2 ${styles.title}`}>{title}</div>
-          <button
-            type="button"
-            className={styles.close}
-            onClick={handleOnClose}
-          >
-            <img src={imageClose} alt="Close" />
-          </button>
+          {!required && (
+            <button
+              type="button"
+              className={styles.close}
+              onClick={handleOnClose}
+            >
+              <img src={imageClose} alt="Close" />
+            </button>
+          )}
         </div>
         {children}
       </div>


### PR DESCRIPTION
This PR adds the following functionality:

- Adds a new `required` prop to prevent the user from closing the modal
- Adds a new `touchmove` event handler to prevent scroll on mobile devices
- Moves all the component logic to the `useOnOpen` hook to share it with the different modals
