### PR TITLE
refactor(typography): add focus state to links

### DIFF
--- a/src/lib/scss/private/base/_typography.scss
+++ b/src/lib/scss/private/base/_typography.scss
@@ -95,9 +95,16 @@ body {
 .p-a {
   color: $ds-primary-500;
   text-decoration: none;
+
   &:hover,
   &:focus {
     color: $ds-primary-700;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $ds-grey-900;
+    border-radius: 2px;
+    outline-offset: 2px;
   }
 }
 

--- a/src/lib/scss/private/base/demo.tsx
+++ b/src/lib/scss/private/base/demo.tsx
@@ -11,6 +11,10 @@ export const Typography = () => (
     <h4 className="p-h4">The quick brown fox jumps over the lazy dog</h4>
     <p className="p-p">The quick brown fox jumps over the lazy dog</p>
     <p className="p-p--small">The quick brown fox jumps over the lazy dog</p>
+    <a href="#" className="p-a">
+      The quick brown fox jumps over the lazy dog
+    </a>
+    <p className="p-error">The quick brown fox jumps over the lazy dog</p>
   </>
 );
 

--- a/src/lib/scss/private/base/typography.stories.mdx
+++ b/src/lib/scss/private/base/typography.stories.mdx
@@ -48,6 +48,8 @@ Dirty swan provides classes to override default heading.
 <h4 class="p-h4">The quick brown fox jumps over the lazy dog</h4>
 <p class="p-p">The quick brown fox jumps over the lazy dog</p>
 <p class="p-p--small">The quick brown fox jumps over the lazy dog</p>
+<a class="p-a">The quick brown fox jumps over the lazy dog</a>
+<p class="p-error">The quick brown fox jumps over the lazy dog</p>
 ```
 
 ## Layout
@@ -69,3 +71,4 @@ Dirty swan provides classes to override default heading.
 | ----------- | ------------------- |
 | `fs-italic` | font-style: italic; |
 | `fs-normal` | font-style: normal; |
+


### PR DESCRIPTION
### What this PR does

_Please include a summary of the change(s)._

1. This PR adds a new `:focus-visible` property to links.

![image](https://user-images.githubusercontent.com/9904702/172398934-3f25df52-6cca-4a37-b92b-68e7129e80a5.png)

### Why is this needed?
To increase accessibility in our projects.  

### Checklist:

- [X] I reviewed my code
- [X] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [X] I have attached screenshot(s), video(s), or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [] I have updated the task(s) status on Linear
N/A
- [ ] All new media is optimized (images, gifs, videos)
N/A

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
Safari does not show the correct color. Instead it displays the focus ring in the default blue:
![image](https://user-images.githubusercontent.com/9904702/172401497-7c25d7f1-1104-492a-bed8-20ae756d58df.png)
- [X] Edge
