### PR TITLE
fix(comparison-table): [no-ticket] fix mobile spacing for table header

### DIFF
--- a/src/lib/components/comparisonTable/components/TableArrows/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableArrows/index.tsx
@@ -16,7 +16,7 @@ const TableArrows = (props: TableArrowsProps) => {
   const handleButtonClick = (value: ArrowValues) => () => onClick(value);
 
   return (
-    <div className={`mt24 ${styles.container}`}>
+    <div className={styles.container}>
       <button
         onClick={handleButtonClick('prev')}
         className={classNames(

--- a/src/lib/components/comparisonTable/components/TableArrows/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableArrows/style.module.scss
@@ -4,8 +4,10 @@
 .container {
   position: absolute;
   width: 100%;
+  height: 100%;
   padding: 0 16px;
   justify-content: space-between;
+  align-items: center;
   z-index: 1;
   display: flex;
   @include p-size-tablet {

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -186,39 +186,43 @@ const ComparisonTable = <T extends { id: number }>(
                         </ScrollSyncPane>
                       </AccordionItem>
                     ) : (
-                      <ScrollSyncPane>
-                        <div
-                          className={classNames(
-                            baseStyles.container,
-                            styles?.container,
-                            {
-                              [baseStyles.noScrollBars]: hideScrollBars,
-                            }
-                          )}
-                        >
+                      <div key={idString}>
+                        <ScrollSyncPane>
                           <div
                             className={classNames(
-                              baseStyles['overflow-container']
+                              baseStyles.container,
+                              styles?.container,
+                              {
+                                [baseStyles.noScrollBars]: hideScrollBars,
+                              }
                             )}
                           >
-                            <div className={baseStyles['group-container']}>
-                              {
-                                /**
-                                 * Print a table subheader if the `label` value is present
-                                 */
-                                headerGroup.label && !collapsibleSections && (
-                                  <div className={baseStyles['group-title']}>
-                                    <h4 className={`p-h4 ${baseStyles.sticky}`}>
-                                      {headerGroup.label}
-                                    </h4>
-                                  </div>
-                                )
-                              }
-                              {content}
+                            <div
+                              className={classNames(
+                                baseStyles['overflow-container']
+                              )}
+                            >
+                              <div className={baseStyles['group-container']}>
+                                {
+                                  /**
+                                   * Print a table subheader if the `label` value is present
+                                   */
+                                  headerGroup.label && !collapsibleSections && (
+                                    <div className={baseStyles['group-title']}>
+                                      <h4
+                                        className={`p-h4 ${baseStyles.sticky}`}
+                                      >
+                                        {headerGroup.label}
+                                      </h4>
+                                    </div>
+                                  )
+                                }
+                                {content}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      </ScrollSyncPane>
+                        </ScrollSyncPane>
+                      </div>
                     )}
                   </>
                 );


### PR DESCRIPTION
### What this PR does

- Fixed misaligned header buttons and title of `ComparisonTable` mobile
- Added missing key to div mapping to remove console warning

**AS-IS**
<img width="275" alt="image" src="https://user-images.githubusercontent.com/26237320/213681022-b9095bf6-a18e-4fdb-a9e2-83892e6bb6cf.png">

**TO-BE**
<img width="277" alt="image" src="https://user-images.githubusercontent.com/26237320/213681060-2acac423-44fe-41c3-a28a-3dc1de8be7a0.png">


### Why is this needed?

For website [PR](https://github.com/getPopsure/website/pull/887) on `ComparisonTable`


### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge
