### PR TITLE
feat(localization): [STO-4281] Expose props to enable localization

### DIFF
--- a/src/lib/components/autocompleteAddress/demo.tsx
+++ b/src/lib/components/autocompleteAddress/demo.tsx
@@ -36,3 +36,53 @@ export const WithAddress = () => {
     />
   );
 };
+
+export const WithoutAddressLocalized = () => {
+  const [address, setAddress] = useState<Partial<Address> | undefined>();
+  return (
+    <AutoCompleteAddress
+      onAddressChange={(address) => {
+        setAddress(address);
+      }}
+      address={address}
+      apiKey="AIzaSyDg0DSrjYKt5smmsjkVasDz7c4T5rbOXT8"
+      placeholders={{
+        manualAddressEntry: 'Adresse suchen',
+        street: 'Straße',
+        houseNumber: 'Hausnummer',
+        additionalInformation: 'Adresszusatz (c/o, z. Hd., o.V.i.A, ...)',
+        postcode: 'PLZ',
+        city: 'Stadt',
+      }}
+      manualAddressEntryTexts={{
+        preText: 'Oder ',
+        cta: 'Adresse direkt eingeben',
+      }}
+    />
+  );
+};
+
+export const WithAddressLocalized = () => {
+  const [address, setAddress] = useState<Partial<Address> | undefined>({});
+  return (
+    <AutoCompleteAddress
+      onAddressChange={(address) => {
+        setAddress(address);
+      }}
+      address={address}
+      apiKey="AIzaSyDg0DSrjYKt5smmsjkVasDz7c4T5rbOXT8"
+      placeholders={{
+        manualAddressEntry: 'Adresse suchen',
+        street: 'Straße',
+        houseNumber: 'Hausnummer',
+        additionalInformation: 'Adresszusatz (c/o, z.Hd., o.V.i.A, ...)',
+        postcode: 'PLZ',
+        city: 'Stadt',
+      }}
+      manualAddressEntryTexts={{
+        preText: 'Oder ',
+        cta: 'Adresse direkt eingeben',
+      }}
+    />
+  );
+};

--- a/src/lib/components/autocompleteAddress/index.stories.mdx
+++ b/src/lib/components/autocompleteAddress/index.stories.mdx
@@ -3,17 +3,24 @@ import { useState } from 'react';
 import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
 import AutocompleteAddress from '.';
-import { WithoutAddress, WithAddress } from './demo';
+import {
+  WithoutAddress,
+  WithoutAddressLocalized,
+  WithAddress,
+  WithAddressLocalized,
+} from './demo';
 
 <Meta title="JSX/Autocomplete Address" component={AutocompleteAddress} />
 
 # Autocomplete Address
 
-| attribute       | unit                                      | description                                                                                                                    | default value | required |
-| --------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------- | -------- |
-| address         | `Partial<Address>`                        | The address                                                                                                                    | undefined     | false    |
-| onAddressChange | `function (newAddress: Partial<Address>)` | Callback with the updated address, this function will get called everytime the address gets updated.                           | n/a           | true     |
-| apiKey          | string                                    | Your private API key for the [Google Places API](https://developers.google.com/maps/documentation/places/web-service/overview) | n/a           | true     |
+| attribute               | unit                                                                                                                                        | description                                                                                                                    | default value | required |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------- | -------- |
+| address                 | `Partial<Address>`                                                                                                                          | The address                                                                                                                    | undefined     | false    |
+| onAddressChange         | `function (newAddress: Partial<Address>)`                                                                                                   | Callback with the updated address, this function will get called everytime the address gets updated.                           | n/a           | true     |
+| apiKey                  | string                                                                                                                                      | Your private API key for the [Google Places API](https://developers.google.com/maps/documentation/places/web-service/overview) | n/a           | true     |
+| placeholders            | `{ manualAddressEntry?: string; street: string?; houseNumber?: string; additionalInformation?: string; postcode?: string; city?: string; }` | Placeholder text                                                                                                               | undefined     | false    |
+| manualAddressEntryTexts | `{ preText?: string; cta: string?; }`                                                                                                       | The CTA that enables manual address entry and the text preceding it                                                            | undefined     | false    |
 
 Autocomplete Address are user interface elements which allow users start typing an address and get autocompletion suggestions on the address.
 
@@ -31,10 +38,12 @@ This component is for now only restricted to "address" types and will restrict e
 
 <WithAddress />
 
-```typescript
-import React, { useState } from 'react';
-import { Address } from '@popsure/public-models';
+### Localized inputs
 
+<WithoutAddressLocalized />
+<WithAddressLocalized />
+
+```typescript import React, {useState} from 'react'; import {Address} from '@popsure/public-models';
 import AutoCompleteAddress from '.';
 
 export default () => {

--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -53,10 +53,24 @@ const AutoCompleteAddress = ({
   apiKey,
   address: initialAddress,
   onAddressChange,
+  placeholders,
+  manualAddressEntryTexts,
 }: {
   apiKey: string;
   address?: Partial<Address>;
   onAddressChange: (address: Partial<Address>) => void;
+  placeholders?: {
+    manualAddressEntry?: string;
+    street?: string;
+    houseNumber?: string;
+    additionalInformation?: string;
+    postcode?: string;
+    city?: string;
+  };
+  manualAddressEntryTexts?: {
+    preText?: string;
+    cta?: string;
+  };
 }) => {
   const [manualAddressEntry, setManualAddressEntry] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -216,7 +230,9 @@ const AutoCompleteAddress = ({
               id="autocomplete"
               data-cy="autocomplete"
               type="text"
-              placeholder="Search for address"
+              placeholder={
+                placeholders?.manualAddressEntry || 'Search for address'
+              }
               ref={autocompleteElement}
             />
             {hasLoadedGoogleAPI === false && (
@@ -232,7 +248,7 @@ const AutoCompleteAddress = ({
                 className="w100"
                 data-cy="autocomplete"
                 type="text"
-                placeholder="Street"
+                placeholder={placeholders?.street || 'Street'}
                 value={address?.street || ''}
                 onChange={(e) => {
                   const newAddress = {
@@ -247,7 +263,7 @@ const AutoCompleteAddress = ({
               <Input
                 className={`wmx2 ${styles['house-number-input']}`}
                 data-cy="autocomplete-house-number"
-                placeholder="House Number"
+                placeholder={placeholders?.houseNumber || 'House Number'}
                 value={address?.houseNumber || ''}
                 onChange={(e) => {
                   const newAddress = {
@@ -263,7 +279,10 @@ const AutoCompleteAddress = ({
             <Input
               className="mt16"
               data-cy="autocomplete-additional-info"
-              placeholder="Additional information (C/O, appartment…)"
+              placeholder={
+                placeholders?.additionalInformation ||
+                'Additional information (C/O, apartment, …)'
+              }
               value={address?.additionalInformation || ''}
               onChange={(e) => {
                 const newAddress = {
@@ -278,7 +297,7 @@ const AutoCompleteAddress = ({
               <Input
                 className="w100"
                 data-cy="autocomplete-postcode"
-                placeholder="Postcode"
+                placeholder={placeholders?.postcode || 'Postcode'}
                 value={address?.postcode || ''}
                 onChange={(e) => {
                   const newAddress = {
@@ -293,7 +312,7 @@ const AutoCompleteAddress = ({
               <Input
                 className="w100"
                 data-cy="autocomplete-city"
-                placeholder="City"
+                placeholder={placeholders?.city || 'City'}
                 value={address?.city || ''}
                 onChange={(e) => {
                   const newAddress = {
@@ -311,12 +330,12 @@ const AutoCompleteAddress = ({
       </div>
       {manualAddressEntry === false && (
         <div className="p-p mt8">
-          Or{' '}
+          {manualAddressEntryTexts?.preText || 'Or '}
           <span
             className="p-a fw-bold c-pointer"
             onClick={handleEnterAddressManually}
           >
-            Enter address manually
+            {manualAddressEntryTexts?.cta || 'Enter address manually'}
           </span>
         </div>
       )}

--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -227,7 +227,7 @@ const AutoCompleteAddress = ({
           </div>
         ) : (
           <>
-            <div className={`d-flex ${styles['input-line']}`}>
+            <div className={`d-flex c-gap16 ${styles['input-line']}`}>
               <Input
                 className="w100"
                 data-cy="autocomplete"
@@ -274,7 +274,7 @@ const AutoCompleteAddress = ({
                 setAddress(newAddress);
               }}
             />
-            <div className={`d-flex mt16 ${styles['input-line']}`}>
+            <div className={`d-flex mt16 c-gap16 ${styles['input-line']}`}>
               <Input
                 className="w100"
                 data-cy="autocomplete-postcode"

--- a/src/lib/components/autocompleteAddress/style.module.scss
+++ b/src/lib/components/autocompleteAddress/style.module.scss
@@ -2,12 +2,6 @@
 @use "../../scss/public/colors" as *;
 
 .input-line {
-  margin-left: -16px;
-
-  > * {
-    margin-left: 16px;
-  }
-
   @include p-size-mobile {
     flex-direction: column;
 

--- a/src/lib/components/dateSelector/index.stories.mdx
+++ b/src/lib/components/dateSelector/index.stories.mdx
@@ -66,11 +66,15 @@ export const DateSelectorWithCalendarStory = () => {
 | attribute      | unit                                               | description                                                       | default value | required |
 | -------------- | -------------------------------------------------- | ----------------------------------------------------------------- | ------------- | -------- |
 | placeholders   | `{ day?: string; month: string?; year?: string; }` | Placeholder text                                                  | undefined     | false    |
-| locale         | string                                             | Locale string                                                     | 'en'          | false    |
+| locale         | supportedDayJSLocales                              | 'en' or 'de'                                                      | 'en'          | false    |
 | firstDayOfWeek | number                                             | Index of the first day of the week (0 = Sunday, 1 = Monday, etc.) | 0             | false    |
 
 The `locale` and `firstDayOfWeek` properties are used to localize the calendar of the `DateSelector`, whereas
 the `placeholders` object can be used to change the text of the different dropdowns.
+
+Currently, only the locales 'en' and 'de' are supported - additional languages can be added in the future by importing them like
+`import 'dayjs/locale/ko';`
+and adding a corresponding entry in the exported `supportedDayJSLocales` type.
 
 export const DateSelectorWithCalendarLocalizedStory = () => {
   const [date, setDate] = useState('');

--- a/src/lib/components/dateSelector/index.stories.mdx
+++ b/src/lib/components/dateSelector/index.stories.mdx
@@ -60,3 +60,40 @@ export const DateSelectorWithCalendarStory = () => {
 };
 
 <DateSelectorWithCalendarStory />
+
+### Localization
+
+| attribute      | unit                                               | description                                                       | default value | required |
+| -------------- | -------------------------------------------------- | ----------------------------------------------------------------- | ------------- | -------- |
+| placeholders   | `{ day?: string; month: string?; year?: string; }` | Placeholder text                                                  | undefined     | false    |
+| locale         | string                                             | Locale string                                                     | 'en'          | false    |
+| firstDayOfWeek | number                                             | Index of the first day of the week (0 = Sunday, 1 = Monday, etc.) | 0             | false    |
+
+The `locale` and `firstDayOfWeek` properties are used to localize the calendar of the `DateSelector`, whereas
+the `placeholders` object can be used to change the text of the different dropdowns.
+
+export const DateSelectorWithCalendarLocalizedStory = () => {
+  const [date, setDate] = useState('');
+  return (
+    <div style={{ paddingBottom: '120px' }}>
+      <DateSelector
+        value={date}
+        className="mt24"
+        yearBoundaries={{ min: 2020, max: 2022 }}
+        onChange={(date) => {
+          setDate(date);
+        }}
+        displayCalendar={true}
+        placeholders={{
+          day: 'Tag',
+          month: 'Monat',
+          year: 'Jahr',
+        }}
+        locale="de"
+        firstDayOfWeek={1}
+      />
+    </div>
+  );
+};
+
+<DateSelectorWithCalendarLocalizedStory />

--- a/src/lib/components/dateSelector/index.stories.mdx
+++ b/src/lib/components/dateSelector/index.stories.mdx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
 import DateSelector from '.';
+import de from 'dayjs/locale/de';
 
 <Meta title="JSX/Date selector" component={DateSelector} />
 
@@ -63,18 +64,20 @@ export const DateSelectorWithCalendarStory = () => {
 
 ### Localization
 
-| attribute      | unit                                               | description                                                       | default value | required |
-| -------------- | -------------------------------------------------- | ----------------------------------------------------------------- | ------------- | -------- |
-| placeholders   | `{ day?: string; month: string?; year?: string; }` | Placeholder text                                                  | undefined     | false    |
-| locale         | supportedDayJSLocales                              | 'en' or 'de'                                                      | 'en'          | false    |
-| firstDayOfWeek | number                                             | Index of the first day of the week (0 = Sunday, 1 = Monday, etc.) | 0             | false    |
+| attribute      | unit                                               | description                                                                             | default value | required |
+| -------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------- | -------- |
+| placeholders   | `{ day?: string; month: string?; year?: string; }` | Placeholder text                                                                        | undefined     | false    |
+| dayjsLocale    | `ILocale`                                          | Imported [Day.js locale Object](https://day.js.org/docs/en/customization/customization) | undefined     | false    |
+| firstDayOfWeek | number                                             | Index of the first day of the week (0 = Sunday, 1 = Monday, etc.)                       | 0             | false    |
 
-The `locale` and `firstDayOfWeek` properties are used to localize the calendar of the `DateSelector`, whereas
-the `placeholders` object can be used to change the text of the different dropdowns.
+The `dayjsLocale` and `firstDayOfWeek` properties are used to localize the calendar of the `DateSelector`, whereas
+the `placeholders` object can be used to change the text of the different dropdowns. If no `dayjsLocale` is supplied, the default locale 'en' will be used for the DateSelector.
 
-Currently, only the locales 'en' and 'de' are supported - additional languages can be added in the future by importing them like
-`import 'dayjs/locale/ko';`
-and adding a corresponding entry in the exported `supportedDayJSLocales` type.
+Additional locales can be imported from dayjs like
+`import de from 'dayjs/locale/de';` and then passed on to the component:
+`<DateSelector ... dayjsLocale={de} />`
+
+[List of all supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale)
 
 export const DateSelectorWithCalendarLocalizedStory = () => {
   const [date, setDate] = useState('');
@@ -93,7 +96,7 @@ export const DateSelectorWithCalendarLocalizedStory = () => {
           month: 'Monat',
           year: 'Jahr',
         }}
-        locale="de"
+        dayjsLocale={de}
         firstDayOfWeek={1}
       />
     </div>

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import 'dayjs/locale/de';
-import 'dayjs/locale/bs';
 
 import localeData from 'dayjs/plugin/localeData';
 import { CalendarDate } from '@popsure/public-models';
@@ -14,6 +13,8 @@ import {
 import styles from './style.module.scss';
 import './datepicker.scss';
 import calendarIcon from './icons/calendar.svg';
+
+export type supportedDayJSLocales = 'en' | 'de';
 
 dayjs.extend(localeData);
 const COLLECTABLE_DATE_FORMAT = 'YYYY-MM-DD';
@@ -70,7 +71,7 @@ const DateSelector = ({
     month?: string;
     year?: string;
   };
-  locale?: string;
+  locale?: supportedDayJSLocales;
   firstDayOfWeek?: number;
 }) => {
   const calendarDateValue = value ? isoStringtoCalendarDate(value) : undefined;

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
+// Import 'de' so that it can be used locale
 import 'dayjs/locale/de';
 
 import localeData from 'dayjs/plugin/localeData';
@@ -14,6 +15,7 @@ import styles from './style.module.scss';
 import './datepicker.scss';
 import calendarIcon from './icons/calendar.svg';
 
+// Union of all dayjs locales the component supports ('en' by default + all other imported locales)
 export type supportedDayJSLocales = 'en' | 'de';
 
 dayjs.extend(localeData);

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -1,5 +1,8 @@
 import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
+import 'dayjs/locale/de';
+import 'dayjs/locale/bs';
+
 import localeData from 'dayjs/plugin/localeData';
 import { CalendarDate } from '@popsure/public-models';
 import DayPicker from 'react-day-picker';
@@ -13,7 +16,6 @@ import './datepicker.scss';
 import calendarIcon from './icons/calendar.svg';
 
 dayjs.extend(localeData);
-
 const COLLECTABLE_DATE_FORMAT = 'YYYY-MM-DD';
 
 /*
@@ -55,11 +57,21 @@ const DateSelector = ({
   onChange,
   yearBoundaries,
   displayCalendar,
+  placeholders,
+  locale = 'en',
+  firstDayOfWeek = 0,
 }: {
   value?: string;
   onChange: (date: string) => void;
   yearBoundaries: { min: number; max: number };
   displayCalendar?: boolean;
+  placeholders?: {
+    day?: string;
+    month?: string;
+    year?: string;
+  };
+  locale?: string;
+  firstDayOfWeek?: number;
 }) => {
   const calendarDateValue = value ? isoStringtoCalendarDate(value) : undefined;
   const daysInSelectedDate = calendarDateValue
@@ -68,9 +80,17 @@ const DateSelector = ({
         year: calendarDateValue.year,
       })
     : 31;
+
+  const localeDate = dayjs().locale(locale).localeData();
+
+  const localizedWeekdays = localeDate.weekdays();
+  const localizedWeekdaysShort = localeDate.weekdaysShort();
+  const localizedMonths = localeDate.months();
+  const localizedMonthsShort = localeDate.monthsShort();
+
   const availableDays = fillArray(1, daysInSelectedDate);
   const availableYears = fillArray(yearBoundaries.max, yearBoundaries.min);
-  const availableMonths = dayjs.monthsShort();
+  const availableMonths = localizedMonthsShort;
 
   const [date, setDate] = useState<Partial<CalendarDate>>(
     calendarDateValue ?? {}
@@ -154,7 +174,7 @@ const DateSelector = ({
             }}
           >
             <option value="" disabled={true}>
-              Day
+              {placeholders?.day || 'Day'}
             </option>
             {availableDays.map((day) => (
               <option key={day} value={day}>
@@ -174,7 +194,7 @@ const DateSelector = ({
             }}
           >
             <option value="" disabled={true}>
-              Month
+              {placeholders?.month || 'Month'}
             </option>
             {availableMonths.map((month, i) => (
               <option key={month} value={i + 1}>
@@ -195,7 +215,7 @@ const DateSelector = ({
           }}
         >
           <option value="" disabled={true}>
-            Year
+            {placeholders?.year || 'Year'}
           </option>
           {availableYears.map((year) => (
             <option key={year} value={year}>
@@ -236,6 +256,11 @@ const DateSelector = ({
                 before: dateCalendarFromMonth,
                 after: dateCalendarToMonth,
               }}
+              firstDayOfWeek={firstDayOfWeek}
+              locale={locale}
+              months={localizedMonths}
+              weekdaysLong={localizedWeekdays}
+              weekdaysShort={localizedWeekdaysShort}
             />
           )}
         </div>

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
-// Import 'de' so that it can be used locale
-import 'dayjs/locale/de';
 
 import localeData from 'dayjs/plugin/localeData';
 import { CalendarDate } from '@popsure/public-models';
@@ -14,9 +12,6 @@ import {
 import styles from './style.module.scss';
 import './datepicker.scss';
 import calendarIcon from './icons/calendar.svg';
-
-// Union of all dayjs locales the component supports ('en' by default + all other imported locales)
-export type supportedDayJSLocales = 'en' | 'de';
 
 dayjs.extend(localeData);
 const COLLECTABLE_DATE_FORMAT = 'YYYY-MM-DD';
@@ -61,7 +56,7 @@ const DateSelector = ({
   yearBoundaries,
   displayCalendar,
   placeholders,
-  locale = 'en',
+  dayjsLocale,
   firstDayOfWeek = 0,
 }: {
   value?: string;
@@ -73,7 +68,7 @@ const DateSelector = ({
     month?: string;
     year?: string;
   };
-  locale?: supportedDayJSLocales;
+  dayjsLocale?: ILocale;
   firstDayOfWeek?: number;
 }) => {
   const calendarDateValue = value ? isoStringtoCalendarDate(value) : undefined;
@@ -84,7 +79,9 @@ const DateSelector = ({
       })
     : 31;
 
-  const localeDate = dayjs().locale(locale).localeData();
+  const localeDate = dayjsLocale
+    ? dayjs().locale(dayjsLocale).localeData()
+    : dayjs().locale('en').localeData();
 
   const localizedWeekdays = localeDate.weekdays();
   const localizedWeekdaysShort = localeDate.weekdaysShort();
@@ -260,7 +257,7 @@ const DateSelector = ({
                 after: dateCalendarToMonth,
               }}
               firstDayOfWeek={firstDayOfWeek}
-              locale={locale}
+              locale={dayjsLocale?.name || 'en'}
               months={localizedMonths}
               weekdaysLong={localizedWeekdays}
               weekdaysShort={localizedWeekdaysShort}


### PR DESCRIPTION
### What this PR does

1.  Fixes the uneven widths for the `AutocompleteAddress` on mobile
**BEFORE:**
<img width="484" alt="image" src="https://user-images.githubusercontent.com/13664983/177928234-9018ddee-eb2e-4e36-83d7-2a2541c8bbaf.png">

**AFTER:**
<img width="501" alt="image" src="https://user-images.githubusercontent.com/13664983/177928298-af74f6d2-92c1-4c25-af95-120fd102ddaf.png">

2. Exposes placeholder text and other props to make `AutocompleteAddress` and `DateSelector` components localizable

<img width="673" alt="image" src="https://user-images.githubusercontent.com/13664983/177928613-af7b46c4-56cc-46cb-9967-6313aa574c39.png">
<img width="753" alt="image" src="https://user-images.githubusercontent.com/13664983/177928667-04cb7190-a5fc-492d-8eb4-f60de1fa0ed2.png">


3. Updates the docs

### Why is this needed?

Solves:  
STO-4281  
STO-3809  

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
