### PR TITLE
feat: [STO-3198] change grey-500 color to #91919C

### DIFF
--- a/src/lib/scss/public/colors/default.scss
+++ b/src/lib/scss/public/colors/default.scss
@@ -43,7 +43,7 @@ $ds-grey-100: #fafaff;
 $ds-grey-200: #f5f5fa;
 $ds-grey-300: #ededf2;
 $ds-grey-400: #d2d2d8;
-$ds-grey-500: #848490;
+$ds-grey-500: #91919c;
 $ds-grey-600: #696970;
 $ds-grey-700: #4c4c53;
 $ds-grey-900: #26262e;


### PR DESCRIPTION
### What this PR does

Change `grey-500` value to #91919C after design review

### Why is this needed?

Solves:  
STO-3198

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
