### PR TITLE
feat: [STO-3198] update neutral colors

### DIFF
--- a/src/lib/components/dateSelector/datepicker.scss
+++ b/src/lib/components/dateSelector/datepicker.scss
@@ -391,7 +391,7 @@
 }
 
 .DayPicker-Day--outside {
-  color: $ds-grey-300;
+  color: $ds-grey-400;
   cursor: pointer;
 
   &:hover {
@@ -400,7 +400,7 @@
 }
 
 .DayPicker-Day--disabled {
-  color: $ds-grey-300;
+  color: $ds-grey-400;
   background-color: transparent;
   pointer-events: none;
 }

--- a/src/lib/components/input/index.stories.mdx
+++ b/src/lib/components/input/index.stories.mdx
@@ -34,6 +34,8 @@ You are looking at the JSX definition of the Input component, if you want you ca
       value="jane.doe@feather-insurance.com"
       placeholder="Email"
     />
+    <h4 className="p-h4 mt24">Disabled</h4>
+    <Input className="wmx5 mt8" placeholder="Email" disabled />
     <h4 className="p-h4 mt24">Error</h4>
     <Input
       className="wmx5 mt8"
@@ -50,6 +52,8 @@ You are looking at the JSX definition of the Input component, if you want you ca
     <Input className="wmx5 mt8" placeholder="amount" prefix="€" />
     <h4 className="p-h4 mt24">Filled with placeholder</h4>
     <Input className="wmx5 mt8" placeholder="amount" value="100" prefix="€" />
+    <h4 className="p-h4 mt24">Disabled</h4>
+    <Input className="wmx5 mt8" placeholder="amount" disabled prefix="€" />
     <h4 className="p-h4 mt24">Error</h4>
     <Input
       className="wmx5 mt8"

--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -10,7 +10,7 @@
 
   transform: translateY(-50%);
 
-  color: var(--ds-grey-300);
+  color: var(--ds-grey-400);
 
   transition: 0.3s top;
 
@@ -78,7 +78,7 @@
   transform: translateY(-50%);
   transition: 0.3s ease all;
 
-  color: var(--ds-grey-300);
+  color: var(--ds-grey-400);
 
   &--with-prefix {
     left: 32px;

--- a/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
+++ b/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
@@ -7,7 +7,7 @@
 
   padding: 8px 16px;
 
-  border: 1px solid $ds-grey-300;
+  border: 1px solid $ds-grey-400;
   border-radius: 8px;
   background-color: white;
 

--- a/src/lib/components/signaturePad/style.module.scss
+++ b/src/lib/components/signaturePad/style.module.scss
@@ -19,7 +19,7 @@
   left: 72px;
   bottom: 32px;
 
-  background-color: var(--ds-grey-300);
+  background-color: var(--ds-grey-400);
 
   border-radius: 1px;
 }

--- a/src/lib/scss/private/base/style.module.scss
+++ b/src/lib/scss/private/base/style.module.scss
@@ -35,7 +35,7 @@
     & > *:nth-child(2) {
       border-top-right-radius: 8px;
       border-bottom-right-radius: 8px;
-      background-color: colors.$ds-grey-300;
+      background-color: colors.$ds-grey-400;
       width: 100%;
     }
   }

--- a/src/lib/scss/private/components/_badge.scss
+++ b/src/lib/scss/private/components/_badge.scss
@@ -26,7 +26,7 @@
 
   &--inactive {
     @extend .p-badge;
-    background-color: $ds-grey-300;
+    background-color: $ds-grey-400;
   }
 
   &--danger {

--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -171,7 +171,7 @@
       color: $ds-grey-500;
       background-color: transparent;
 
-      border: 1px dashed $ds-grey-300;
+      border: 1px dashed $ds-grey-400;
 
       &:hover {
         color: $ds-grey-600;
@@ -180,7 +180,7 @@
 
       &[disabled] {
         color: $ds-grey-500;
-        border-color: $ds-grey-300;
+        border-color: $ds-grey-400;
         opacity: 0.5;
       }
 

--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -27,7 +27,7 @@
 
   &:disabled {
     background-color: $ds-grey-300;
-    border-color: $ds-grey-500;
+    border: none;
   }
 
   &:focus {

--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -14,7 +14,7 @@
   width: 100%;
 
   border-radius: 8px;
-  border: 1px solid $ds-grey-300;
+  border: 1px solid $ds-grey-400;
   background-color: white;
 
   color: $ds-grey-900;
@@ -81,7 +81,7 @@
       height: 16px;
       min-height: 16px;
 
-      border: 1px solid $ds-grey-300;
+      border: 1px solid $ds-grey-400;
       border-radius: 50%;
 
       background-color: white;
@@ -113,7 +113,7 @@
       height: 16px;
       min-height: 16px;
 
-      border: 1px solid $ds-grey-300;
+      border: 1px solid $ds-grey-400;
       border-radius: 4px;
 
       background-color: white;
@@ -163,7 +163,7 @@
     padding-left: 16px;
 
     border-radius: 8px;
-    border: 1px solid $ds-grey-300;
+    border: 1px solid $ds-grey-400;
     background-color: white;
 
     &:hover {
@@ -201,7 +201,7 @@ input:checked[type='checkbox'] + .p-label--bordered {
   height: 48px;
 
   border-radius: 8px;
-  border: 1px solid $ds-grey-300;
+  border: 1px solid $ds-grey-400;
   background-color: white;
 
   font-family: inherit;

--- a/src/lib/scss/public/colors/default.scss
+++ b/src/lib/scss/public/colors/default.scss
@@ -41,8 +41,9 @@ $ds-pink-900: #700024;
 
 $ds-grey-100: #fafaff;
 $ds-grey-200: #f5f5fa;
-$ds-grey-300: #d2d2d8;
-$ds-grey-500: #b4b4ba;
+$ds-grey-300: #ededf2;
+$ds-grey-400: #d2d2d8;
+$ds-grey-500: #848490;
 $ds-grey-600: #696970;
 $ds-grey-700: #4c4c53;
 $ds-grey-900: #26262e;
@@ -98,6 +99,7 @@ $colors: (
   'grey-100': $ds-grey-100,
   'grey-200': $ds-grey-200,
   'grey-300': $ds-grey-300,
+  'grey-400': $ds-grey-400,
   'grey-500': $ds-grey-500,
   'grey-600': $ds-grey-600,
   'grey-700': $ds-grey-700,

--- a/src/lib/scss/third-party/_google_places.scss
+++ b/src/lib/scss/third-party/_google_places.scss
@@ -47,7 +47,7 @@
 
 .pac-container {
   background-color: white;
-  border: 1px solid var(--ds-grey-300);
+  border: 1px solid var(--ds-grey-400);
   box-shadow: none;
   border-radius: 8px;
   margin-top: 8px;


### PR DESCRIPTION
### What this PR does

1. Rename the current Grey 300 to Grey 400

2. Create a new Grey 300 at #EDEDF2

3. Update Grey-500 to #848490

TableRowHeader (@app)
![image](https://user-images.githubusercontent.com/26237320/179478801-79658d33-6593-43bc-b16a-50eada1d1b0c.png)

Download complete state
![image](https://user-images.githubusercontent.com/26237320/179479709-0187d9ca-04a3-4b5b-8578-87fa7d8b1b30.png)

MultiDropzone
![image](https://user-images.githubusercontent.com/26237320/179480026-f09d35ad-483c-4cf5-8846-d12ab666908d.png)

SegmentedControl with subtitle
![image](https://user-images.githubusercontent.com/26237320/179480287-00e2ec9c-f228-4d4b-ab50-0534b19975cf.png)

Signaturepad
![image](https://user-images.githubusercontent.com/26237320/179480587-5c63174f-a6b2-4915-bc6a-c33a97ae8261.png)

Outline grey button
![image](https://user-images.githubusercontent.com/26237320/179481087-537ba85a-d0a1-4ea0-b3d2-4111582db4f4.png)

Outline grey button (hovered)
![image](https://user-images.githubusercontent.com/26237320/179481134-1dfbbdb6-bcf7-4518-9bae-6d1276226d00.png)

`grey-500` on Disabled Input will be removed for STO-3198


### Why is this needed?

Solves:  
STO-3198  

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
