### PR TITLE
[CHA-2393] Update description color on info cards

### DIFF
--- a/src/lib/components/cards/cardWithLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.tsx
@@ -52,7 +52,7 @@ export default ({
           />
         )}
       </div>
-      <p className="p-p mt8 tc-grey-700">{children}</p>
+      <p className="p-p mt8 tc-grey-600">{children}</p>
     </div>
   </div>
 );

--- a/src/lib/components/cards/cardWithTopIcon/index.stories.mdx
+++ b/src/lib/components/cards/cardWithTopIcon/index.stories.mdx
@@ -26,7 +26,7 @@ import { featherLogo } from '../icons';
       rightIcon="arrow"
       topIcon={featherLogo}
     >
-      <p className="p-p mt16 tc-grey-700">
+      <p className="p-p mt16 tc-grey-600">
         Praesent euismod porta odio at tempus.{' '}
         <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
         eros at, rhoncus imperdiet nunc
@@ -40,7 +40,7 @@ import { featherLogo } from '../icons';
       rightIcon="arrow"
       topIcon={featherLogo}
     >
-      <p className="p-p mt16 tc-grey-700">
+      <p className="p-p mt16 tc-grey-600">
         Praesent euismod porta odio at tempus.{' '}
         <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
         eros at, rhoncus imperdiet nunc
@@ -54,7 +54,7 @@ import { featherLogo } from '../icons';
       rightIcon="arrow"
       topIcon={featherLogo}
     >
-      <p className="p-p mt16 tc-grey-700">
+      <p className="p-p mt16 tc-grey-600">
         Praesent euismod porta odio at tempus.{' '}
         <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
         eros at, rhoncus imperdiet nunc
@@ -68,7 +68,7 @@ import { featherLogo } from '../icons';
       topIcon={featherLogo}
       state="muted"
     >
-      <p className="p-p mt16 tc-grey-700">
+      <p className="p-p mt16 tc-grey-600">
         Praesent euismod porta odio at tempus.{' '}
         <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
         eros at, rhoncus imperdiet nunc
@@ -81,7 +81,7 @@ import { featherLogo } from '../icons';
       titleSize="small"
       className="wmx6 mt8"
     >
-      <p className="p-p mt16 tc-grey-700">
+      <p className="p-p mt16 tc-grey-600">
         Praesent euismod porta odio at tempus.{' '}
         <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
         eros at, rhoncus imperdiet nunc
@@ -95,7 +95,7 @@ import { featherLogo } from '../icons';
       className="wmx6 mt8"
       dropshadow={false}
     >
-      <p className="p-p mt16 tc-grey-700">
+      <p className="p-p mt16 tc-grey-600">
         Praesent euismod porta odio at tempus.{' '}
         <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
         eros at, rhoncus imperdiet nunc

--- a/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
@@ -52,7 +52,7 @@ export default ({
       )}
     </div>
     <p
-      className={`p-p tc-grey-700 ${
+      className={`p-p tc-grey-600 ${
         titleSize === 'xsmall' ? styles.indent : 'mt16'
       }`}
     >

--- a/src/lib/components/cards/infoCard/index.tsx
+++ b/src/lib/components/cards/infoCard/index.tsx
@@ -41,7 +41,7 @@ export default ({
         />
       )}
       <div className="p-h4 ta-center mt64">{title}</div>
-      <p className="p-p mt16 tc-grey-700">{children}</p>
+      <p className="p-p mt16 tc-grey-600">{children}</p>
     </div>
   </div>
 );


### PR DESCRIPTION
This PR updates the description color of the card component
Before:
![image](https://user-images.githubusercontent.com/9904702/128784625-b464a2d7-da2b-423f-a96f-a8a481295bc9.png)

After:
![image](https://user-images.githubusercontent.com/9904702/128784712-51f0c480-8897-48c1-95b2-36cc3210bd2f.png)
