### PR TITLE
feat(ComparisonTable): [NoTicket] Add support for JSX in labels

### DIFF
--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
@@ -25,20 +25,18 @@ export const AccordionItem = ({
   children,
   className = '',
   headerClassName = '',
-  iconSrc = '',
   isOpen,
   onOpen,
   onClose,
-  title,
+  label,
 }: {
   children: React.ReactNode | string;
   className?: string;
   headerClassName?: string;
-  iconSrc?: string;
   isOpen: boolean;
   onOpen: () => void;
   onClose: () => void;
-  title: string;
+  label: React.ReactNode;
 }) => {
   const handleClick = () => {
     if (!isOpen) {
@@ -56,8 +54,11 @@ export const AccordionItem = ({
         type="button"
       >
         <div className={`d-flex ai-center ${styles.iconAndTextContainer}`}>
-          {!!iconSrc && <img src={iconSrc} alt={`${title} icon`} />}
-          <h4 className="p-h4">{title}</h4>
+          {typeof label === 'string' ? (
+            <h4 className="p-h4">{label}</h4>
+          ) : (
+            <>{label}</>
+          )}
         </div>
         <ChevronSVG
           className={`${styles.chevron} ${!isOpen && styles.chevronClosed}`}

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -154,7 +154,7 @@ const ComparisonTable = <T extends { id: number }>(
                     {headerGroup.label && collapsibleSections ? (
                       <AccordionItem
                         className="mt8"
-                        title={String(headerGroup.label)}
+                        label={headerGroup.label}
                         headerClassName="p24 br8"
                         isOpen={selectedSection === String(headerGroup.label)}
                         onOpen={() =>


### PR DESCRIPTION
### What this PR does

This PR changes the `AccordionItem` subcomponent to accept JSX in addition to strings as a label and removes the separate `iconSrc` prop as it is no longer needed.

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/13664983/199207706-387279f8-f3a0-4063-8b4a-ade7f6ff1877.png">


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
