### PR TITLE
fix(p-btn): [EMU-3904] Update p-btn spacing to match Figma design

### DIFF
--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -14,12 +14,14 @@
 .p-btn {
   position: relative;
 
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 
   cursor: pointer;
 
   height: 48px;
-  padding: 0 16px;
+  padding: 12px 24px;
 
   font-size: 16px;
   font-family: inherit;


### PR DESCRIPTION
### What this PR does
This PR fixes the spacing on the CSS and JSX versions of the buttons by updating the
p-btn class padding to match the values of the Figma design.

Design:
![image](https://user-images.githubusercontent.com/13664983/154049399-a5872834-acb5-45c1-a301-762f5f9aa2af.png)

Updated button:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/13664983/154049475-3dfd5aa5-9b4d-4885-82b8-e0d87a9c56f3.png">


### Why is this needed?

To have consistent button styles across all of the feather products.

Solves:  
EMU-3904 

### Checklist:

- [X] I reviewed my own code
- [X] The changes align with the designs I received  
       Or give a reason why this does not apply:
- [X] I have attached screenshot(s), Loom video(s), or gif(s) showing that the solution is working as expected  
       Or give a reason why this does not apply:
- [X] I have updated the task(s) status on Linear

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [X] Edge
