### PR TITLE
chore: Updating @popsure/public-model to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popsure/dirty-swan",
-  "version": "0.26.13",
+  "version": "0.27.0-alpha.3",
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "Readme.md"
   ],
   "dependencies": {
-    "@popsure/public-models": "^0.0.14",
+    "@popsure/public-models": "^1.0.1",
     "classnames": "^2.3.1",
     "dayjs": "^1.10.7",
     "lodash.debounce": "^4.0.8",

--- a/src/lib/components/autocompleteAddress/util/index.ts
+++ b/src/lib/components/autocompleteAddress/util/index.ts
@@ -1,4 +1,8 @@
-import { Address, countryNameFromAlphaCode } from '@popsure/public-models';
+import {
+  Address,
+  countryNameFromAlphaCode,
+  Alpha2CountryCode,
+} from '@popsure/public-models';
 
 export const geocoderAddressComponentToPartialAddress = (
   input: google.maps.GeocoderAddressComponent[]
@@ -52,4 +56,4 @@ export const geocoderAddressComponentToPartialAddress = (
 export const inlineAddress = (address: Address) =>
   `${address.street} ${address.houseNumber}, ${
     address.city
-  }, ${countryNameFromAlphaCode(address.country)}`;
+  }, ${countryNameFromAlphaCode(address.country as Alpha2CountryCode)}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1781,12 +1781,10 @@
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@popsure/public-models@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.npmjs.org/@popsure/public-models/-/public-models-0.0.14.tgz#228eda53f9400e908e57931a341a3f5293abd21f"
-  integrity sha512-rfDvCE/HiNEPTISRpfKbyv2w2JzmeQzT7QRLEvpf/+Rv5LQu/+viegj0yopn+IrEqUFR+nEd9jBarrIAUh/dfQ==
-  dependencies:
-    "@rollup/plugin-image" "^2.0.6"
+"@popsure/public-models@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@popsure/public-models/-/public-models-1.0.1.tgz#95149065463caf49ade38c3c27a45bb72120921b"
+  integrity sha512-fO53EpwvpbxV4yNdxza079Hy8knegbgYlhmVZe6QgcbOoTKDyfEcegtrbz2y05BJPdxdLqIeIVEnQoAxrSADiw==
 
 "@reach/router@^1.3.4":
   version "1.3.4"
@@ -1810,14 +1808,6 @@
     is-reference "^1.2.1"
     magic-string "^0.25.7"
     resolve "^1.17.0"
-
-"@rollup/plugin-image@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/@rollup/plugin-image/-/plugin-image-2.0.6.tgz#2e6d7a72b25df81aa80c8c0866d45a45c1e6a265"
-  integrity sha512-bB+spXogbPiFjhBS7i8ajUOgOnVwWK3bnJ6VroxKey/q8/EPRkoSh+4O1qPCw97qMIDspF4TlzXVBhZ7nojIPw==
-  dependencies:
-    "@rollup/pluginutils" "^3.1.0"
-    mini-svg-data-uri "^1.2.3"
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
@@ -9713,11 +9703,6 @@ mini-css-extract-plugin@0.11.3:
     normalize-url "1.9.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
-
-mini-svg-data-uri@^1.2.3:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz#91d2c09f45e056e5e1043340b8b37ba7b50f4fac"
-  integrity sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# What this PR does

We're updating to public-model in order to take advantage of the ESM module definition

# Why is this needed?

- The dist/index.js file size was 3MB 😱 now it is 733KB
- NextJS12 now supports ESM, it's now safe to have all our libraries exported as ESM.
