### PR TITLE
fix(Input): [STO-4003] Hide input number arrows in Firefox

### DIFF
--- a/src/lib/scss/private/_reset.scss
+++ b/src/lib/scss/private/_reset.scss
@@ -147,3 +147,8 @@ input[type='number']::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+/* Firefox */
+input[type='number'] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
### What this PR does

This PR hides the input number arrows when using Firefox. The arrows were already hidden for Chrome / Webkit / Opera based browsers but a corresponding CSS rule for Firefox was missing.

BEFORE:
<img width="420" alt="image" src="https://user-images.githubusercontent.com/13664983/175253781-f8e0d925-aaef-4dfd-9005-9db75095ddf8.png">

AFTER:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/13664983/175253900-3ec0a4aa-d68c-4295-a290-a063e9e55dcc.png">


### Why is this needed?

_Please include additional context of why this PR is necessary._

Solves:  
STO-4003
STO-4195

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
