### PR TITLE
feat: [STO-3198] update grey color variables

### DIFF
--- a/src/lib/scss/public/colors/default.scss
+++ b/src/lib/scss/public/colors/default.scss
@@ -41,8 +41,9 @@ $ds-pink-900: #700024;
 
 $ds-grey-100: #fafaff;
 $ds-grey-200: #f5f5fa;
-$ds-grey-300: #d2d2d8;
-$ds-grey-500: #b4b4ba;
+$ds-grey-300: #ededf2;
+$ds-grey-400: #d2d2d8;
+$ds-grey-500: #848490;
 $ds-grey-600: #696970;
 $ds-grey-700: #4c4c53;
 $ds-grey-900: #26262e;
@@ -98,6 +99,7 @@ $colors: (
   'grey-100': $ds-grey-100,
   'grey-200': $ds-grey-200,
   'grey-300': $ds-grey-300,
+  'grey-400': $ds-grey-400,
   'grey-500': $ds-grey-500,
   'grey-600': $ds-grey-600,
   'grey-700': $ds-grey-700,

--- a/src/lib/scss/public/demo.tsx
+++ b/src/lib/scss/public/demo.tsx
@@ -159,12 +159,17 @@ const colors = [
   {
     name: 'Grey 300',
     code: 'grey-300',
+    hex: '#ededf2',
+  },
+    {
+    name: 'Grey 400',
+    code: 'grey-400',
     hex: '#d2d2d8',
   },
   {
     name: 'Grey 500',
     code: 'grey-500',
-    hex: '#b4b4ba',
+    hex: '#848490',
   },
   {
     name: 'Grey 600',


### PR DESCRIPTION
### What this PR does

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/26237320/178697008-a1b09add-4a6a-4b44-976d-8574ff3ede5a.png">

1. Rename the current Grey 300 to Grey 400
2. Create a new Grey 300 at #EDEDF2
3. Update Grey-500 to #848490

### Why is this needed?

Solves:  
STO-3198

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
