### PR TITLE
refactor(input): [no-ticket] update input to use sr-only class on hidden label

### DIFF
--- a/src/lib/components/input/currency/index.stories.mdx
+++ b/src/lib/components/input/currency/index.stories.mdx
@@ -27,5 +27,7 @@ The following will be done:
     <CurrencyInput className="wmx5 mt8" label="Amount" placeholder="100" />
     <h4 className="p-h4 mt24">With label and no placeholder</h4>
     <CurrencyInput className="wmx5 mt8" label="Amount" />
+    <h4 className="p-h4 mt24">With placeholder and no label</h4>
+    <CurrencyInput className="wmx5 mt8" hideLabel label="Amount" placeholder="0" />
   </>
 </Preview>

--- a/src/lib/components/input/index.tsx
+++ b/src/lib/components/input/index.tsx
@@ -40,7 +40,7 @@ export default React.forwardRef(
             htmlFor={uniqueId}
             className={classnames('p-p', styles.label, {
               [styles['label--with-error']]: error,
-              [styles['label--hidden']]: hideLabel,
+              "sr-only": hideLabel,
             })}
           >
             {label}

--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -101,12 +101,6 @@
   &--with-error {
     color: var(--ds-red-500);
   }
-
-  &--hidden {
-    visibility: hidden;
-    height: 0;
-    margin: 0;
-  }
 }
 
 .error {

--- a/src/lib/scss/utils/_index.scss
+++ b/src/lib/scss/utils/_index.scss
@@ -1,3 +1,15 @@
 @function url-encoded-color($color) {
   @return '%23' + str-slice('#{$color}', 2, -1);
 }
+
+.sr-only {
+  border-width: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}


### PR DESCRIPTION
### What this PR does
Update input to use sr-only class on hidden label. 
This PR also adds the `.sr-only` class to dirty-swan utils.

The `sr-only` class is based on several utils and accessibility recommendations:
https://tailwindcss.com/docs/screen-readers
https://a11y-guidelines.orange.com/en/articles/accessible-hiding/

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
