### PR TITLE
fix(button): [STO-4942] add padding right to bordered input

### DIFF
--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -158,9 +158,7 @@
   &--bordered {
     align-items: center;
 
-    padding-top: 8px;
-    padding-bottom: 8px;
-    padding-left: 16px;
+    padding: 8px 16px;
 
     border-radius: 8px;
     border: 1px solid $ds-grey-400;


### PR DESCRIPTION
### What this PR does

Added padding right to `p-label--bordered`

As-is
<img width="915" alt="image" src="https://user-images.githubusercontent.com/26237320/208715510-793a2e91-3816-49d8-8362-c8cbb3cddc35.png">

To-be
<img width="921" alt="image" src="https://user-images.githubusercontent.com/26237320/208715443-8384e0b5-1c7d-4615-a668-1f24095c00ca.png">


### Why is this needed?

Long text that stretches the button needs a padding

Solves:  
[STO-4942](https://linear.app/feather-insurance/issue/STO-4942/the-buttons-in-calculator-need-to-accommodate-long-german-words)

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
