### PR TITLE
fix(CardWithLeftIcon): [STO-3497] Add whitespace between title and text

### DIFF
--- a/src/lib/components/cards/cardWithLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.tsx
@@ -1,8 +1,4 @@
-import {
-  associatedClassForCardState,
-  CardProps,
-  headingForCardSize,
-} from '..';
+import { associatedClassForCardState, CardProps, headingForCardSize } from '..';
 import { Icon, arrowRight } from '../icons';
 
 import styles from './style.module.scss';
@@ -17,6 +13,20 @@ const containerStyleFromCardSize = (
       return 'container--small';
     default:
       return 'container';
+  }
+};
+
+const cardTextStyleFromCardSize = (
+  cardSize: 'xsmall' | 'small' | 'medium' | 'big'
+): string => {
+  switch (cardSize) {
+    case 'xsmall':
+    case 'small':
+      return 'card-text--small';
+    case 'medium':
+      return 'card-text--medium';
+    default:
+      return 'card-text--big';
   }
 };
 
@@ -42,7 +52,9 @@ export default ({
 
   const headingStyle = headingForCardSize(cardSize);
   const iconStyle = cardSize === 'xsmall' ? 'mr16' : 'mr32';
-  const cardTextStyle = `tc-grey-600 ${cardSize === 'xsmall' ? 'p-p--small' : 'p-p '}`;
+  const cardTextStyle = `tc-grey-600 ${
+    cardSize === 'xsmall' ? 'p-p--small' : 'p-p '
+  } ${styles[cardTextStyleFromCardSize(cardSize)]}`;
 
   return (
     <div className={cardStyle} {...props}>

--- a/src/lib/components/cards/cardWithLeftIcon/style.module.scss
+++ b/src/lib/components/cards/cardWithLeftIcon/style.module.scss
@@ -9,3 +9,15 @@
     padding: 16px 16px 16px 24px;
   }
 }
+
+.card-text--small {
+  margin-top: 2px;
+}
+
+.card-text--medium {
+  margin-top: 4px;
+}
+
+.card-text--big {
+  margin-top: 6px;
+}


### PR DESCRIPTION
### What this PR does
This PR adds the missing whitespace between card title and text to make the design consistent with the Figma file.

![image](https://user-images.githubusercontent.com/13664983/151797415-0753beb8-4c79-44f2-8482-589028340aad.png)

### Why is this needed?

Solves:  
STO-3497 

### Checklist:

- [X] I reviewed my own code
- [X] The changes align with the designs I received  
       Or give a reason why this does not apply:
- [X] I have attached screenshot(s), Loom video(s), or gif(s) showing that the solution is working as expected  
       Or give a reason why this does not apply:
- [X] I have updated the task(s) status on Linear

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [X] Edge
