### PR TITLE
[NoTicket]: fix: add inputs and buttons to CSS reset

### DIFF
--- a/src/lib/scss/private/_reset.scss
+++ b/src/lib/scss/private/_reset.scss
@@ -78,7 +78,11 @@ summary,
 time,
 mark,
 audio,
-video {
+video,
+input,
+select,
+button,
+textarea {
   margin: 0;
   padding: 0;
   border: 0;


### PR DESCRIPTION
These elements were missing in the CSS reset and so among other things, rule 'font:inherit;' wasn't applied. This led to some inconsistencies when using the elements without additional CSS classes - most notably the "Products" button on the homepage not inheriting 'Lato' but using the OS fallback font instead

![font](https://user-images.githubusercontent.com/13664983/147059862-5b382750-9883-4320-8f64-ef50ff49d3ec.jpg)
.