### PR TITLE
fix(tree-shaking): [NoTicket] enable tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:getPopsure/dirtySwan.git"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "author": "Vincent Audoire <vincent@getpopsure.com>",
   "license": "MIT",
   "private": false,
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git@github.com:getPopsure/dirtySwan.git"
   },
   "main": "dist/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "engines": {
     "node": ">=8",
     "npm": ">=5"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "type": "git",
     "url": "git@github.com:getPopsure/dirtySwan.git"
   },
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
   "engines": {
     "node": ">=8",
     "npm": ">=5"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,28 +20,29 @@ const postcssCustomProperties = require('postcss-custom-properties');
  * Need to look into which plugins are needed for each build.
  *
  */
+const plugins = [
+  external(),
+  postcss({
+    modules: true,
+    plugins: [postcssCustomProperties({ preserve: true })],
+  }),
+  url(),
+  resolve(),
+  commonjs(),
+];
+
 export default [
   {
     input: 'src/lib/index.tsx',
     output: [
       {
-        dir: 'dist',
+        dir: 'dist/cjs',
         format: 'cjs',
         exports: 'named',
         sourcemap: true,
       },
     ],
-    plugins: [
-      external(),
-      postcss({
-        modules: true,
-        plugins: [postcssCustomProperties({ preserve: true })],
-      }),
-      url(),
-      resolve(),
-      typescript(),
-      commonjs(),
-    ],
+    plugins: [...plugins, typescript({ outDir: 'dist/cjs' })],
   },
   {
     input: Object.fromEntries(
@@ -63,16 +64,6 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [
-      external(),
-      postcss({
-        modules: true,
-        plugins: [postcssCustomProperties({ preserve: true })],
-      }),
-      url(),
-      resolve(),
-      typescript(),
-      commonjs(),
-    ],
+    plugins: [...plugins, typescript({ outDir: 'dist/esm' })],
   },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,10 +47,10 @@ export default [
     input: Object.fromEntries(
       glob
         // we need to look into why adding ts breaks the build
-        .sync('src/**/*(*.tsx)')
+        .sync('src/lib/**/*(*.tsx)')
         .map((file) => [
           path.relative(
-            'src',
+            'src/lib',
             file.slice(0, file.length - path.extname(file).length)
           ),
           fileURLToPath(new URL(file, import.meta.url)),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,27 +4,75 @@ import external from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
 import resolve from 'rollup-plugin-node-resolve';
 import url from 'rollup-plugin-url';
+
+import glob from 'glob';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 const postcssCustomProperties = require('postcss-custom-properties');
 
-export default {
-  input: 'src/lib/index.tsx',
-  output: [
-    {
-      dir: 'dist',
-      format: 'cjs',
-      exports: 'named',
-      sourcemap: true,
-    },
-  ],
-  plugins: [
-    external(),
-    postcss({
-      modules: true,
-      plugins: [postcssCustomProperties({ preserve: true })],
-    }),
-    url(),
-    resolve(),
-    typescript(),
-    commonjs(),
-  ],
-};
+/**
+ *
+ * We need to decide how to isolate cjs and esm builds
+ * For now this totally separates the two builds by defining
+ * explicit input/output properties.
+ *
+ * Need to look into which plugins are needed for each build.
+ *
+ */
+export default [
+  {
+    input: 'src/lib/index.tsx',
+    output: [
+      {
+        dir: 'dist',
+        format: 'cjs',
+        exports: 'named',
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      external(),
+      postcss({
+        modules: true,
+        plugins: [postcssCustomProperties({ preserve: true })],
+      }),
+      url(),
+      resolve(),
+      typescript(),
+      commonjs(),
+    ],
+  },
+  {
+    input: Object.fromEntries(
+      glob
+        // we need to look into why adding ts breaks the build
+        .sync('src/**/*(*.tsx)')
+        .map((file) => [
+          path.relative(
+            'src',
+            file.slice(0, file.length - path.extname(file).length)
+          ),
+          fileURLToPath(new URL(file, import.meta.url)),
+        ])
+    ),
+    output: [
+      {
+        dir: 'dist/esm',
+        format: 'esm',
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      external(),
+      postcss({
+        modules: true,
+        plugins: [postcssCustomProperties({ preserve: true })],
+      }),
+      url(),
+      resolve(),
+      typescript(),
+      commonjs(),
+    ],
+  },
+];

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "module": "esnext",
     "target": "es5",
     "lib": ["es6", "dom", "es2016", "es2017"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist/esm",
+    "outDir": "dist",
     "module": "esnext",
     "target": "es5",
     "lib": ["es6", "dom", "es2016", "es2017"],


### PR DESCRIPTION
### What this PR does

This is an initial approach to enable consuming apps to tree-shake ds correctly.

To help tree-shake optimized apps, we will need to make some changes:
* `package.json` needs to define an esm specific entry point, this can be achieved by defining `module`.
* `package.json` needs a defined `sideEffects` which excludes css to ensure that the the library can be tree-shaked.
* Create an `esm` build that is isolated from the `cjs` build.
* Set the `TypeScript` output directory to the `esm` build folder to enable consuming applications to find the types.

These are first steps to get to a minimal bundle size when working with ds.

#### Testing the changes

To `test` the changes, the following approach is required:

* Create a controlled environment, f.e. using vite and the react-ts template to setup a barebones app
* Run `yarn add ../dirty-swan` (assuming the test app and ds are siblings, otherwise the relative path to ds)
* Add one or two ds components
* Run in dev mode and see if it compiles and check the console output
* Run the build and check the bundled js size
* Use an analyzer library that can help with visualizing the bundle (i.e. `rollup-plugin-visualizer`)


#### Testing results

Testing the changes yields the following results when testing it with a barebones `vite:react-ts` setup:

The example App imports four ds components:

```
import {
  Chip,
  Input,
  CurrencyInput,
  Button,
} from "@popsure/dirty-swan";
```

#### Pre changes

<img width="1509" alt="tree-shaking-pre-1" src="https://user-images.githubusercontent.com/718727/214548822-28d3c332-0951-420f-b077-13917505954d.png">

<img width="1121" alt="tree-shaking-pre-2" src="https://user-images.githubusercontent.com/718727/214548827-922b39ed-e8a3-4553-b739-6ba166e3ade8.png">


#### Post changes

<img width="1512" alt="tree-shaking-post-1" src="https://user-images.githubusercontent.com/718727/214547081-8cb9cda5-f395-4ba0-8163-956bb59a564c.png">

<img width="1509" alt="tree-shaking-post-2" src="https://user-images.githubusercontent.com/718727/214547089-63849234-3ef9-4f98-8d8b-890f75bfe825.png">

<img width="668" alt="tree-shaking-post-3" src="https://user-images.githubusercontent.com/718727/214547481-18e948c3-b6fe-4c35-bece-825af97874f9.png">


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
