### PR TITLE
fix(Buttons): [NoTicket] Set line-height to a fixed value

### DIFF
--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -20,7 +20,7 @@
   height: 48px;
   padding: 12px 24px;
 
-  line-height: normal;
+  line-height: 24px;
 
   font-size: 16px;
   font-family: inherit;


### PR DESCRIPTION
This PR sets the line-height to a fixed value to fix an issue where anchor tags using button classes would have text that is slightly off center.