### PR TITLE
feat(Colors): [EMU-3942] Add glacier, spearmint and pink color families

### DIFF
--- a/src/lib/scss/public/colors/default.scss
+++ b/src/lib/scss/public/colors/default.scss
@@ -21,11 +21,23 @@ $ds-blue-500: #8bb4ea;
 $ds-blue-700: #5f7ba0;
 $ds-blue-900: #2d394a;
 
+$ds-glacier-100: #e0f7fe;
+$ds-glacier-300: #aeddec;
+$ds-glacier-500: #8bcbdf;
+$ds-glacier-700: #5d8896;
+$ds-glacier-900: #2d4148;
+
 $ds-red-100: #fedede;
 $ds-red-300: #faa0a0;
 $ds-red-500: #e55454;
 $ds-red-700: #c64848;
 $ds-red-900: #4b2525;
+
+$ds-pink-100: #ffebf1;
+$ds-pink-300: #ffb1cb;
+$ds-pink-500: #f96092;
+$ds-pink-700: #c0305f;
+$ds-pink-900: #700024;
 
 $ds-grey-100: #fafaff;
 $ds-grey-200: #f5f5fa;
@@ -40,6 +52,12 @@ $ds-green-300: #c4f5c8;
 $ds-green-500: #84de8a;
 $ds-green-700: #5b985f;
 $ds-green-900: #354a2d;
+
+$ds-spearmint-100: #e3fff2;
+$ds-spearmint-300: #aaeacc;
+$ds-spearmint-500: #85dcb4;
+$ds-spearmint-700: #599278;
+$ds-spearmint-900: #2b4639;
 
 $ds-yellow-100: #fff8e3;
 $ds-yellow-300: #fae3a5;
@@ -84,6 +102,21 @@ $colors: (
   'green-500': $ds-green-500,
   'green-700': $ds-green-700,
   'green-900': $ds-green-900,
+  'glacier-100': $ds-glacier-100,
+  'glacier-300': $ds-glacier-300,
+  'glacier-500': $ds-glacier-500,
+  'glacier-700': $ds-glacier-700,
+  'glacier-900': $ds-glacier-900,
+  'spearmint-100': $ds-spearmint-100,
+  'spearmint-300': $ds-spearmint-300,
+  'spearmint-500': $ds-spearmint-500,
+  'spearmint-700': $ds-spearmint-700,
+  'spearmint-900': $ds-spearmint-900,
+  'pink-100': $ds-pink-100,
+  'pink-300': $ds-pink-300,
+  'pink-500': $ds-pink-500,
+  'pink-700': $ds-pink-700,
+  'pink-900': $ds-pink-900,
   'yellow-100': $ds-yellow-100,
   'yellow-300': $ds-yellow-300,
   'yellow-500': $ds-yellow-500,

--- a/src/lib/scss/public/demo.tsx
+++ b/src/lib/scss/public/demo.tsx
@@ -2,31 +2,6 @@ import React from 'react';
 
 const colors = [
   {
-    name: 'Blue 100',
-    code: 'blue-100',
-    hex: '#e5f0ff',
-  },
-  {
-    name: 'Blue 300',
-    code: 'blue-300',
-    hex: '#b0cdf3',
-  },
-  {
-    name: 'Blue 500',
-    code: 'blue-500',
-    hex: '#8bb4ea',
-  },
-  {
-    name: 'Blue 700',
-    code: 'blue-700',
-    hex: '#5f7ba0',
-  },
-  {
-    name: 'Blue 900',
-    code: 'blue-900',
-    hex: '#2d394a',
-  },
-  {
     name: 'Primary 25',
     code: 'primary-25',
     hex: '#fcfcff',
@@ -62,6 +37,56 @@ const colors = [
     hex: '#2e2e4c',
   },
   {
+    name: 'Blue 100',
+    code: 'blue-100',
+    hex: '#e5f0ff',
+  },
+  {
+    name: 'Blue 300',
+    code: 'blue-300',
+    hex: '#b0cdf3',
+  },
+  {
+    name: 'Blue 500',
+    code: 'blue-500',
+    hex: '#8bb4ea',
+  },
+  {
+    name: 'Blue 700',
+    code: 'blue-700',
+    hex: '#5f7ba0',
+  },
+  {
+    name: 'Blue 900',
+    code: 'blue-900',
+    hex: '#2d394a',
+  },
+  {
+    name: 'Glacier 100',
+    code: 'glacier-100',
+    hex: '#e0f7fe',
+  },
+  {
+    name: 'Glacier 300',
+    code: 'glacier-300',
+    hex: '#aeddec',
+  },
+  {
+    name: 'Glacier 500',
+    code: 'glacier-500',
+    hex: '#8bcbdf',
+  },
+  {
+    name: 'Glacier 700',
+    code: 'glacier-700',
+    hex: '#5d8896',
+  },
+  {
+    name: 'Glacier 900',
+    code: 'glacier-900',
+    hex: '#2d4148',
+  },
+  {
     name: 'Red 100',
     code: 'red-100',
     hex: '#fedede',
@@ -85,6 +110,31 @@ const colors = [
     name: 'Red 900',
     code: 'red-900',
     hex: '#4b2525',
+  },
+  {
+    name: 'Pink 100',
+    code: 'pink-100',
+    hex: '#ffebf1',
+  },
+  {
+    name: 'Pink 300',
+    code: 'pink-300',
+    hex: '#ffb1cb',
+  },
+  {
+    name: 'Pink 500',
+    code: 'pink-500',
+    hex: '#f96092',
+  },
+  {
+    name: 'Pink 700',
+    code: 'pink-700',
+    hex: '#c0305f',
+  },
+  {
+    name: 'Pink 900',
+    code: 'pink-900',
+    hex: '#700024',
   },
   {
     name: 'Grey 100',
@@ -145,6 +195,31 @@ const colors = [
     name: 'Green 900',
     code: 'green-900',
     hex: '#354a2d',
+  },
+  {
+    name: 'Spearmint 100',
+    code: 'spearmint-100',
+    hex: '#e3fff2',
+  },
+  {
+    name: 'Spearmint 300',
+    code: 'spearmint-300',
+    hex: '#aaeacc',
+  },
+  {
+    name: 'Spearmint 500',
+    code: 'spearmint-500',
+    hex: '#85dcb4',
+  },
+  {
+    name: 'Spearmint 700',
+    code: 'spearmint-700',
+    hex: '#599278',
+  },
+  {
+    name: 'Spearmint 900',
+    code: 'spearmint-900',
+    hex: '#2b4639',
   },
   {
     name: 'Yellow 100',


### PR DESCRIPTION
### What this PR does
This PR adds 3 new color families: glacier, spearmint and pink

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/13664983/154458827-13ca9d18-1171-40f5-9d87-0c8289c7bb80.png">

Solves:  
EMU-3942 

### Checklist:

- [X] I reviewed my own code
- [X] The changes align with the designs I received  
       Or give a reason why this does not apply:
- [X] I have attached screenshot(s), Loom video(s), or gif(s) showing that the solution is working as expected  
       Or give a reason why this does not apply:
- [X] I have updated the task(s) status on Linear

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [X] Edge
