### PR TITLE
fix(Buttons): [EMU-4003] Remove incorrect line-height and superfluous flex attributes

### DIFF
--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -12,12 +12,9 @@
 }
 
 .p-btn {
+  display: inline-block;
+
   position: relative;
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
   cursor: pointer;
 
   height: 48px;
@@ -25,7 +22,6 @@
 
   font-size: 16px;
   font-family: inherit;
-  line-height: 48px;
   letter-spacing: 0.5px;
   text-decoration: none;
   text-align: center;


### PR DESCRIPTION
When updating the buttons with the proper paddings the text was no longer centered which was counteracted by using flex to center the text. But the root cause was actually the incorrect line-height. 

When the line-height is removed the text is centered without the need for flex. This avoids visual regressions due to manually set display: inline-block or block in the other parts of the codebase.