### PR TITLE
feat(MultiDropzone): [NoTicket] Add i18n capabilities

### DIFF
--- a/src/lib/components/multiDropzone/index.stories.mdx
+++ b/src/lib/components/multiDropzone/index.stories.mdx
@@ -110,3 +110,20 @@ MultiDropzone component allows upload of multiple documents / files.
     onRemoveFile={() => {}}
   />
 </Preview>
+
+### i18n support
+
+<Preview>
+  <MultiDropzone
+    uploadedFiles={[]}
+    onFileSelect={() => {}}
+    uploading={false}
+    onRemoveFile={() => {}}
+    textOverrides={{
+      instructionsText: 'Datei auswählen oder per Drag & Drop platzieren',
+      supportsText: 'Unterstützt werden JPEG, PNG, PDF',
+      currentlyUploadingText:
+        'Bitte warten während die Datei hochgeladen wird...',
+    }}
+  />
+</Preview>

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -46,6 +46,11 @@ interface Props {
   onRemoveFile: (id: string) => void;
   isCondensed?: boolean;
   maxFiles?: number;
+  textOverrides?: {
+    instructionsText?: string;
+    currentlyUploadingText?: string;
+    supportsText?: string;
+  };
 }
 
 export default ({
@@ -55,6 +60,7 @@ export default ({
   onRemoveFile,
   isCondensed = false,
   maxFiles = 0,
+  textOverrides,
 }: Props) => {
   const [error, setError] = useState('');
 
@@ -93,10 +99,13 @@ export default ({
         />
         <div className={`p-h4 mt8 ${isCondensed ? styles.textInline : ''}`}>
           {uploading
-            ? 'Please wait while uploading file...'
-            : 'Choose file or drag & drop'}
+            ? textOverrides?.currentlyUploadingText ||
+              'Please wait while uploading file...'
+            : textOverrides?.instructionsText || 'Choose file or drag & drop'}
         </div>
-        <div className="p-p--small tc-grey-500">Supports JPEG, PNG, PDF</div>
+        <div className="p-p--small tc-grey-500">
+          {textOverrides?.supportsText || 'Supports JPEG, PNG, PDF'}
+        </div>
       </div>
       <AnimateHeight duration={300} height={error ? 'auto' : 0}>
         <p className="tc-red-500 p-p--small">{error}</p>


### PR DESCRIPTION
### What this PR does

This PR adds i18n capabilities to the MultiDropzone component by exposing text override properties.
<img width="591" alt="image" src="https://user-images.githubusercontent.com/13664983/202705065-b5ee835d-7f0b-4147-a316-3990bb777351.png">

### Why is this needed?

To be able to localize the component.

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
