### PR TITLE
[NoTicket] Update Autosuggest component suggestion list width

### DIFF
--- a/src/lib/components/input/autoSuggestInput/style.module.scss
+++ b/src/lib/components/input/autoSuggestInput/style.module.scss
@@ -10,8 +10,6 @@
 }
 
 .suggestionsList {
-  position: absolute;
-
   z-index: 100;
   overflow: hidden;
   border-radius: 8px;


### PR DESCRIPTION
### What this PR does

Fixes Autosuggest suggestions list positioning

![Screen Shot 2022-11-28 at 15 50 41](https://user-images.githubusercontent.com/28936587/204307652-e829993b-0621-4d95-9254-733d5a039539.png)

### Why is this needed?

This fixes the width of the container

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
