### PR TITLE
feat(Spacing): [EMU-3910] Add gap utility classes to DS

### DIFF
--- a/src/lib/scss/private/base/_display.scss
+++ b/src/lib/scss/private/base/_display.scss
@@ -29,3 +29,7 @@
 .d-none {
   display: none !important;
 }
+
+.d-grid {
+  display: grid !important;
+}

--- a/src/lib/scss/private/base/_spacing.scss
+++ b/src/lib/scss/private/base/_spacing.scss
@@ -73,3 +73,17 @@ $valid_areas: (
   margin-top: auto;
   margin-bottom: auto;
 }
+
+@for $i from 0 through 12 {
+  .gap#{$i * 8} {
+    gap: $i * 8px;
+  }
+
+  .c-gap#{$i * 8} {
+    column-gap: $i * 8px;
+  }
+
+  .r-gap#{$i * 8} {
+    row-gap: $i * 8px;
+  }
+}

--- a/src/lib/scss/private/base/display.stories.mdx
+++ b/src/lib/scss/private/base/display.stories.mdx
@@ -16,3 +16,4 @@ Dirty swan provides atomic display classes that allow you to change an elementâ€
 | `.d-table`        | `display: table;`        |
 | `.d-table-cell`   | `display: table-cell;`   |
 | `.d-none`         | `display: none;`         |
+| `.d-grid`         | `display: grid;`         |

--- a/src/lib/scss/private/base/spacing.stories.mdx
+++ b/src/lib/scss/private/base/spacing.stories.mdx
@@ -4,7 +4,7 @@
 
 Dirty swan provides way to express spacing
 
-## Margin / Padding
+## Margin / Padding / Gaps
 
 You can use the shorthand class name to define the four margin properties:
 
@@ -25,6 +25,14 @@ The same applies for padding:
 `padding-right` with `.pr{x}`
 
 `padding-left` with `.pl{x}`
+
+Gaps can be expressed via 3 different classes, depending on your use case:
+
+`gap` with `.gap{x}`
+
+`column-gap` with `.c-gap{x}`
+
+`row-gap` with `.r-gap{x}`
 
 ### Top margin / padding
 
@@ -109,3 +117,57 @@ Note: this only applies to the margin property
 | `.mb-auto` | `margin-bottom: auto` |
 | `.ml-auto` | `margin-left: auto`   |
 | `.mr-auto` | `margin-right: auto`  |
+
+### gap (Equal gap horizontally and vertically)
+
+| Class    | Output    |
+| -------- | --------- |
+| `.gap0`  | `gap: 0`  |
+| `.gap8`  | `gap: 8`  |
+| `.gap6`  | `gap: 16` |
+| `.gap24` | `gap: 24` |
+| `.gap32` | `gap: 32` |
+| `.gap40` | `gap: 40` |
+| `.gap48` | `gap: 48` |
+| `.gap56` | `gap: 56` |
+| `.gap64` | `gap: 64` |
+| `.gap72` | `gap: 72` |
+| `.gap80` | `gap: 80` |
+| `.gap88` | `gap: 88` |
+| `.gap96` | `gap: 96` |
+
+### column-gap (Horizontal gap between items)
+
+| Class      | Output           |
+| ---------- | ---------------- |
+| `.c-gap0`  | `column-gap: 0`  |
+| `.c-gap8`  | `column-gap: 8`  |
+| `.c-gap6`  | `column-gap: 16` |
+| `.c-gap24` | `column-gap: 24` |
+| `.c-gap32` | `column-gap: 32` |
+| `.c-gap40` | `column-gap: 40` |
+| `.c-gap48` | `column-gap: 48` |
+| `.c-gap56` | `column-gap: 56` |
+| `.c-gap64` | `column-gap: 64` |
+| `.c-gap72` | `column-gap: 72` |
+| `.c-gap80` | `column-gap: 80` |
+| `.c-gap88` | `column-gap: 88` |
+| `.c-gap96` | `column-gap: 96` |
+
+### row-gap (Vertical gap between items)
+
+| Class      | Output        |
+| ---------- | ------------- |
+| `.r-gap0`  | `row-gap: 0`  |
+| `.r-gap8`  | `row-gap: 8`  |
+| `.r-gap6`  | `row-gap: 16` |
+| `.r-gap24` | `row-gap: 24` |
+| `.r-gap32` | `row-gap: 32` |
+| `.r-gap40` | `row-gap: 40` |
+| `.r-gap48` | `row-gap: 48` |
+| `.r-gap56` | `row-gap: 56` |
+| `.r-gap64` | `row-gap: 64` |
+| `.r-gap72` | `row-gap: 72` |
+| `.r-gap80` | `row-gap: 80` |
+| `.r-gap88` | `row-gap: 88` |
+| `.r-gap96` | `row-gap: 96` |

--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -14,12 +14,14 @@
 .p-btn {
   position: relative;
 
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 
   cursor: pointer;
 
   height: 48px;
-  padding: 0 16px;
+  padding: 12px 24px;
 
   font-size: 16px;
   font-family: inherit;


### PR DESCRIPTION
### What this PR does
This PR adds 3 new utility classes `.gap`, `.c-gap` and `.r-gap` to enable the use of the properties `gap`, `column-gap` and `row-gap` without the need for custom css.

It also adds the missing `.d-grid `class.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/13664983/154055547-426f8e26-72a4-42fd-b0ad-53543bcae794.png">

### Why is this needed?

To be able to use gaps without having to resort to custom CSS.

Solves:  
EMU-3910 

### Checklist:

- [X] I reviewed my own code
- [X] The changes align with the designs I received  
       Or give a reason why this does not apply:
- [X] I have attached screenshot(s), Loom video(s), or gif(s) showing that the solution is working as expected  
       Or give a reason why this does not apply:
- [X] I have updated the task(s) status on Linear

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [X] Edge
