### PR TITLE
fix: [STO-3197] change input prefix color to grey-600 when it's disabled

### DIFF
--- a/src/lib/components/input/index.tsx
+++ b/src/lib/components/input/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classnames from 'classnames';
 
 import styles from './style.module.scss';
 
@@ -11,7 +12,7 @@ export type InputProps = {
 
 export default React.forwardRef(
   (
-    { className, placeholder, prefix, error, ...props }: InputProps,
+    { className, placeholder, prefix, error, disabled, ...props }: InputProps,
     ref?: React.ForwardedRef<HTMLInputElement>
   ) => (
     <div className={`${styles.container} ${className ?? ''}`}>
@@ -19,27 +20,34 @@ export default React.forwardRef(
         data-testid="ds-input-input"
         type="text"
         ref={ref}
-        className={`${error ? 'p-input--error' : 'p-input'} ${
-          placeholder && placeholder?.length > 0
+        className={classnames(
+          error ? 'p-input--error' : 'p-input',
+          placeholder && placeholder.length > 0
             ? styles.input
-            : styles['input--no-placeholder']
-        } ${prefix ? styles['input--with-prefix'] : ''}`}
+            : styles['input--no-placeholder'],
+          { [styles['input--with-prefix']]: prefix }
+        )}
         placeholder=" "
+        disabled={disabled}
         {...props}
       />
       {prefix && (
         <span
-          className={`${styles.prefix} ${
-            error ? styles['prefix--with-error'] : ''
-          }`}
+          className={classnames(
+            styles.prefix,
+            { [styles['prefix--with-error']]: error },
+            { [styles['prefix--disabled']]: disabled }
+          )}
         >
           {prefix}
         </span>
       )}
       <span
-        className={`${styles.placeholder} ${
-          prefix ? styles['placeholder--with-prefix'] : ''
-        } ${error ? styles['placeholder--with-error'] : ''}`}
+        className={classnames(
+          styles.placeholder,
+          { [styles['placeholder--with-prefix']]: prefix },
+          { [styles['placeholder--with-error']]: error }
+        )}
       >
         {placeholder}
       </span>

--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -17,6 +17,10 @@
   &--with-error {
     color: var(--ds-red-500);
   }
+
+  &--disabled {
+    color: var(--ds-grey-600);
+  }
 }
 
 .input:not(:placeholder-shown) ~ .placeholder,


### PR DESCRIPTION
### What this PR does

Fix input prefix color on disabled state to grey-600

<img width="453" alt="image" src="https://user-images.githubusercontent.com/26237320/180237147-0f37fc23-46cf-4ed1-a199-dd4c2d4b9e97.png">


### Why is this needed?

Solves:
STO-3197

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
