### PR TITLE
[No ticket] remove responsive utilities

### DIFF
--- a/src/lib/scss/public/grid.scss
+++ b/src/lib/scss/public/grid.scss
@@ -9,7 +9,7 @@ $p-mobile-breakpoint: 34rem;
 }
 
 @mixin p-size-tablet {
-  @media (min-width: $p-tablet-breakpoint) {
+  @media (min-width: $p-mobile-breakpoint) {
     @content;
   }
 }


### PR DESCRIPTION
This PR reverts the variable used in the `p-size-tablet` media query