### PR TITLE
Noticket date comp fix

### DIFF
--- a/src/lib/components/dateSelector/datepicker.scss
+++ b/src/lib/components/dateSelector/datepicker.scss
@@ -160,14 +160,8 @@
 }
 
 .DayPicker-Day {
-  display: table-cell;
-  padding: 0.5em;
-  border-radius: 50%;
-  vertical-align: middle;
-  text-align: center;
-  cursor: pointer;
-
-  font: normal 16px Lato;
+  min-width: 40px;
+  height: 40px;
 }
 
 .DayPicker-WeekNumber {

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import dayjs from 'dayjs';
 
 import localeData from 'dayjs/plugin/localeData';
@@ -156,6 +156,8 @@ const DateSelector = ({
     } else {
       setDate(newValue);
     }
+
+    setOpenCalendar(false);
   };
 
   return (

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 
 import localeData from 'dayjs/plugin/localeData';


### PR DESCRIPTION
### What this PR does

1. Fixes widths of dates on day picker
2. Closes day picker pop up when date is chosen on selector

### Why is this needed?

We want the date component to align with Figma designs

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
