### PR TITLE
fix(modal): [EMU-4306] do not open modal when pressing the esc key

### DIFF
--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 const useOnClose = (
   onClose: () => void,
@@ -7,13 +7,32 @@ const useOnClose = (
 ) => {
   const [isClosing, setIsClosing] = useState(false);
 
+  const handleOnClose = useCallback(() => {
+    setIsClosing(true);
+    setTimeout(() => {
+      onClose();
+      setIsClosing(false);
+    }, 300);
+  }, [setIsClosing, onClose]);
+
+  const handleEscKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.code !== 'Escape') return;
+      if (!dismissable) return null;
+      if (!isOpen) return null;
+
+      handleOnClose();
+    },
+    [isOpen, dismissable, handleOnClose]
+  );
+
   useEffect(() => {
     window.addEventListener('keydown', handleEscKey);
 
     return () => {
       window.removeEventListener('keydown', handleEscKey);
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [handleEscKey]);
 
   useEffect(() => {
     document.body.style.overflow = isOpen ? 'hidden' : 'auto';
@@ -22,22 +41,6 @@ const useOnClose = (
       document.body.style.overflow = 'auto';
     };
   }, [isOpen]);
-
-  const handleOnClose = () => {
-    if (!dismissable) return null;
-
-    setIsClosing(true);
-    setTimeout(() => {
-      onClose();
-      setIsClosing(false);
-    }, 300);
-  };
-
-  const handleEscKey = (e: KeyboardEvent) => {
-    if (e.code !== 'Escape') return;
-
-    handleOnClose();
-  };
 
   const handleContainerClick = (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>

--- a/src/lib/components/modal/index.stories.mdx
+++ b/src/lib/components/modal/index.stories.mdx
@@ -30,22 +30,19 @@ Modals are dialog overlays that prevent the user from interacting with the rest 
 
 export const RegularModalStory = () => {
   const [display, setDisplay] = useState(false);
+  const toggleOpen = () => setDisplay(!display);
   return (
     <>
       <button
         className="p-btn--primary wmn2"
-        onClick={() => {
-          setDisplay(!display);
-        }}
+        onClick={toggleOpen}
       >
         Regular modal
       </button>
       <RegularModal
         title="Regular modal title"
         isOpen={display}
-        onClose={() => {
-          setDisplay(false);
-        }}
+        onClose={toggleOpen}
       >
         <div style={{ padding: '0 24px 24px 24px' }}>
           <p className="p-p">

--- a/src/lib/components/modal/regularModal/style.module.scss
+++ b/src/lib/components/modal/regularModal/style.module.scss
@@ -1,18 +1,22 @@
 @keyframes fade-in {
   0% {
     background-color: rgba($color: #000000, $alpha: 0);
+    visibility: hidden;
   }
   100% {
     background-color: rgba($color: #000000, $alpha: 0.3);
+    visibility: visible;
   }
 }
 
 @keyframes fade-out {
   from {
     background-color: rgba($color: #000000, $alpha: 0.3);
+    visibility: visible;
   }
   to {
     background-color: rgba($color: #000000, $alpha: 0);
+    visibility: hidden;
   }
 }
 
@@ -20,10 +24,12 @@
   0% {
     transform: translateY(24px) translateX(-50%);
     opacity: 0;
+    visibility: hidden;
   }
   100% {
     transform: translateY(0) translateX(-50%);
     opacity: 1;
+    visibility: visible;
   }
 }
 
@@ -31,10 +37,12 @@
   0% {
     transform: translateY(0) translateX(-50%);
     opacity: 1;
+    visibility: visible;
   }
   100% {
     transform: translateY(24px) translateX(-50%);
     opacity: 0;
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
### What this PR does

1. This PR fixes a bug that was allowing users to open modals when pressing the `ESC` key
2. It also fixes the  dependency array on `useOnClose.ts` hook

### Why is this needed?
We want the modals to execute the `onClose` function only when the modal is open.

Solves:  
EMU-4306

### Checklist:

- [X] I reviewed my own code
- [X] ~The changes align with the designs I received~  
No visual changes
- [X] ~I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected~  
No visual changes
- [X] I have updated the task(s) status on Linear
- [X] ~All new media is optimized (images, gifs, videos)~
N/A

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [X] Edge
