### PR TITLE
Add flex utilities and responsiveness v0.1

### DIFF
--- a/src/lib/scss/private/base/_flex.scss
+++ b/src/lib/scss/private/base/_flex.scss
@@ -1,0 +1,43 @@
+@use 'grid';
+
+/** Shared values across align and justify properties */
+$common-values: (
+  'start': flex-start,
+  'end': flex-end,
+  'center': center,
+);
+
+$align-values: map-merge(
+  $common-values,
+  (
+    'stretch': stretch,
+    'baseline': baseline,
+  )
+);
+
+$jutify-values: map-merge(
+  $common-values,
+  (
+    'between': space-between,
+    'around': space-around,
+    'evenly': space-evenly,
+  )
+);
+
+// Align items
+@each $name, $value in $align-values {
+  .ai-#{$name} {
+    @include grid.add-responsive {
+      align-items: $value;
+    }
+  }
+}
+
+// Justify content
+@each $name, $value in $jutify-values {
+  .jc-#{$name} {
+    @include grid.add-responsive {
+      justify-content: $value;
+    }
+  }
+}

--- a/src/lib/scss/private/base/_grid.scss
+++ b/src/lib/scss/private/base/_grid.scss
@@ -1,4 +1,5 @@
 @use '../../public/grid';
+@use '../utils/str-replace';
 
 .p-body {
   @include grid.p-size-mobile {
@@ -12,5 +13,35 @@
   @include grid.p-size-desktop {
     width: 56rem;
     margin: 0 auto;
+  }
+}
+
+/** Taken from https://gist.github.com/Bamieh/912a6f0b63cbb53f3ad0bd8df7171c6a */
+@function remove-dot-from-class($class) {
+  $class-string: quote($class);
+  @return if(
+    str-slice($class-string, 0, 1) == '.',
+    str-slice($class-string, 2, str-length($class-string)),
+    $class-string
+  );
+}
+
+@mixin add-responsive {
+  $selector: remove-dot-from-class(#{&});
+  @content;
+
+  /** We need to use @at-root to prevent the following rules to be nested */
+  @at-root {
+    .md\:#{$selector} {
+      @include grid.p-size-tablet {
+        @content;
+      }
+    }
+
+    .lg\:#{$selector} {
+      @include grid.p-size-desktop {
+        @content;
+      }
+    }
   }
 }

--- a/src/lib/scss/private/base/_grid.scss
+++ b/src/lib/scss/private/base/_grid.scss
@@ -16,7 +16,7 @@
   }
 }
 
-/** Taken from https://gist.github.com/Bamieh/912a6f0b63cbb53f3ad0bd8df7171c6a */
+// Taken from https://gist.github.com/Bamieh/912a6f0b63cbb53f3ad0bd8df7171c6a
 @function remove-dot-from-class($class) {
   $class-string: quote($class);
   @return if(
@@ -30,7 +30,7 @@
   $selector: remove-dot-from-class(#{&});
   @content;
 
-  /** We need to use @at-root to prevent the following rules to be nested */
+  // We need to use @at-root to prevent the following rules to be nested inside the selector
   @at-root {
     .md\:#{$selector} {
       @include grid.p-size-tablet {

--- a/src/lib/scss/private/base/_index.scss
+++ b/src/lib/scss/private/base/_index.scss
@@ -1,5 +1,6 @@
 @forward "display";
 @forward "shadows";
+@forward "flex";
 @forward "grid";
 @forward "spacing";
 @forward "width_and_height";

--- a/src/lib/scss/private/base/_spacing.scss
+++ b/src/lib/scss/private/base/_spacing.scss
@@ -1,43 +1,80 @@
+@use 'grid';
+
 @for $i from 0 through 12 {
-  .mt#{$i * 8} {
-    margin-top: $i * 8px;
+  .m#{$i * 8} {
+    @include grid.add-responsive {
+      margin: $i * 8px;
+    }
+  }
+
+  .p#{$i * 8} {
+    @include grid.add-responsive {
+      padding: $i * 8px;
+    }
   }
 }
 
+// Spacing left & right
 @for $i from 0 through 12 {
-  .mb#{$i * 8} {
-    margin-bottom: $i * 8px;
+  .mx#{$i * 8} {
+    @include grid.add-responsive {
+      margin-left: $i * 8px;
+      margin-right: $i * 8px;
+    }
+  }
+
+  .px#{$i * 8} {
+    @include grid.add-responsive {
+      padding-left: $i * 8px;
+      padding-right: $i * 8px;
+    }
   }
 }
 
+// Spacing up & down
 @for $i from 0 through 12 {
-  .mr#{$i * 8} {
-    margin-right: $i * 8px;
+  .my#{$i * 8} {
+    @include grid.add-responsive {
+      margin-top: $i * 8px;
+      margin-bottom: $i * 8px;
+    }
+  }
+
+  .py#{$i * 8} {
+    @include grid.add-responsive {
+      padding-top: $i * 8px;
+      padding-bottom: $i * 8px;
+    }
   }
 }
 
-@for $i from 0 through 12 {
-  .ml#{$i * 8} {
-    margin-left: $i * 8px;
+// Spacing for each specific area
+$valid_areas: (
+  't': 'top',
+  'b': 'bottom',
+  'l': 'left',
+  'r': 'right',
+);
+
+@each $key, $area in $valid_areas {
+  @for $i from 0 through 12 {
+    .m#{$key}#{$i * 8} {
+      @include grid.add-responsive {
+        margin-#{$area}: $i * 8px;
+      }
+    }
+
+    .p#{$key}#{$i * 8} {
+      @include grid.add-responsive {
+        padding-#{$area}: $i * 8px;
+      }
+    }
   }
-}
 
-.m-auto {
-  margin: auto;
-}
-
-.mt-auto {
-  margin-top: auto;
-}
-
-.mb-auto {
-  margin-bottom: auto;
-}
-
-.mr-auto {
-  margin-right: auto;
-}
-
-.ml-auto {
-  margin-left: auto;
+  // Auto value for margin
+  .m#{$key}-auto {
+    @include grid.add-responsive {
+      margin-#{$area}: auto;
+    }
+  }
 }

--- a/src/lib/scss/private/base/flex.stories.mdx
+++ b/src/lib/scss/private/base/flex.stories.mdx
@@ -1,0 +1,48 @@
+<Meta title="CSS/Base/Flex" />
+
+# Flex
+
+Dirty swan provides alignment options using Flexbox
+
+## Align items
+
+| Class          | Output                    |
+| -------------- | ------------------------- |
+| `.ai-start`    | `align-items: flex-start` |
+| `.ai-end`      | `align-items: flex-end`   |
+| `.ai-center`   | `align-items: center`     |
+| `.ai-stretch`  | `align-items: stretch`    |
+| `.ai-baseline` | `align-items: baseline`   |
+
+## Justify content
+
+| Class         | Output                           |
+| ------------- | -------------------------------- |
+| `.jc-start`   | `justify-content: flex-start`    |
+| `.jc-end`     | `justify-content: flex-end`      |
+| `.jc-center`  | `justify-content: center`        |
+| `.jc-between` | `justify-content: space-between` |
+| `.jc-around`  | `justify-content: space-around`  |
+| `.jc-evenly`  | `justify-content: space-evenly`  |
+
+export const RenderJcExample = () => {
+  const values = ['start', 'end', 'center', 'between', 'around', 'evenly'];
+  return (
+    <div>
+      {values.map((value) => (
+        <div className={`d-flex bg-grey-500 w100 jc-${value} p32`}>
+          <div className="bg-grey-100 p16">.jc-{value}</div>
+          <div className="bg-grey-100 p16">.jc-{value}</div>
+          <div className="bg-grey-100 p16">.jc-{value}</div>
+        </div>
+      ))}
+      <div className={`d-flex bg-grey-500 w100 jc-start md:jc-center lg:jc-end p32`}>
+        <div className="bg-grey-100 p16">responsive test</div>
+        <div className="bg-grey-100 p16">responsive test</div>
+        <div className="bg-grey-100 p16">responsive test</div>
+      </div>
+    </div>
+  );
+};
+
+<RenderJcExample />

--- a/src/lib/scss/public/grid.scss
+++ b/src/lib/scss/public/grid.scss
@@ -9,7 +9,7 @@ $p-mobile-breakpoint: 34rem;
 }
 
 @mixin p-size-tablet {
-  @media (min-width: $p-mobile-breakpoint) {
+  @media (min-width: $p-tablet-breakpoint) and (max-width: $p-desktop-breakpoint) {
     @content;
   }
 }


### PR DESCRIPTION
This PR adds utilities for the most common display properties and a very basic example:
<img width="720" src="https://user-images.githubusercontent.com/9904702/128785936-9631f99f-86b3-41c2-821c-728e0a43f2f8.png" />

It also introduces the following spacing utilities:
- `p{x}` for adding padding utilities.
- `mx{x}`, `my{x}`, `p{x}` and `py{x}` for adding left-right and bottom-top spacing.

Lastly, it adds a mixin for working on responsive styles, and also adds the first version of it to the `display` and `spacing` utilities.

The proposed API is using the prefixes `md:` and `lg:` to add styles to medium and large devices respectively.
I.E. `<div className="p16 md:p24 lg:p32">` will apply the following classes to the `div` component:

```css
.p16 {
  padding: 16px;
}

@media (min-width: 45rem) and (max-width: 64rem) {
  .md\:p24 {
    padding: 24px;
  }
}

@media (min-width: 64rem) {
  .lg\:p32 {
    padding: 32px;
  }
}
```
There is a working example on the Flex page.

One thing to consider: right now using the `@include grid.add-responsive` will introduce a new media query declaration for each CSS property. I'm worried this could make our generated CSS file grow very very big.
I think the best approach would be adding a compression that groups all media query declarations. I would like to know your opinion on this matter. 