### PR TITLE
[NoTicket] add prefix to fit-content width value to support Firefox

### DIFF
--- a/src/lib/components/chip/style.module.scss
+++ b/src/lib/components/chip/style.module.scss
@@ -6,6 +6,7 @@
 
   padding: 4px 8px;
   width: fit-content;
+  width: -moz-fit-content;
 
   display: flex;
   align-items: center;

--- a/src/lib/components/modal/regularModal/style.module.scss
+++ b/src/lib/components/modal/regularModal/style.module.scss
@@ -68,6 +68,7 @@
 
   max-width: 592px;
   width: fit-content;
+  width: -moz-fit-content;
 
   animation-name: appear-in;
   animation-duration: 0.4s;


### PR DESCRIPTION
This PR is tiny, but it adds the `-moz-fit-content` value to some `width` properties in the Modal and Chip components.
This is necessary to make this property work on Firefox. And right now it's causing style inconsistencies in some modals.