### PR TITLE
Yejin/sto 3473 radio button styling is broken on

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,14 @@ Dirty Swan UI is the Design system used at [Feather Insurance](https://feather-i
 
 See our official website for installation and usage [dirtyswan.design](http://dirtyswan.design/)
 
+### Preview
+
+Start the development server using
+
+```shell
+yarn storybook
+```
+
 ## Contributing
 
 ### Releasing a new version

--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -94,10 +94,7 @@
 .p-radio:checked {
   & + label::before {
     border-color: $ds-primary-500;
-
-    background-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="6" cy="6" r="5.5" fill="#{util.url-encoded-color($ds-primary-500)}" /></svg>');
-    background-repeat: no-repeat;
-    background-position: center;
+    background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 20 20" stroke="white" stroke-width="4" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="50%" fill="#{util.url-encoded-color($ds-primary-500)}"/></svg>');
   }
 }
 


### PR DESCRIPTION
### What this PR does

Style fix for selected radio button
You can check the pre-release with tag `v0.27.1-alpha`

As-is (dots not centered):
<img width="500" alt="image" src="https://user-images.githubusercontent.com/26237320/174277574-e05d5ca4-93d9-4d3e-9fdc-79816518ea4c.png">

To-be:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/26237320/174277917-f0d2f8ff-f5d6-49a4-984b-d39131e80ddb.png">

### Why is this needed?

Solves: STO-3473

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
