### PR TITLE
feat(input): [NoTicket] fine-tune label input styling

### DIFF
--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -95,7 +95,6 @@
 
 .label {
   display: inline-block;
-  margin-top: 8px;
   margin-bottom: 8px;
   color: var(--ds-grey-600);
 
@@ -106,6 +105,7 @@
   &--hidden {
     visibility: hidden;
     height: 0;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
### What this PR does

Remove unnecessary margins for the label in the Input component 

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
