### PR TITLE
[CHA-2539] Update modal documentation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,8 @@ export {
   TableInfoButton,
 } from './lib';
 
+export type { TableHeader } from './lib';
+
 export type { DownloadRingDownloadStatus } from './lib';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
-import ComparisonTable, { TableRating, TableTrueFalse } from '.';
+import { ComparisonTable, TableRating, TableTrueFalse } from '.';
 
 <Meta title="JSX/Comparison Table" component={ComparisonTable} />
 

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -92,7 +92,7 @@ export const ComparisonTableWithData = () => {
         {
           id: 6,
           key: 'boxOffice',
-          label: 'Family friendly',
+          label: 'Box office',
           render: (value) =>
             value.toLocaleString('de-DE', {
               style: 'currency',
@@ -143,10 +143,26 @@ export const ComparisonTableWithData = () => {
 <ComparisonTableWithData />
 
 ```typescript jsx
-import ComparisonTable, { TableRating, TableTrueFalse } from '.';
+import ComparisonTable, {
+  TableRating,
+  TableTrueFalse,
+  TableHeader,
+} from '@popsure/dirty-swan';
+
+interface TableData {
+  id: number;
+  name: string;
+  country: string;
+  year: string;
+  rating: number;
+  imdb: number;
+  recommended: number;
+  familyFriendly: boolean;
+  boxOffice: number;
+}
 
 export const ComparisonTableWithData = () => {
-  const headers = [
+  const headers: Array<TableHeader<TableData>> = [
     {
       id: 1,
       cells: [
@@ -186,7 +202,7 @@ export const ComparisonTableWithData = () => {
         {
           id: 6,
           key: 'boxOffice',
-          label: 'Family friendly',
+          label: 'Box office',
           render: (value) =>
             value.toLocaleString('de-DE', {
               style: 'currency',
@@ -196,7 +212,7 @@ export const ComparisonTableWithData = () => {
       ],
     },
   ];
-  const data = [
+  const data: Array<TableData> = [
     {
       id: 1,
       name: 'Pulp Fiction',
@@ -205,7 +221,8 @@ export const ComparisonTableWithData = () => {
       rating: 3,
       imdb: 8.9,
       recommended: 3,
-      family_friendly: false,
+      familyFriendly: false,
+      boxOffice: 213928762,
     },
     {
       id: 2,
@@ -215,7 +232,8 @@ export const ComparisonTableWithData = () => {
       rating: 2,
       imdb: 8.6,
       recommended: 3,
-      family_friendly: false,
+      familyFriendly: false,
+      boxOffice: 355475245,
     },
     {
       id: 3,
@@ -225,7 +243,8 @@ export const ComparisonTableWithData = () => {
       rating: 3,
       imdb: 8.6,
       recommended: 3,
-      family_friendly: true,
+      familyFriendly: true,
+      boxOffice: 258908054,
     },
   ];
   return <ComparisonTable data={data} headers={headers} />;

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -194,7 +194,7 @@ const ComparisonTable = <T extends { id: number }>(
 };
 
 export {
-  ComparisonTable as default,
+  ComparisonTable,
   TableRating,
   TableTrueFalse,
   TableRowHeader,

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -11,7 +11,7 @@ import TableInfoButton from './components/TableInfoButton';
 import Chevron from './components/Chevron';
 import { useActiveTableArrows } from './hooks/useActiveTableArrows';
 
-import styles from './style.module.scss';
+import baseStyles from './style.module.scss';
 
 export interface CellBaseProps<T> {
   /** Used to display the row's title */
@@ -46,12 +46,16 @@ export interface ComparisonTableProps<T> {
   headers: Array<Header<T>>;
   data: Array<T>;
   hideDetails?: boolean;
+  styles?: {
+    header?: string;
+    container?: string;
+  };
 }
 
 const ComparisonTable = <T extends { id: number }>(
   props: ComparisonTableProps<T>
 ) => {
-  const { headers, data, hideDetails } = props;
+  const { headers, data, hideDetails, styles } = props;
   const [showMore, setShowMore] = useState<boolean>(false);
   const headerContainerRef = useRef<HTMLDivElement | null>(null);
   const { activeArrows, contentContainerRef, contentWrapperRef } =
@@ -94,11 +98,11 @@ const ComparisonTable = <T extends { id: number }>(
   return (
     <ScrollSync>
       <div>
-        <div className={styles.header}>
+        <div className={classNames(baseStyles.header, styles?.header)}>
           <ScrollSyncPane>
-            <div className={styles.container} ref={headerContainerRef}>
-              <div className={classNames(styles['overflow-container'])}>
-                <div className={styles['group-container']}>
+            <div className={baseStyles.container} ref={headerContainerRef}>
+              <div className={classNames(baseStyles['overflow-container'])}>
+                <div className={baseStyles['group-container']}>
                   <TableArrows
                     onClick={handleArrowsClick}
                     active={activeArrows}
@@ -116,12 +120,15 @@ const ComparisonTable = <T extends { id: number }>(
           </ScrollSyncPane>
         </div>
         <ScrollSyncPane>
-          <div className={styles.container} ref={contentWrapperRef}>
+          <div
+            className={classNames(baseStyles.container, styles?.container)}
+            ref={contentWrapperRef}
+          >
             <div
-              className={classNames(styles['overflow-container'])}
+              className={classNames(baseStyles['overflow-container'])}
               ref={contentContainerRef}
             >
-              <div className={styles['group-container']}>
+              <div className={baseStyles['group-container']}>
                 {Array.isArray(headers) &&
                   headers
                     .filter(
@@ -135,8 +142,8 @@ const ComparisonTable = <T extends { id: number }>(
                            * Print a table subheader if the `label` value is present
                            */
                           headerGroup.label && (
-                            <div className={styles['group-title']}>
-                              <h4 className={`p-h4 ${styles.sticky}`}>
+                            <div className={baseStyles['group-title']}>
+                              <h4 className={`p-h4 ${baseStyles.sticky}`}>
                                 {headerGroup.label}
                               </h4>
                             </div>
@@ -166,19 +173,21 @@ const ComparisonTable = <T extends { id: number }>(
                 {hideDetails && (
                   <div
                     className={classNames(
-                      styles['show-details-container'],
-                      styles.sticky,
+                      baseStyles['show-details-container'],
+                      baseStyles.sticky,
                       'mt48'
                     )}
                   >
                     <div>
                       <button
-                        className={`w100 d-flex p-a p-h4 c-pointer ${styles['show-details-button']}`}
+                        className={`w100 d-flex p-a p-h4 c-pointer ${baseStyles['show-details-button']}`}
                         onClick={toggleMoreRows}
                       >
                         {showMore ? 'Hide details' : 'Show details'}
                         <Chevron
-                          className={showMore ? '' : styles['icon-inverted']}
+                          className={
+                            showMore ? '' : baseStyles['icon-inverted']
+                          }
                         />
                       </button>
                     </div>

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -33,7 +33,7 @@ export type Cell<T> =
   | ({ key: Extract<keyof T, string> } & CellBaseProps<T>)
   | ({ key?: undefined } & CellWithId<T>);
 
-export interface Header<T> {
+export interface TableHeader<T> {
   /** Required unique id number for each table group */
   id: number;
   /** Used to display a table group subheader */
@@ -43,7 +43,7 @@ export interface Header<T> {
 }
 
 export interface ComparisonTableProps<T> {
-  headers: Array<Header<T>>;
+  headers: Array<TableHeader<T>>;
   data: Array<T>;
   hideDetails?: boolean;
   styles?: {

--- a/src/lib/components/comparisonTable/style.module.scss
+++ b/src/lib/components/comparisonTable/style.module.scss
@@ -58,7 +58,7 @@
 
 .header {
   position: sticky;
-  top: 64px;
+  top: 0;
   z-index: 2;
   background-color: white;
 
@@ -69,10 +69,6 @@
     &::-webkit-scrollbar {
       display: none;
     }
-  }
-
-  @include p-size-desktop {
-    top: 72px; // TODO: add top position as prop
   }
 }
 

--- a/src/lib/components/input/autoSuggestMultiSelect/index.tsx
+++ b/src/lib/components/input/autoSuggestMultiSelect/index.tsx
@@ -29,8 +29,9 @@ export default ({
         <div
           className={`mb8 ${styles['chip-container']} ${chipsListClassName}`}
         >
-          {selectedValues.map((value) => (
+          {selectedValues.map((value, index) => (
             <Chip
+              key={`${value.value}-${index}`}
               value={value}
               onRemove={(value: Option) => {
                 const newValues = [...selectedValues].filter(

--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -12,13 +12,13 @@ export default ({
   children,
   onClose,
   className = '',
-  dismissable = true,
+  dismissible = true,
 }: Props) => {
   const [containerXOffset, setContainerXOffset] = useState(0);
   const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
     onClose,
     isOpen,
-    dismissable
+    dismissible
   );
 
   const containerRef = useCallback((node: HTMLDivElement) => {
@@ -51,7 +51,7 @@ export default ({
       >
         <div className={styles.header}>
           <div className={`p-h4 ${styles.title}`}>{title}</div>
-          {dismissable && (
+          {dismissible && (
             <button
               type="button"
               className={styles.close}

--- a/src/lib/components/modal/index.stories.mdx
+++ b/src/lib/components/modal/index.stories.mdx
@@ -26,7 +26,7 @@ Modals are dialog overlays that prevent the user from interacting with the rest 
 | onClose     | `function () => void` | Callback when the user close the modal                                                 | n/a           | true     |
 | children    | React.jsx             | The content that gets displayed on the modal                                           | n/a           | true     |
 | className   | string                | Any additional className                                                               | n/a           | false    |
-| dismissable | boolean               | When set to `false` prevents the user from closing the modal                     | true          | false    |
+| dismissible | boolean               | When set to `false` prevents the user from closing the modal                     | true          | false    |
 
 export const RegularModalStory = () => {
   const [display, setDisplay] = useState(false);
@@ -264,7 +264,7 @@ Bottom or Regular modal will automatically choose what’s best to display based
 
 ## Required modal
 
-Passing the `required` prop to the modal will hide the close button and prevent the user from closing it using the escape key or clicking outside.
-This prop can be useful if we don't want the user to dismiss the modal and close it after direct interaction.
+Setting the `dismissible` prop to false will hide the close button and prevent the user from closing it using the escape key or clicking outside.
+This prop can be useful if we want the user to explicitly interact with the modal options.
 
-**Warning:** a modal with the `required` prop can only be closed by setting the `isOpen` prop to `false`.
+**Warning:** a modal with the `dismissible` prop can only be closed by changing the `isOpen` prop to `false`.

--- a/src/lib/components/modal/index.stories.mdx
+++ b/src/lib/components/modal/index.stories.mdx
@@ -26,7 +26,7 @@ Modals are dialog overlays that prevent the user from interacting with the rest 
 | onClose     | `function () => void` | Callback when the user close the modal                                                 | n/a           | true     |
 | children    | React.jsx             | The content that gets displayed on the modal                                           | n/a           | true     |
 | className   | string                | Any additional className                                                               | n/a           | false    |
-| dismissible | boolean               | When set to `false` prevents the user from closing the modal                     | true          | false    |
+| dismissible | boolean               | When set to `false` prevents the user from closing the modal                           | true          | false    |
 
 export const RegularModalStory = () => {
   const [display, setDisplay] = useState(false);
@@ -124,6 +124,50 @@ export const BottomModalStory = () => {
           </button>
         </div>
       </BottomModal>
+    </>
+  );
+};
+
+export const NonDismissibleModal = () => {
+  const [display, setDisplay] = useState(false);
+  return (
+    <>
+      <button
+        className="p-btn--primary wmn2"
+        onClick={() => {
+          setDisplay(!display);
+        }}
+      >
+        Open modal
+      </button>
+      <RegularModal
+        title="Non-dismissible modal title"
+        isOpen={display}
+        onClose={() => {
+          setDisplay(false);
+        }}
+        dismissible={false}
+      >
+        <div style={{ padding: '0 24px 24px 24px' }}>
+          <p className="p-p">
+            This modal requires clear user interaction to dismiss it. The close
+            button is hidden, and it cannot be closed using the keyboard nor
+            clicking outside.
+          </p>
+          <button
+            className="p-btn--primary bg-red-500 mt24 wmn3"
+            onClick={() => setDisplay(false)}
+          >
+            Reject
+          </button>
+          <button
+            className="p-btn--primary mt24 wmn3 ml16"
+            onClick={() => setDisplay(false)}
+          >
+            Accept
+          </button>
+        </div>
+      </RegularModal>
     </>
   );
 };
@@ -262,9 +306,11 @@ export default () => {
 
 Bottom or Regular modal will automatically choose what’s best to display based on the users screen width.
 
-## Required modal
+## Non-dismissible modal
 
 Setting the `dismissible` prop to false will hide the close button and prevent the user from closing it using the escape key or clicking outside.
 This prop can be useful if we want the user to explicitly interact with the modal options.
 
 **Warning:** a modal with the `dismissible` prop can only be closed by changing the `isOpen` prop to `false`.
+
+<NonDismissibleModal />

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -8,7 +8,7 @@ export interface Props {
   children: React.ReactNode;
   onClose: () => void;
   className?: string;
-  dismissable?: boolean;
+  dismissible?: boolean;
 }
 
 export { BottomModal, RegularModal, BottomOrRegularModal };

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -13,12 +13,12 @@ export default ({
   children,
   onClose,
   className = '',
-  dismissable = true,
+  dismissible = true,
 }: Props) => {
   const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
     onClose,
     isOpen,
-    dismissable
+    dismissible
   );
 
   if (!isOpen) {
@@ -38,7 +38,7 @@ export default ({
       >
         <div className={styles.header}>
           <div className={`p-h2 ${styles.title}`}>{title}</div>
-          {dismissable && (
+          {dismissible && (
             <button
               type="button"
               className={styles.close}

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -22,7 +22,8 @@ import Button from './components/button';
 import AutoSuggestMultiSelect from './components/input/autoSuggestMultiSelect';
 import Chip from './components/chip';
 import AutoSuggestInput from './components/input/autoSuggestInput';
-import ComparisonTable, {
+import {
+  ComparisonTable,
   TableRating,
   TableTrueFalse,
   TableRowHeader,

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -28,6 +28,7 @@ import {
   TableTrueFalse,
   TableRowHeader,
   TableInfoButton,
+  TableHeader,
 } from './components/comparisonTable';
 
 export {
@@ -57,5 +58,7 @@ export {
   TableRowHeader,
   TableInfoButton,
 };
+
+export type { TableHeader };
 
 export type { DownloadRingDownloadStatus } from './models/downloadRing';


### PR DESCRIPTION
This PR does the following:

- Fixes a typo in the `dismissible` modal prop and updates modal documentation
- Removes the `default` export in the ComparisonTable component.
- Adds a new `styles` prop to the `<ComparisonTable />` component to allow style overrides
