### PR TITLE
feat(CardWithLeftIcon): [STO-3386] implement missing xsmall card variant

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
       <div className="mt80"></div>
       <CardWithLeftIcon
         title="Lorem ipsum"
-        titleSize="small"
+        cardSize="small"
         className="wmx6 mt8"
         rightIcon="arrow"
       >

--- a/src/lib/components/cards/a.stories.mdx
+++ b/src/lib/components/cards/a.stories.mdx
@@ -17,9 +17,10 @@ Cards are interactive elements that can be used to display an action that a user
 
 # Models
 
-## Title Size (xsmall, small, medium, big)
+## Card Size (xsmall, small, medium, big)
 
-The card title can be set with the following properties: `xsmall`, `small`, `medium`, `big`.
+The card size can be set with the following properties: `xsmall`, `small`, `medium`, `big`. Depending on the type of card this setting
+affects the font size of the title and card padding.
 
 ## Card State
 

--- a/src/lib/components/cards/cardWithLeftIcon/index.stories.mdx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.stories.mdx
@@ -10,14 +10,27 @@ import { featherLogo } from '../icons';
 | attribute  | unit                                                                                 | description                                       | default value | required |
 | ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------- | ------------- | -------- |
 | title      | string                                                                               | The title text that needs to be displayed         | n/a           | true     |
-| titleSize  | [Title Size (s,m,b)](?path=/story/jsx-cards-intro--page#title-size-small-medium-big) | Size of the title                                 | medium        | false    |
+| titleSize  | [Title Size (xs,s,m,b)](?path=/story/jsx-cards-intro--page#title-size-small-medium-big) | Size of the title                                 | medium        | false    |
 | leftIcon   | [Icon](?path=/story/jsx-cards-intro--page#icon)                                      | Icon displayed on the left hand side of the card  | n/a           | false    |
 | rightIcon  | [Icon](?path=/story/jsx-cards-intro--page#icon)                                      | Icon displayed on the right hand side of the card | n/a           | false    |
 | state      | [Card State](?path=/story/jsx-cards-intro--page#card-state)                          | State that describe the interation with the card  | actionable    | false    |
 | dropshadow | boolean                                                                              | If the card should have a box-shadow or not       | true          | false    |
+| className  | string                                                                               | Class name for most top parent element         | 'n/a'           | false    |
 
 <Preview>
   <>
+    <h4 className="p-h4">Extra small title</h4>
+    <CardWithLeftIcon
+      title="Lorem ipsum"
+      titleSize="xsmall"
+      className="wmx6 mt8"
+      rightIcon="arrow"
+      leftIcon={featherLogo}
+    >
+      Praesent euismod porta odio at tempus.{' '}
+      <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
+      eros at, rhoncus imperdiet nunc
+    </CardWithLeftIcon>
     <h4 className="p-h4">Small title</h4>
     <CardWithLeftIcon
       title="Lorem ipsum"

--- a/src/lib/components/cards/cardWithLeftIcon/index.stories.mdx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.stories.mdx
@@ -10,7 +10,7 @@ import { featherLogo } from '../icons';
 | attribute  | unit                                                                                 | description                                       | default value | required |
 | ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------- | ------------- | -------- |
 | title      | string                                                                               | The title text that needs to be displayed         | n/a           | true     |
-| titleSize  | [Title Size (xs,s,m,b)](?path=/story/jsx-cards-intro--page#title-size-small-medium-big) | Size of the title                                 | medium        | false    |
+| cardSize  | [Card Size (xs,s,m,b)](?path=/story/jsx-cards-intro--page#card-size-xsmall-small-medium-big) | Size of the card                                 | medium        | false    |
 | leftIcon   | [Icon](?path=/story/jsx-cards-intro--page#icon)                                      | Icon displayed on the left hand side of the card  | n/a           | false    |
 | rightIcon  | [Icon](?path=/story/jsx-cards-intro--page#icon)                                      | Icon displayed on the right hand side of the card | n/a           | false    |
 | state      | [Card State](?path=/story/jsx-cards-intro--page#card-state)                          | State that describe the interation with the card  | actionable    | false    |
@@ -19,10 +19,10 @@ import { featherLogo } from '../icons';
 
 <Preview>
   <>
-    <h4 className="p-h4">Extra small title</h4>
+    <h4 className="p-h4">Extra small card</h4>
     <CardWithLeftIcon
       title="Lorem ipsum"
-      titleSize="xsmall"
+      cardSize="xsmall"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -31,10 +31,10 @@ import { featherLogo } from '../icons';
       <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
       eros at, rhoncus imperdiet nunc
     </CardWithLeftIcon>
-    <h4 className="p-h4">Small title</h4>
+    <h4 className="p-h4">Small card</h4>
     <CardWithLeftIcon
       title="Lorem ipsum"
-      titleSize="small"
+      cardSize="small"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -43,10 +43,10 @@ import { featherLogo } from '../icons';
       <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
       eros at, rhoncus imperdiet nunc
     </CardWithLeftIcon>
-    <h4 className="p-h4 mt24">Medium title</h4>
+    <h4 className="p-h4 mt24">Medium card</h4>
     <CardWithLeftIcon
       title="Lorem ipsum"
-      titleSize="medium"
+      cardSize="medium"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -55,10 +55,10 @@ import { featherLogo } from '../icons';
       <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
       eros at, rhoncus imperdiet nunc
     </CardWithLeftIcon>
-    <h4 className="p-h4 mt24">Big title</h4>
+    <h4 className="p-h4 mt24">Big card</h4>
     <CardWithLeftIcon
       title="Lorem ipsum"
-      titleSize="big"
+      cardSize="big"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -71,7 +71,7 @@ import { featherLogo } from '../icons';
     <CardWithLeftIcon
       state="muted"
       title="Lorem ipsum"
-      titleSize="big"
+      cardSize="big"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -81,7 +81,7 @@ import { featherLogo } from '../icons';
       eros at, rhoncus imperdiet nunc
     </CardWithLeftIcon>
     <h4 className="p-h4 mt24">No left icon and right icon</h4>
-    <CardWithLeftIcon title="Lorem ipsum" titleSize="big" className="wmx6 mt8">
+    <CardWithLeftIcon title="Lorem ipsum" cardSize="big" className="wmx6 mt8">
       Praesent euismod porta odio at tempus.{' '}
       <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
       eros at, rhoncus imperdiet nunc
@@ -89,7 +89,7 @@ import { featherLogo } from '../icons';
     <h4 className="p-h4 mt24">No dropshadow</h4>
     <CardWithLeftIcon
       title="Lorem ipsum"
-      titleSize="medium"
+      cardSize="medium"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}

--- a/src/lib/components/cards/cardWithLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.tsx
@@ -1,16 +1,16 @@
 import {
   associatedClassForCardState,
   CardProps,
-  headingForTitleSize,
+  headingForCardSize,
 } from '..';
 import { Icon, arrowRight } from '../icons';
 
 import styles from './style.module.scss';
 
-const containerStyleFromTitleSize = (
-  titleSize: 'xsmall' | 'small' | 'medium' | 'big'
+const containerStyleFromCardSize = (
+  cardSize: 'xsmall' | 'small' | 'medium' | 'big'
 ): string => {
-  switch (titleSize) {
+  switch (cardSize) {
     case 'xsmall':
       return 'container--xsmall';
     case 'small':
@@ -23,7 +23,7 @@ const containerStyleFromTitleSize = (
 export default ({
   className = '',
   title,
-  titleSize = 'medium',
+  cardSize = 'medium',
   children,
   leftIcon,
   rightIcon,
@@ -31,17 +31,17 @@ export default ({
   dropshadow = true,
   ...props
 }: CardProps & {
-  titleSize?: 'xsmall' | 'small' | 'medium' | 'big';
+  cardSize?: 'xsmall' | 'small' | 'medium' | 'big';
   leftIcon?: Icon;
   rightIcon?: 'arrow' | Icon;
 }) => {
   const cardStyle = `d-flex ai-center ${className} ${associatedClassForCardState(
     state,
     dropshadow
-  )} ${styles[containerStyleFromTitleSize(titleSize)]}`;
+  )} ${styles[containerStyleFromCardSize(cardSize)]}`;
 
-  const headingStyle = headingForTitleSize(titleSize);
-  const iconStyle = titleSize === 'xsmall' ? 'mr16' : 'mr32';
+  const headingStyle = headingForCardSize(cardSize);
+  const iconStyle = cardSize === 'xsmall' ? 'mr16' : 'mr32';
 
   return (
     <div className={cardStyle} {...props}>

--- a/src/lib/components/cards/cardWithLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.tsx
@@ -42,6 +42,7 @@ export default ({
 
   const headingStyle = headingForCardSize(cardSize);
   const iconStyle = cardSize === 'xsmall' ? 'mr16' : 'mr32';
+  const cardTextStyle = `tc-grey-600 ${cardSize === 'xsmall' ? 'p-p--small' : 'p-p '}`;
 
   return (
     <div className={cardStyle} {...props}>
@@ -67,7 +68,7 @@ export default ({
             />
           )}
         </div>
-        <p className="p-p mt8 tc-grey-600">{children}</p>
+        <p className={cardTextStyle}>{children}</p>
       </div>
     </div>
   );

--- a/src/lib/components/cards/cardWithLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.tsx
@@ -7,8 +7,21 @@ import { Icon, arrowRight } from '../icons';
 
 import styles from './style.module.scss';
 
+const containerStyleFromTitleSize = (
+  titleSize: 'xsmall' | 'small' | 'medium' | 'big'
+): string => {
+  switch (titleSize) {
+    case 'xsmall':
+      return 'container--xsmall';
+    case 'small':
+      return 'container--small';
+    default:
+      return 'container';
+  }
+};
+
 export default ({
-  className,
+  className = '',
   title,
   titleSize = 'medium',
   children,
@@ -18,41 +31,44 @@ export default ({
   dropshadow = true,
   ...props
 }: CardProps & {
-  titleSize?: 'small' | 'medium' | 'big';
+  titleSize?: 'xsmall' | 'small' | 'medium' | 'big';
   leftIcon?: Icon;
   rightIcon?: 'arrow' | Icon;
-}) => (
-  <div
-    className={`${associatedClassForCardState(state, dropshadow)} d-flex ${
-      styles.container
-    } ${className ?? ''} ${
-      titleSize === 'small' ? styles['container--small'] : ''
-    }`}
-    {...props}
-  >
-    {leftIcon && (
-      <img
-        width="48px"
-        height="48px"
-        className={`mr32 ${styles['left-icon']}`}
-        src={leftIcon.src}
-        alt={leftIcon.alt}
-      />
-    )}
-    <div>
-      <div className="d-flex">
-        <div className={headingForTitleSize(titleSize)}>{title}</div>
-        {rightIcon && (
-          <img
-            className={styles['right-icon']}
-            width="24px"
-            height="24px"
-            src={rightIcon === 'arrow' ? arrowRight.src : rightIcon.src}
-            alt={rightIcon === 'arrow' ? arrowRight.alt : rightIcon.alt}
-          />
-        )}
+}) => {
+  const cardStyle = `d-flex ai-center ${className} ${associatedClassForCardState(
+    state,
+    dropshadow
+  )} ${styles[containerStyleFromTitleSize(titleSize)]}`;
+
+  const headingStyle = headingForTitleSize(titleSize);
+  const iconStyle = titleSize === 'xsmall' ? 'mr16' : 'mr32';
+
+  return (
+    <div className={cardStyle} {...props}>
+      {leftIcon && (
+        <img
+          width="48px"
+          height="48px"
+          className={iconStyle}
+          src={leftIcon.src}
+          alt={leftIcon.alt}
+        />
+      )}
+      <div>
+        <div className="d-flex">
+          <div className={headingStyle}>{title}</div>
+          {rightIcon && (
+            <img
+              className="ml-auto"
+              width="24px"
+              height="24px"
+              src={rightIcon === 'arrow' ? arrowRight.src : rightIcon.src}
+              alt={rightIcon === 'arrow' ? arrowRight.alt : rightIcon.alt}
+            />
+          )}
+        </div>
+        <p className="p-p mt8 tc-grey-600">{children}</p>
       </div>
-      <p className="p-p mt8 tc-grey-600">{children}</p>
     </div>
-  </div>
-);
+  );
+};

--- a/src/lib/components/cards/cardWithLeftIcon/style.module.scss
+++ b/src/lib/components/cards/cardWithLeftIcon/style.module.scss
@@ -1,16 +1,11 @@
 .container {
   padding: 24px 24px 24px 32px;
-  align-items: center;
 
   &--small {
     padding: 16px 24px 16px 32px;
   }
-}
 
-.left-icon {
-  margin-right: 32px;
-}
-
-.right-icon {
-  margin-left: auto;
+  &--xsmall {
+    padding: 16px 16px 16px 24px;
+  }
 }

--- a/src/lib/components/cards/cardWithTopIcon/index.stories.mdx
+++ b/src/lib/components/cards/cardWithTopIcon/index.stories.mdx
@@ -10,7 +10,7 @@ import { featherLogo } from '../icons';
 | attribute  | unit                                                                                 | description                                      | default value | required |
 | ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------- | -------- |
 | title      | string                                                                               | The title text that needs to be displayed        | n/a           | true     |
-| titleSize  | [Title Size (s,m,b)](?path=/story/jsx-cards-intro--page#title-size-small-medium-big) | Size of the title                                | medium        | false    |
+| cardSize  | [Card Size (s,m,b)](?path=/story/jsx-cards-intro--page#card-size-xsmall-small-medium-big) | Size of the card                                | medium        | false    |
 | topIcon    | [Icon](?path=/story/jsx-cards-intro--page#icon)                                      | Icon displayed on the top of the card            | n/a           | true     |
 | rightIcon  | [Icon](?path=/story/jsx-cards-intro--page#icon)                                      | Icon displayed on the right of the title         | n/a           | false    |
 | state      | [Card State](?path=/story/jsx-cards-intro--page#card-state)                          | State that describe the interation with the card | actionable    | false    |
@@ -18,10 +18,10 @@ import { featherLogo } from '../icons';
 
 <Preview>
   <>
-    <h4 className="p-h4">Small title</h4>
+    <h4 className="p-h4">Small card</h4>
     <CardWithTopIcon
       title="Lorem ipsum"
-      titleSize="small"
+      cardSize="small"
       className="wmx6 mt8"
       rightIcon="arrow"
       topIcon={featherLogo}
@@ -32,10 +32,10 @@ import { featherLogo } from '../icons';
         eros at, rhoncus imperdiet nunc
       </p>
     </CardWithTopIcon>
-    <h4 className="p-h4 mt24">Medium title</h4>
+    <h4 className="p-h4 mt24">Medium card</h4>
     <CardWithTopIcon
       title="Lorem ipsum"
-      titleSize="medium"
+      cardSize="medium"
       className="wmx6 mt8"
       rightIcon="arrow"
       topIcon={featherLogo}
@@ -46,10 +46,10 @@ import { featherLogo } from '../icons';
         eros at, rhoncus imperdiet nunc
       </p>
     </CardWithTopIcon>
-    <h4 className="p-h4 mt24">Big title</h4>
+    <h4 className="p-h4 mt24">Big card</h4>
     <CardWithTopIcon
       title="Lorem ipsum"
-      titleSize="big"
+      cardSize="big"
       className="wmx6 mt8"
       rightIcon="arrow"
       topIcon={featherLogo}
@@ -78,7 +78,7 @@ import { featherLogo } from '../icons';
     <CardWithTopIcon
       title="Lorem ipsum"
       topIcon={featherLogo}
-      titleSize="small"
+      cardSize="small"
       className="wmx6 mt8"
     >
       <p className="p-p mt16 tc-grey-600">
@@ -91,7 +91,7 @@ import { featherLogo } from '../icons';
     <CardWithTopIcon
       title="Lorem ipsum"
       topIcon={featherLogo}
-      titleSize="small"
+      cardSize="small"
       className="wmx6 mt8"
       dropshadow={false}
     >

--- a/src/lib/components/cards/cardWithTopIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopIcon/index.tsx
@@ -1,7 +1,7 @@
 import {
   associatedClassForCardState,
   CardProps,
-  headingForTitleSize,
+  headingForCardSize,
 } from '..';
 import { Icon, arrowRight, IconSize } from '../icons';
 
@@ -10,7 +10,7 @@ import styles from './style.module.scss';
 export default ({
   className,
   title,
-  titleSize = 'medium',
+  cardSize = 'medium',
   children,
   topIcon,
   topIconSize = { width: 48, height: 48 },
@@ -21,7 +21,7 @@ export default ({
 }: CardProps & {
   topIcon: Icon;
   topIconSize: IconSize;
-  titleSize?: 'small' | 'medium' | 'big';
+  cardSize?: 'small' | 'medium' | 'big';
   rightIcon?: 'arrow' | Icon;
 }) => {
   const cardStyle = `d-flex fd-column ai-center ${className} ${associatedClassForCardState(
@@ -29,7 +29,7 @@ export default ({
     dropshadow
   )} ${styles.container}`;
 
-  const headingStyle = headingForTitleSize(titleSize);
+  const headingStyle = headingForCardSize(cardSize);
   const iconStyle = styles['right-icon'];
 
   return (

--- a/src/lib/components/cards/cardWithTopIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopIcon/index.tsx
@@ -23,33 +23,38 @@ export default ({
   topIconSize: IconSize;
   titleSize?: 'small' | 'medium' | 'big';
   rightIcon?: 'arrow' | Icon;
-}) => (
-  <>
-    <div
-      className={`d-flex ${associatedClassForCardState(state, dropshadow)} ${
-        styles.container
-      } ${className ?? ''}`}
-      {...props}
-    >
-      <img
-        width={topIconSize.width}
-        height={topIconSize.height}
-        alt={topIcon.alt}
-        src={topIcon.src}
-      />
-      <div className="d-flex mt16">
-        <div className={headingForTitleSize(titleSize)}>{title}</div>
-        {rightIcon && (
-          <img
-            className={styles['right-icon']}
-            width="24px"
-            height="24px"
-            src={rightIcon === 'arrow' ? arrowRight.src : rightIcon.src}
-            alt={rightIcon === 'arrow' ? arrowRight.alt : rightIcon.alt}
-          />
-        )}
+}) => {
+  const cardStyle = `d-flex fd-column ai-center ${className} ${associatedClassForCardState(
+    state,
+    dropshadow
+  )} ${styles.container}`;
+
+  const headingStyle = headingForTitleSize(titleSize);
+  const iconStyle = styles['right-icon'];
+
+  return (
+    <>
+      <div className={cardStyle} {...props}>
+        <img
+          width={topIconSize.width}
+          height={topIconSize.height}
+          alt={topIcon.alt}
+          src={topIcon.src}
+        />
+        <div className="d-flex mt16">
+          <div className={headingStyle}>{title}</div>
+          {rightIcon && (
+            <img
+              className={iconStyle}
+              width="24px"
+              height="24px"
+              src={rightIcon === 'arrow' ? arrowRight.src : rightIcon.src}
+              alt={rightIcon === 'arrow' ? arrowRight.alt : rightIcon.alt}
+            />
+          )}
+        </div>
+        {children}
       </div>
-      {children}
-    </div>
-  </>
-);
+    </>
+  );
+};

--- a/src/lib/components/cards/cardWithTopLeftIcon/index.stories.mdx
+++ b/src/lib/components/cards/cardWithTopLeftIcon/index.stories.mdx
@@ -10,7 +10,7 @@ import { featherLogo } from '../icons';
 | attribute  | unit                                                                              | description                                      | default value | required |
 | ---------- | --------------------------------------------------------------------------------- | ------------------------------------------------ | ------------- | -------- |
 | title      | string                                                                            | The title text that needs to be displayed        | n/a           | true     |
-| titleSize  | [Title Size (xs,s,m,b)](?path=/story/jsx-cards-intro--page#title-size-medium-big) | Size of the title                                | medium        | false    |
+| cardSize  | [Card Size (xs,s,m,b)](?path=/story/jsx-cards-intro--page#card-size-xsmall-small-medium-big) | Size of the card                                | medium        | false    |
 | topIcon    | [Icon](?path=/story/jsx-cards-intro--page#icon)                                   | Icon displayed on the left of the title          | n/a           | false    |
 | rightIcon  | [Icon](?path=/story/jsx-cards-intro--page#icon)                                   | Icon displayed on the right of the title         | n/a           | false    |
 | state      | [Card State](?path=/story/jsx-cards-intro--page#card-state)                       | State that describe the interation with the card | actionable    | false    |
@@ -18,10 +18,10 @@ import { featherLogo } from '../icons';
 
 <Preview>
   <>
-    <h4 className="p-h4">Extra small title</h4>
+    <h4 className="p-h4">Extra small card</h4>
     <CardWithTopLeftIcon
       title="Lorem ipsum"
-      titleSize="xsmall"
+      cardSize="xsmall"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -30,10 +30,10 @@ import { featherLogo } from '../icons';
       <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
       eros at, rhoncus imperdiet nunc
     </CardWithTopLeftIcon>
-    <h4 className="p-h4 mt24">Small title</h4>
+    <h4 className="p-h4 mt24">Small card</h4>
     <CardWithTopLeftIcon
       title="Lorem ipsum"
-      titleSize="small"
+      cardSize="small"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -42,10 +42,10 @@ import { featherLogo } from '../icons';
       <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
       eros at, rhoncus imperdiet nunc
     </CardWithTopLeftIcon>
-    <h4 className="p-h4 mt24">Medium title</h4>
+    <h4 className="p-h4 mt24">Medium card</h4>
     <CardWithTopLeftIcon
       title="Lorem ipsum"
-      titleSize="medium"
+      cardSize="medium"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -54,10 +54,10 @@ import { featherLogo } from '../icons';
       <span className="fw-bold">Aenean urna massa</span>, facilisis malesuada
       eros at, rhoncus imperdiet nunc
     </CardWithTopLeftIcon>
-    <h4 className="p-h4 mt24">Big title</h4>
+    <h4 className="p-h4 mt24">Big card</h4>
     <CardWithTopLeftIcon
       title="Lorem ipsum"
-      titleSize="big"
+      cardSize="big"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}
@@ -87,7 +87,7 @@ import { featherLogo } from '../icons';
     <h4 className="p-h4">No dropshadow</h4>
     <CardWithTopLeftIcon
       title="Lorem ipsum"
-      titleSize="medium"
+      cardSize="medium"
       className="wmx6 mt8"
       rightIcon="arrow"
       leftIcon={featherLogo}

--- a/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
@@ -7,6 +7,17 @@ import { Icon, arrowRight, featherLogo } from '../icons';
 
 import styles from './style.module.scss';
 
+const containerStyleFromTitleSize = (
+  titleSize: 'xsmall' | 'small' | 'medium' | 'big'
+): string => {
+  switch (titleSize) {
+    case 'xsmall':
+      return 'container--xsmall';
+    default:
+      return 'container';
+  }
+};
+
 export default ({
   className,
   title,
@@ -21,42 +32,41 @@ export default ({
   titleSize?: 'xsmall' | 'small' | 'medium' | 'big';
   leftIcon?: 'logo' | Icon;
   rightIcon?: 'arrow' | Icon;
-}) => (
-  <div
-    className={`${associatedClassForCardState(state, dropshadow)} ${
-      styles.container
-    }
-    ${titleSize === 'xsmall' ? styles['container--xsmall'] : ''}
-    ${className ?? ''}`}
-    {...props}
-  >
-    <div className={styles['title-container']}>
-      {leftIcon && (
-        <img
-          className="mr8"
-          width="28px"
-          height="28px"
-          src={leftIcon === 'logo' ? featherLogo.src : leftIcon.src}
-          alt={leftIcon === 'logo' ? featherLogo.alt : leftIcon.src}
-        />
-      )}
-      <div className={headingForTitleSize(titleSize)}>{title}</div>
-      {rightIcon && (
-        <img
-          className={styles['right-icon']}
-          width="24px"
-          height="24px"
-          src={rightIcon === 'arrow' ? arrowRight.src : rightIcon.src}
-          alt={rightIcon === 'arrow' ? arrowRight.alt : rightIcon.alt}
-        />
-      )}
+}) => {
+  const cardStyle = `${className} ${associatedClassForCardState(
+    state,
+    dropshadow
+  )} ${styles[containerStyleFromTitleSize(titleSize)]}`;
+
+  const titleContainerStyle = styles['title-container'];
+  const headingStyle = headingForTitleSize(titleSize);
+  const iconStyle = styles['right-icon'];
+  const cardTextStyle = `p-p tc-grey-600 ${titleSize === 'xsmall' ? styles.indent : 'mt16'}`;
+
+  return (
+    <div className={cardStyle} {...props}>
+      <div className={titleContainerStyle}>
+        {leftIcon && (
+          <img
+            className="mr8"
+            width="28px"
+            height="28px"
+            src={leftIcon === 'logo' ? featherLogo.src : leftIcon.src}
+            alt={leftIcon === 'logo' ? featherLogo.alt : leftIcon.src}
+          />
+        )}
+        <div className={headingStyle}>{title}</div>
+        {rightIcon && (
+          <img
+            className={iconStyle}
+            width="24px"
+            height="24px"
+            src={rightIcon === 'arrow' ? arrowRight.src : rightIcon.src}
+            alt={rightIcon === 'arrow' ? arrowRight.alt : rightIcon.alt}
+          />
+        )}
+      </div>
+      <p className={cardTextStyle}>{children}</p>
     </div>
-    <p
-      className={`p-p tc-grey-600 ${
-        titleSize === 'xsmall' ? styles.indent : 'mt16'
-      }`}
-    >
-      {children}
-    </p>
-  </div>
-);
+  );
+};

--- a/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
@@ -1,7 +1,7 @@
 import {
   associatedClassForCardState,
   CardProps,
-  headingForTitleSize,
+  headingForCardSize,
 } from '..';
 import { Icon, arrowRight, featherLogo } from '../icons';
 
@@ -21,7 +21,7 @@ const containerStyleFromTitleSize = (
 export default ({
   className,
   title,
-  titleSize = 'medium',
+  cardSize = 'medium',
   children,
   leftIcon,
   rightIcon,
@@ -29,19 +29,19 @@ export default ({
   dropshadow = true,
   ...props
 }: CardProps & {
-  titleSize?: 'xsmall' | 'small' | 'medium' | 'big';
+  cardSize?: 'xsmall' | 'small' | 'medium' | 'big';
   leftIcon?: 'logo' | Icon;
   rightIcon?: 'arrow' | Icon;
 }) => {
   const cardStyle = `${className} ${associatedClassForCardState(
     state,
     dropshadow
-  )} ${styles[containerStyleFromTitleSize(titleSize)]}`;
+  )} ${styles[containerStyleFromTitleSize(cardSize)]}`;
 
   const titleContainerStyle = styles['title-container'];
-  const headingStyle = headingForTitleSize(titleSize);
+  const headingStyle = headingForCardSize(cardSize);
   const iconStyle = styles['right-icon'];
-  const cardTextStyle = `p-p tc-grey-600 ${titleSize === 'xsmall' ? styles.indent : 'mt16'}`;
+  const cardTextStyle = `p-p tc-grey-600 ${cardSize === 'xsmall' ? styles.indent : 'mt16'}`;
 
   return (
     <div className={cardStyle} {...props}>

--- a/src/lib/components/cards/index.tsx
+++ b/src/lib/components/cards/index.tsx
@@ -13,10 +13,10 @@ export type CardProps = {
   dropshadow?: boolean;
 } & JSX.IntrinsicElements['div'];
 
-export const headingForTitleSize = (
-  titleSize: 'xsmall' | 'small' | 'medium' | 'big'
+export const headingForCardSize = (
+  cardSize: 'xsmall' | 'small' | 'medium' | 'big'
 ): string => {
-  switch (titleSize) {
+  switch (cardSize) {
     case 'xsmall':
     case 'small':
       return 'p-h4';


### PR DESCRIPTION
### What this PR does
This PR implements the missing "xsmall" variant of the CardWithLeftIcon component to match the corresponding checkbox component.

![image](https://user-images.githubusercontent.com/13664983/150970627-12a40a3c-37fb-409e-96e7-fb0679399371.png)

It also includes, among some minor refactors, a breaking change as it changes the current card prop "titleSize" to "cardSize" to better reflect the intent and effect. 

### Why is this needed?
The xsmall card variant is needed to be able to use a card on roughly the same level of importance as paragraph text.

'titleSize' in a lot of cases not only changes the title size but also other attributes such as padding and margin, so this is why the prop renaming was deemed necessary.

Solves:  
STO-3386 

### Checklist:

- [X] I reviewed my own code
- [X] The changes align with the designs I received  
       Or give a reason why this does not apply:
- [X] I have attached screenshot(s), Loom video(s), or gif(s) showing that the solution is working as expected  
       Or give a reason why this does not apply:
- [X] I have updated the task(s) status on Linear

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [X] Edge
