### PR TITLE
Yejin/sto 3198 update ds neutral colors

### DIFF
--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -10,7 +10,7 @@
 
   transform: translateY(-50%);
 
-  color: var(--ds-grey-400);
+  color: var(--ds-grey-500);
 
   transition: 0.3s top;
 

--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -78,7 +78,7 @@
   transform: translateY(-50%);
   transition: 0.3s ease all;
 
-  color: var(--ds-grey-400);
+  color: var(--ds-grey-500);
 
   &--with-prefix {
     left: 32px;


### PR DESCRIPTION
### What this PR does

Updated input prefix and placeholder color to grey-500

![image](https://user-images.githubusercontent.com/26237320/179984026-47f23e4b-9557-41b2-b613-68f9f43d51f5.png)


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
