### PR TITLE
fix(Buttons) [EMU-4007] add explicit line height to ds button

### DIFF
--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -20,6 +20,8 @@
   height: 48px;
   padding: 12px 24px;
 
+  line-height: normal;
+
   font-size: 16px;
   font-family: inherit;
   letter-spacing: 0.5px;


### PR DESCRIPTION
This PR fixes an issue where the missing line-height would lead to off center text in some edge cases.