### PR TITLE
feat: add a default color variant to badge component

### DIFF
--- a/src/lib/scss/private/components/_badge.scss
+++ b/src/lib/scss/private/components/_badge.scss
@@ -38,4 +38,9 @@
     @extend .p-badge;
     background-color: $ds-blue-300;
   }
+
+  &--default {
+    @extend .p-badge;
+    background-color: $ds-purple-100;
+  }
 }

--- a/src/lib/scss/private/components/badge.stories.mdx
+++ b/src/lib/scss/private/components/badge.stories.mdx
@@ -35,3 +35,9 @@ Badges are label used for flags.
 <Preview>
   <div className="p-badge--info">Info badge</div>
 </Preview>
+
+## Default
+
+<Preview>
+  <div className="p-badge--default">Default badge</div>
+</Preview>


### PR DESCRIPTION
### What this PR does

Added a purple color variant to badge component scss.
This update will be needed in website [ImageWithText slice PR](https://github.com/getPopsure/website/pull/763)

<img width="980" alt="image" src="https://user-images.githubusercontent.com/26237320/190190112-c45f0f7c-8c1e-42f3-832c-3c5dd16ebbef.png">


### Why is this needed?

It is a common use case of badge in website like below:

<img width="534" alt="image" src="https://user-images.githubusercontent.com/26237320/190189626-e5a67993-2411-4690-bb9a-8b527fb03b8a.png">


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
