### PR TITLE
[STO-4342] Refactor Multidropzone to collect multiple files at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "hastscript": "^7.0.2",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
+    "react-animate-height": "^3.0.4",
     "react-autosuggest": "^10.1.0",
     "react-day-picker": "^7.4.10",
     "react-dropzone": "^11.3.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-animate-height": "^3.0.4",
     "react-autosuggest": "^10.1.0",
     "react-day-picker": "^7.4.10",
-    "react-dropzone": "^11.3.2",
+    "react-dropzone": "^14.2.2",
     "react-markdown": "^8.0.3",
     "react-scroll-sync": "^0.9.0",
     "remark-directive": "^2.0.1",

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -40,7 +40,7 @@ export interface UploadedFile {
 }
 
 interface Props {
-  onFileSelect: (file: File) => void;
+  onFileSelect: (files: File[]) => void;
   uploadedFiles: UploadedFile[];
   uploading: boolean;
   onRemoveFile: (id: string) => void;
@@ -55,8 +55,8 @@ export default ({
   isCondensed = false,
 }: Props) => {
   const onDrop = useCallback(
-    (acceptedFiles) => {
-      onFileSelect(acceptedFiles[0]);
+    (acceptedFiles: File[]) => {
+      onFileSelect(acceptedFiles);
     },
     [onFileSelect]
   );

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -60,10 +60,14 @@ export default ({
 
   const onDrop = useCallback(
     (acceptedFiles: File[], filesRejected: FileRejection[]) => {
-      if (filesRejected.length === 0) {
-        onFileSelect(acceptedFiles);
+      setError('');
+
+      if (filesRejected.length > 0) {
+        setError(filesRejected[0].errors[0].message);
+        return;
       }
-      setError(filesRejected[0].errors[0].message);
+
+      onFileSelect(acceptedFiles);
     },
     [onFileSelect]
   );

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { useDropzone } from 'react-dropzone';
+import { useCallback, useState } from 'react';
+import { useDropzone, FileRejection } from 'react-dropzone';
 import classnames from 'classnames';
-
+import AnimateHeight from 'react-animate-height';
 import styles from './style.module.scss';
 import icons from './icons/index'; // TODO: inline all of the svgs
 import UploadFileCell from './UploadFileCell';
@@ -45,6 +45,7 @@ interface Props {
   uploading: boolean;
   onRemoveFile: (id: string) => void;
   isCondensed?: boolean;
+  maxFiles?: number;
 }
 
 export default ({
@@ -53,15 +54,21 @@ export default ({
   uploading,
   onRemoveFile,
   isCondensed = false,
+  maxFiles = 0,
 }: Props) => {
+  const [error, setError] = useState('');
+
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      onFileSelect(acceptedFiles);
+    (acceptedFiles: File[], filesRejected: FileRejection[]) => {
+      if (filesRejected.length === 0) {
+        onFileSelect(acceptedFiles);
+      }
+      setError(filesRejected[0].errors[0].message);
     },
     [onFileSelect]
   );
 
-  const { getRootProps, getInputProps } = useDropzone({ onDrop });
+  const { getRootProps, getInputProps } = useDropzone({ onDrop, maxFiles });
 
   return (
     <div className={styles.container}>
@@ -87,6 +94,9 @@ export default ({
         </div>
         <div className="p-p--small tc-grey-500">Supports JPEG, PNG, PDF</div>
       </div>
+      <AnimateHeight duration={300} height={error ? 'auto' : 0}>
+        <p className="tc-red-500 p-p--small">{error}</p>
+      </AnimateHeight>
       {uploadedFiles.length > 0 && (
         <div className="w100 mt16">
           {uploadedFiles.map((file) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12237,6 +12237,13 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+react-animate-height@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-animate-height/-/react-animate-height-3.0.4.tgz#80c9cc25e8569709ad1c626b968dbe5108d0ce46"
+  integrity sha512-k+mBS8yCzpFp+7BdrHsL5bXd6CO/2bYO2SvRGKfxK+Ss3nzplAJLlgnd6Zhcxe/avdpy/CgcziicFj7pIHgG5g==
+  dependencies:
+    classnames "^2.3.1"
+
 react-app-polyfill@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz#a0bea50f078b8a082970a9d853dc34b6dcc6a3cf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3744,9 +3744,9 @@ atob@^2.1.2:
   resolved "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-attr-accept@^2.2.1:
+attr-accept@^2.2.2:
   version "2.2.2"
-  resolved "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
 autoprefixer@^9.6.1, autoprefixer@^9.8.6:
@@ -6855,12 +6855,12 @@ file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-file-selector@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz#7b98286f9dbb9925f420130ea5ed0a69238d4d80"
-  integrity sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==
+file-selector@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.6.0.tgz#fa0a8d9007b829504db4d07dd4de0310b65287dc"
+  integrity sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==
   dependencies:
-    tslib "^2.0.3"
+    tslib "^2.4.0"
 
 file-system-cache@^1.0.5:
   version "1.0.5"
@@ -12040,6 +12040,15 @@ prop-types@^15.0.0, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1, 
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"
   resolved "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
@@ -12358,14 +12367,14 @@ react-draggable@^4.4.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-dropzone@^11.3.2:
-  version "11.3.2"
-  resolved "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.3.2.tgz#2efb6af800a4779a9daa1e7ba1f8d51d0ab862d7"
-  integrity sha512-Z0l/YHcrNK1r85o6RT77Z5XgTARmlZZGfEKBl3tqTXL9fZNQDuIdRx/J0QjvR60X+yYu26dnHeaG2pWU+1HHvw==
+react-dropzone@^14.2.2:
+  version "14.2.2"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.2.tgz#a75a0676055fe9e2cb78578df4dedb4c42b54f98"
+  integrity sha512-5oyGN/B5rNhop2ggUnxztXBQ6q6zii+OMEftPzsxAR2hhpVWz0nAV+3Ktxo2h5bZzdcCKrpd8bfWAVsveIBM+w==
   dependencies:
-    attr-accept "^2.2.1"
-    file-selector "^0.2.2"
-    prop-types "^15.7.2"
+    attr-accept "^2.2.2"
+    file-selector "^0.6.0"
+    prop-types "^15.8.1"
 
 react-element-to-jsx-string@^14.3.2:
   version "14.3.2"
@@ -12405,7 +12414,7 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -14505,6 +14514,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
### What this PR does

1. Refactors Multidropzone component to collect multiple files at once
2. Adds `maxFiles` prop to the component to give control of how many files can be uploaded
3. Adds a generic error display to the component when user tried to upload more files than allowed.

‼️ Note: This component should be refactored again to unify all errors. Currently, file size and invalid file type errors are handled on BE and therefore omitted from defining the error inside this component.

### Why is this needed?

We want to allow customers to upload multiple files at once

Solves:  
STO-4342

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
