### PR TITLE
[NoTicket] go back to old css solution to allow scroll on modals

### DIFF
--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -16,22 +16,10 @@ const useOnClose = (
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const handleWheelEvent = (e: Event) => (isOpen ? e.preventDefault() : null);
-
-    /**
-     * If we add an event listener with identical options,
-     * the event listener will be discarded.
-     * So we can safely add the event inside a useEffect function
-     * that will excecute multiple times.
-     *
-     * More info: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#multiple_identical_event_listeners
-     */
-    window.addEventListener('touchmove', handleWheelEvent, { passive: false }); // mobile
-    window.addEventListener('wheel', handleWheelEvent, { passive: false }); // desktop
+    document.body.style.overflow = isOpen ? 'hidden' : 'auto';
 
     return () => {
-      window.removeEventListener('touchmove', handleWheelEvent);
-      window.removeEventListener('wheel', handleWheelEvent);
+      document.body.style.overflow = 'auto';
     };
   }, [isOpen]);
 


### PR DESCRIPTION
This PR goes back to the old CSS solution to prevent page scroll when a modal is open.
We have to go back to this solution temporarily since the current solution doesn't allow scrolling inside the modal if the modal is too big.

I'm going to do more tests to prevent the page jump that happens with the CSS solution, but for now, I think we have to leave it like this to prevent any content blocking.