### PR TITLE
 fix(input): [NoTicket] add stable id to input

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "react-scroll-sync": "^0.9.0",
     "remark-directive": "^2.0.1",
     "sass": "^1.35.1",
-    "signature_pad": "^3.0.0-beta.3",
-    "uuid": "^9.0.0"
+    "signature_pad": "^3.0.0-beta.3"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/src/lib/components/input/index.tsx
+++ b/src/lib/components/input/index.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import classnames from 'classnames';
-import { v4 as uuidv4 } from 'uuid';
 
 import styles from './style.module.scss';
+
+const generateUniqueId = () => {
+  return `input-id-${Math.floor(Math.random() * 10000000)}`;
+};
 
 // Something weird is going on with enterKeyHint that makes it a required field under certain circumstances. The & Omit<…> and & Pick<…> is a hacky way to go around that.
 export type InputProps = {
@@ -29,7 +32,7 @@ export default React.forwardRef(
     }: InputProps,
     ref?: React.ForwardedRef<HTMLInputElement>
   ) => {
-    const uniqueId = id ?? uuidv4();
+    const [uniqueId] = useState(id ?? generateUniqueId());
     return (
       <div className={`${styles.container} ${className ?? ''}`}>
         {label && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -15002,11 +15002,6 @@ uuid@^8.3.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
 uvu@^0.5.0:
   version "0.5.6"
   resolved "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz"


### PR DESCRIPTION
### What this PR does

Make the generated input id stable and use a simple id generation approach, as the id only has to be unique at render time.

* Drop the uuid dependency 

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
