### PR TITLE
[EMU-3211] add new prop to control text wrapping on autosuggest dropdown

### DIFF
--- a/src/lib/components/input/autoSuggestInput/index.stories.mdx
+++ b/src/lib/components/input/autoSuggestInput/index.stories.mdx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Meta, Preview } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 
 import AutoSuggestInput from '.';
 import featherLogo from '../../cards/icons/feather-logo.svg';
@@ -31,6 +31,7 @@ export interface Option {
 | handleSuggestionClearRequest | function | Function that runs when suggestions are cleared (eg. input removal, selecting suggestion) | n/a           | true     |
 | placeholder                  | string   | Placeholder for DirtySwan Input component                                                 | n/a           | true     |
 | className                    | string   | Class name for the most parent element                                                    | undefined     | false    |
+| wrapText                     | boolean  | Wether or not wrap the entries in the dropdown or hide overflown text                     | false         | false    |
 
 ## Example
 

--- a/src/lib/components/input/autoSuggestInput/index.tsx
+++ b/src/lib/components/input/autoSuggestInput/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import Autosuggest from 'react-autosuggest';
 
 import styles from './style.module.scss';
@@ -13,6 +14,7 @@ export default ({
   handleSuggestionClearRequest,
   placeholder,
   className,
+  wrapText,
 }: {
   currentOption: string;
   suggestions: Option[];
@@ -22,6 +24,7 @@ export default ({
   handleSuggestionClearRequest: () => void;
   placeholder: string;
   className?: string;
+  wrapText?: boolean;
 }) => {
   const renderSuggestion = (suggestion: Option) => (
     <div className={`${styles['suggestion-option']}`}>
@@ -32,7 +35,13 @@ export default ({
           alt={suggestion.value}
         />
       )}
-      <div className={styles['suggestion-text']}>{suggestion.value}</div>
+      <div
+        className={classNames(styles['suggestion-text'], {
+          [styles.nowrap]: !wrapText,
+        })}
+      >
+        {suggestion.value}
+      </div>
     </div>
   );
 

--- a/src/lib/components/input/autoSuggestInput/style.module.scss
+++ b/src/lib/components/input/autoSuggestInput/style.module.scss
@@ -41,12 +41,12 @@
   position: relative;
 
   margin: 0;
-  padding: 0 16px;
+  padding: 12px 16px;
 
   color: var(--ds-grey-900);
 
   min-height: 48px;
-  line-height: 48px;
+  line-height: 24px;
 }
 
 .suggestion-img {
@@ -57,6 +57,10 @@
 }
 
 .suggestion-text {
+  flex: 1;
+}
+
+.nowrap {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/lib/components/input/autoSuggestMultiSelect/index.stories.mdx
+++ b/src/lib/components/input/autoSuggestMultiSelect/index.stories.mdx
@@ -37,6 +37,7 @@ export interface Option {
 | placeholder          | string   | Placeholder for DirtySwan Input component                                | n/a           | true     |
 | chipsListClassName   | string   | Class name for the most parent element of the Chip component             | undefined     | false    |
 | multiSelectClassName | string   | Class name for the most parent element of the AutoSuggestInput component | undefined     | false    |
+| wrapText             | boolean  | Wether or not wrap the entries in the dropdown or hide overflown text    | false         | false    |
 
 ## Example
 

--- a/src/lib/components/input/autoSuggestMultiSelect/index.tsx
+++ b/src/lib/components/input/autoSuggestMultiSelect/index.tsx
@@ -12,6 +12,7 @@ export default ({
   placeholder,
   chipsListClassName,
   multiSelectClassName,
+  wrapText,
 }: {
   options: Option[];
   selectedValues?: Option[];
@@ -19,6 +20,7 @@ export default ({
   placeholder: string;
   chipsListClassName?: string;
   multiSelectClassName?: string;
+  wrapText?: boolean;
 }) => {
   const [suggestions, setSuggestions] = useState<Option[]>([]);
   const [currentOption, setCurrentOption] = useState('');
@@ -66,6 +68,7 @@ export default ({
         currentOption={currentOption}
         suggestions={suggestions}
         handleSuggestionClearRequest={() => setSuggestions([])}
+        wrapText={wrapText}
       />
     </>
   );


### PR DESCRIPTION
This PR adds a new prop to the Autosuggest component that allows the dropdown text to be wrapped:

<img width="450" src="https://user-images.githubusercontent.com/9904702/137348245-54e68df4-6066-4c59-8790-ccedac15ee42.png" />
