### PR TITLE
fix(npm): [STO-3642] Add src folder to package.json's tracked files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "bin": "dist/bin/index.js",
   "files": [
     "dist",
+    "src",
     "Readme.md"
   ],
   "dependencies": {


### PR DESCRIPTION
Currently only the dist folder is included in the package which makes react-scripts 5.0 show 51 warnings after the planned version bump in the app repo.

![image](https://user-images.githubusercontent.com/13664983/156750042-356d2dbc-5202-4a26-a7d8-e0f286ea5c0b.png)

Adding the src folder to package.json's "files" should get rid of this issue:

https://github.com/facebook/create-react-app/discussions/11767#discussioncomment-2096794 