### PR TITLE
chore: update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,14 @@
 ### What this PR does
 
-Please include a summary of the change and which issue is fixed or a link to the feature it implements.
+_Please include a summary of the change(s)._
+
+1.
+2.
+3.
 
 ### Why is this needed?
 
-Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...
+_Please include additional context of why this PR is necessary._
 
 Solves:  
 STO-XXX  
@@ -14,11 +18,11 @@ EMU-XXX
 
 - [ ] I reviewed my own code
 - [ ] The changes align with the designs I received  
-       Or give a reason why this does not apply:
-- [ ] I have attached screenshot(s), Loom video(s), or gif(s) showing that the solution is working as expected  
-       Or give a reason why this does not apply:
+  Or give a reason why this does not apply:
+- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
+  Or give a reason why this does not apply:
 - [ ] I have updated the task(s) status on Linear
-- [ ] I have compressed the images
+- [ ] All new media is optimized (images, gifs, videos)
 
 ### Browser support
 


### PR DESCRIPTION
### What this PR does

This PR updates the pull request template to a more generic version

### Why is this needed?

The current PR is too opinionated about the technologies and can become dated if we decide to stop using them. This version is simpler and more generic.