### PR TITLE
refactor(multidropzone): [EMU-3320] Add accept filetype validation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-scroll-sync": "^0.9.0",
     "remark-directive": "^2.0.1",
     "sass": "^1.35.1",
-    "signature_pad": "^3.0.0-beta.3"
+    "signature_pad": "^3.0.0-beta.3",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "remark-directive": "^2.0.1",
     "sass": "^1.35.1",
     "signature_pad": "^3.0.0-beta.3",
-    "uuid": "^9.0.0"
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "react": "^16.12.0",

--- a/src/lib/components/multiDropzone/UploadFileCell/index.tsx
+++ b/src/lib/components/multiDropzone/UploadFileCell/index.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 
 import styles from './style.module.scss';
 import icons from '../icons/index';
-import { UploadStatus, UploadedFile } from '..';
+import { UploadStatus, UploadedFile } from '../types';
 
 interface Props {
   uploadStatus: UploadStatus;
@@ -57,7 +57,7 @@ const UploadFileCell: React.FC<Props> = ({
           alt=""
         />
         <div className="w100">
-          <div className={`p-p wmx5 ${styles['upload-display-text']}`}>
+          <div className={`p-p ${styles['upload-display-text']}`}>
             {mapDisplayText[uploadStatus]}
           </div>
 

--- a/src/lib/components/multiDropzone/UploadFileCell/index.tsx
+++ b/src/lib/components/multiDropzone/UploadFileCell/index.tsx
@@ -65,6 +65,7 @@ const UploadFileCell: React.FC<Props> = ({
             <div className={`mt8 w100 ${styles['progress-bar-container']}`}>
               <div className={`${styles['progress-bar']}`} />
               <div
+                data-testid="ds-filecell-progressbar"
                 className={`${styles['progress-bar-filler']}`}
                 style={{ width: `${progress}%` }}
               />
@@ -79,7 +80,12 @@ const UploadFileCell: React.FC<Props> = ({
       >
         {isUploading ? (
           <div className={styles.spinner}>
-            {showLoadingSpinner && <div className='ds-spinner ds-spinner__m' />}
+            {showLoadingSpinner && (
+              <div
+                className='ds-spinner ds-spinner__m'
+                data-testid="ds-filecell-spinner"
+              />
+            )}
           </div>
         ) : (
           <div>

--- a/src/lib/components/multiDropzone/index.stories.mdx
+++ b/src/lib/components/multiDropzone/index.stories.mdx
@@ -130,6 +130,32 @@ MultiDropzone component allows upload of multiple documents / files.
   />
 </Preview>
 
+### Accepting only images
+
+<Preview>
+  <MultiDropzone
+    accept="image"
+    isCondensed
+    uploadedFiles={[]}
+    onFileSelect={() => {}}
+    uploading={false}
+    onRemoveFile={() => {}}
+  />
+</Preview>
+
+### Accepting only documents
+
+<Preview>
+  <MultiDropzone
+    accept="document"
+    isCondensed
+    uploadedFiles={[]}
+    onFileSelect={() => {}}
+    uploading={false}
+    onRemoveFile={() => {}}
+  />
+</Preview>
+
 ### i18n support
 
 <Preview>
@@ -140,9 +166,9 @@ MultiDropzone component allows upload of multiple documents / files.
     onRemoveFile={() => {}}
     textOverrides={{
       instructionsText: 'Datei auswählen oder per Drag & Drop platzieren',
-      supportsText: 'Unterstützt werden JPEG, PNG, PDF',
+      supportsTextShort: 'Unterstützt werden',
       currentlyUploadingText:
-        'Bitte warten während die Datei hochgeladen wird...',
+        'Bitte warten während die Datei hochgeladen wird...'
     }}
   />
 </Preview>

--- a/src/lib/components/multiDropzone/index.stories.mdx
+++ b/src/lib/components/multiDropzone/index.stories.mdx
@@ -35,7 +35,7 @@ MultiDropzone component allows upload of multiple documents / files.
         previewUrl: 'http://getpopsure.com/test_file_name.pdf',
       },
       {
-        id: '123',
+        id: '124',
         type: 'pdf',
         progress: '72',
         name: 'test_file_name.pdf',
@@ -45,7 +45,7 @@ MultiDropzone component allows upload of multiple documents / files.
         showProgressBar: false,
       },
       {
-        id: '123',
+        id: '125',
         type: 'pdf',
         progress: '72',
         name: 'test_file_name.pdf',

--- a/src/lib/components/multiDropzone/index.test.tsx
+++ b/src/lib/components/multiDropzone/index.test.tsx
@@ -1,0 +1,220 @@
+import { fireEvent, render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import '@testing-library/jest-dom';
+
+import MultiDropzone, { MultiDropzoneProps } from '.';
+
+const mockOnFileSelect = jest.fn();
+const mockOnRemoveFile = jest.fn();
+const file = new File(['FileTest'], 'chucknorris.png', { type: 'image/png' });
+
+const inputTestId = "ds-drop-input";
+const spinnerTestId = "ds-filecell-spinner";
+const progressbarTestId = "ds-filecell-progressbar";
+const uploadedFilesMock = {
+   id: "123",
+   name: "File name",
+   progress: 100,
+   type: "jpg",
+};
+
+const setup = ({
+ uploadedFiles = [],
+ uploading = false,
+ ...rest
+}: Partial<MultiDropzoneProps>) => {
+  return render(
+    <MultiDropzone
+      {...rest}
+      uploadedFiles={uploadedFiles}
+      uploading={uploading}
+      onFileSelect={mockOnFileSelect}
+      onRemoveFile={mockOnRemoveFile}
+    />
+  );
+};
+
+describe('MultiDropzone component', () => {
+  it("should call onFileSelect on files change", async () => {
+    const screen = setup({});
+    const input = screen.getByTestId(inputTestId);
+    const files = [file, file];
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files } });
+    });
+
+    expect(mockOnFileSelect).toHaveBeenCalledWith(files);
+  });
+
+  describe('Error states', () => {
+    it("should show max files error message", () => {
+      const screen = setup({
+        maxFiles: 1,
+        uploadedFiles: [uploadedFilesMock, {
+          ...uploadedFilesMock,
+          id: "222"
+        }],
+      });
+  
+      expect(screen.getByText("Too many files.")).toBeVisible();
+    });
+
+    it("should show wrong filetype error message", async () => {
+      const screen = setup({ accept: "document" });
+      const input = screen.getByTestId(inputTestId);
+  
+      await act(async () => {
+        fireEvent.change(input, { target: { files: [file] } });
+      });
+  
+      expect(
+        screen.getByText("File type must be one of DOC, DOCX, PDF")
+      ).toBeInTheDocument();
+    });
+
+    it("should remove wrong filetype error message", async () => {
+      const screen = setup({ accept: "document" });
+      const input = screen.getByTestId(inputTestId);
+  
+      await act(async () => {
+        fireEvent.change(input, { target: { files: [file] } });
+      });
+      
+      screen.getByAltText("remove").click();
+
+      expect(
+        screen.queryByText("File type must be one of DOC, DOCX, PDF")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Copy text', () => {
+    it("should show uploader text", () => {
+      const screen = setup({});
+
+      expect(screen.getByText("Choose file or drag & drop")).toBeInTheDocument();
+    });
+
+    it("should show uploader text translated", () => {
+      const instructionsText = "Drag drop file";
+      const screen = setup({
+        textOverrides: { instructionsText }
+      });
+
+      expect(screen.getByText(instructionsText)).toBeInTheDocument();
+    });
+
+    it("should show image accept file type label", () => {
+      const screen = setup({ accept: "image" });
+
+      expect(
+        screen.getByText("Supports HEIC, BMP, JPEG, JPG, PNG")
+      ).toBeInTheDocument();
+    });
+
+    it("should show document accept file type label", () => {
+      const screen = setup({ accept: "document" });
+
+      expect(
+        screen.getByText("Supports DOC, DOCX, PDF")
+      ).toBeInTheDocument();
+    });
+
+    it("should custom document accept file type label", () => {
+      const screen = setup({ accept: {
+        "application/pdf": [".pdf"],
+        "image/jpg": [".jpg"],
+      } });
+
+      expect(
+        screen.getByText("Supports PDF, JPG")
+      ).toBeInTheDocument();
+    });
+
+    it("should show disabled text if is uploading", () => {
+      const screen = setup({ uploading: true });
+
+      expect(
+        screen.getByText("Please wait while uploading file...")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Uploaded files', () => {
+    it("should show uploaded files", () => {
+      const screen = setup({
+        uploadedFiles: [uploadedFilesMock],
+      });
+
+      expect(
+        screen.getByText(uploadedFilesMock.name)
+      ).toBeInTheDocument();
+    });
+
+    it("should call onRemoveFile with uploaded file id", () => {
+      const screen = setup({
+        uploadedFiles: [uploadedFilesMock],
+      });
+
+      screen.getByAltText("remove").click();
+
+      expect(mockOnRemoveFile).toBeCalledWith(uploadedFilesMock.id);
+    });
+
+    it("should show uploaded file with uploading label", () => {
+      const screen = setup({
+        uploadedFiles: [{ ...uploadedFilesMock, progress: 50 }],
+      });
+
+      expect(screen.getByText("Uploading...")).toBeInTheDocument();
+    });
+
+    it("should show uploaded file with progress bar", () => {
+      const screen = setup({
+        uploadedFiles: [{
+          ...uploadedFilesMock,
+          progress: 50,
+        }],
+      });
+
+      expect(screen.getByTestId(progressbarTestId)).toBeInTheDocument();
+    });
+
+    it("should show uploaded file with no progress bar", () => {
+      const screen = setup({
+        uploadedFiles: [{
+          ...uploadedFilesMock,
+          progress: 50,
+          showProgressBar: false
+        }],
+      });
+
+      expect(screen.queryByTestId(progressbarTestId)).not.toBeInTheDocument();
+    });
+
+    it("should show uploaded file with loading spinner", () => {
+      const screen = setup({
+        uploadedFiles: [{
+          ...uploadedFilesMock,
+          progress: 50,
+          showLoadingSpinner: true
+        }],
+      });
+
+      expect(screen.getByTestId(spinnerTestId)).toBeInTheDocument();
+    });
+
+    it("should show uploaded file with no loading spinner", () => {
+      const screen = setup({
+        uploadedFiles: [{
+          ...uploadedFilesMock,
+          progress: 50,
+          showLoadingSpinner: false
+        }],
+      });
+
+      expect(screen.queryByTestId(spinnerTestId)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/multiDropzone/index.test.tsx
+++ b/src/lib/components/multiDropzone/index.test.tsx
@@ -6,7 +6,7 @@ import MultiDropzone, { MultiDropzoneProps } from '.';
 
 const mockOnFileSelect = jest.fn();
 const mockOnRemoveFile = jest.fn();
-const file = new File(['FileTest'], 'chucknorris.png', { type: 'image/png' });
+const file = new File(['DummyFile'], 'dummy.png', { type: 'image/png' });
 
 const inputTestId = "ds-drop-input";
 const spinnerTestId = "ds-filecell-spinner";

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -40,7 +40,7 @@ const MultiDropZone = ({
   uploading,
   onRemoveFile,
   isCondensed = false,
-  maxFiles = 2,
+  maxFiles = 0,
   textOverrides,
 }: Props) => {
   const [errors, setErrors] = useState<ErrorMessage[]>([]);

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -5,57 +5,34 @@ import AnimateHeight from 'react-animate-height';
 import styles from './style.module.scss';
 import icons from './icons/index'; // TODO: inline all of the svgs
 import UploadFileCell from './UploadFileCell';
-
-export type UploadStatus = 'UPLOADING' | 'COMPLETE' | 'ERROR';
-
-export type FileType =
-  | 'heic'
-  | 'bmp'
-  | 'jpeg'
-  | 'jpg'
-  | 'png'
-  | 'doc'
-  | 'docx'
-  | 'pdf';
-
-const getUploadStatus = (progress: number, error?: string): UploadStatus => {
-  if (error) {
-    return 'ERROR';
-  }
-
-  if (progress < 100) {
-    return 'UPLOADING';
-  }
-
-  return 'COMPLETE';
-};
-
-export interface UploadedFile {
-  id: string;
-  name: string;
-  type: FileType | string;
-  previewUrl?: string;
-  progress: number;
-  error?: string;
-  showProgressBar?: boolean;
-  showLoadingSpinner?: boolean;
-}
+import { 
+  formatAcceptFileList, 
+  getErrorMessage, 
+  getFormattedAcceptObject, 
+  getUploadStatus 
+} from './utils';
+import { 
+  AcceptType, 
+  ErrorMessage, 
+  FileType, 
+  TextOverrides, 
+  UploadedFile, 
+  UploadStatus 
+} from './types';
 
 interface Props {
+  accept?: AcceptType;
   onFileSelect: (files: File[]) => void;
   uploadedFiles: UploadedFile[];
   uploading: boolean;
   onRemoveFile: (id: string) => void;
   isCondensed?: boolean;
   maxFiles?: number;
-  textOverrides?: {
-    instructionsText?: string;
-    currentlyUploadingText?: string;
-    supportsText?: string;
-  };
+  textOverrides?: TextOverrides;
 }
 
-export default ({
+const MultiDropZone = ({
+  accept,
   uploadedFiles,
   onFileSelect,
   uploading,
@@ -64,23 +41,35 @@ export default ({
   maxFiles = 0,
   textOverrides,
 }: Props) => {
-  const [error, setError] = useState('');
+  const [error, setError] = useState<ErrorMessage | null>();
+  const resetError = () => setError(null);
+  const formattedAccept = getFormattedAcceptObject(accept);
+  const fileList = formatAcceptFileList(formattedAccept);
+  const placeholder = `${textOverrides?.supportsTextShort || "Supports"} ${fileList || "JPEG, PNG, PDF"}`;
 
   const onDrop = useCallback(
     (acceptedFiles: File[], filesRejected: FileRejection[]) => {
-      setError('');
+      resetError();
 
       if (filesRejected.length > 0) {
-        setError(filesRejected[0].errors[0].message);
+        setError(getErrorMessage(
+          filesRejected[0].errors[0],
+          { fileList },
+          textOverrides
+        ));
         return;
       }
 
       onFileSelect(acceptedFiles);
     },
-    [onFileSelect]
+    [fileList, onFileSelect, textOverrides]
   );
 
-  const { getRootProps, getInputProps } = useDropzone({ onDrop, maxFiles });
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: formattedAccept,
+    onDrop,
+    maxFiles
+  });
 
   return (
     <div className={styles.container}>
@@ -106,28 +95,45 @@ export default ({
             : textOverrides?.instructionsText || 'Choose file or drag & drop'}
         </div>
         <div className="p-p--small tc-grey-500">
-          {textOverrides?.supportsText || 'Supports JPEG, PNG, PDF'}
+          {textOverrides?.supportsText || placeholder}
         </div>
       </div>
-      <AnimateHeight duration={300} height={error ? 'auto' : 0}>
-        <p className="tc-red-500 p-p--small">{error}</p>
+
+      {error?.message && !error?.inlineError && (
+        <UploadFileCell
+          uploadStatus="ERROR"
+          file={{
+            error: error.message,
+            id: "error",
+            name: error.message,
+            progress: 0,
+            type: "",
+          }}
+          onRemoveFile={resetError}
+          uploading={false}
+        />
+      )}
+
+      <AnimateHeight duration={300} height={error?.message && error?.inlineError ? 'auto' : 0}>
+        <p className="tc-red-500 p-p--small">{error?.message}</p>
       </AnimateHeight>
+
       {uploadedFiles.length > 0 && (
         <div className="w100 mt16">
-          {uploadedFiles.map((file) => {
-            const uploadStatus = getUploadStatus(file.progress, file.error);
-            return (
-              <UploadFileCell
-                uploadStatus={uploadStatus}
-                file={file}
-                key={file.id}
-                onRemoveFile={onRemoveFile}
-                uploading={uploading}
-              />
-            );
-          })}
+          {uploadedFiles.map((file) => (
+            <UploadFileCell
+              uploadStatus={getUploadStatus(file.progress, file.error)}
+              file={file}
+              key={file.id}
+              onRemoveFile={onRemoveFile}
+              uploading={uploading}
+            />
+          ))}
         </div>
       )}
     </div>
   );
 };
+
+export type { FileType, UploadedFile, UploadStatus };
+export default MultiDropZone;

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -22,7 +22,7 @@ import {
   UploadStatus 
 } from './types';
 
-interface Props {
+interface MultiDropzoneProps {
   accept?: AcceptType;
   onFileSelect: (files: File[]) => void;
   uploadedFiles: UploadedFile[];
@@ -42,7 +42,7 @@ const MultiDropZone = ({
   isCondensed = false,
   maxFiles = 0,
   textOverrides,
-}: Props) => {
+}: MultiDropzoneProps) => {
   const [errors, setErrors] = useState<ErrorMessage[]>([]);
   const formattedAccept = getFormattedAcceptObject(accept);
   const fileList = formatAcceptFileList(formattedAccept);
@@ -75,6 +75,7 @@ const MultiDropZone = ({
 
   const { getRootProps, getInputProps } = useDropzone({
     accept: formattedAccept,
+    disabled: uploading,
     onDrop,
   });
 
@@ -89,7 +90,10 @@ const MultiDropZone = ({
         )}
         {...getRootProps()}
       >
-        <input {...getInputProps()} />
+        <input
+          data-testid="ds-drop-input"
+          {...getInputProps()}
+        />
         <img
           className={isCondensed ? styles.img : ''}
           src={isCondensed ? icons.uploadSmallIcon : icons.uploadIcon}
@@ -145,5 +149,5 @@ const MultiDropZone = ({
   );
 };
 
-export type { FileType, UploadedFile, UploadStatus };
+export type { FileType, MultiDropzoneProps, UploadedFile, UploadStatus };
 export default MultiDropZone;

--- a/src/lib/components/multiDropzone/types.ts
+++ b/src/lib/components/multiDropzone/types.ts
@@ -12,7 +12,7 @@ export type FileType =
   | 'docx'
   | 'pdf';
 
-export interface UploadedFile {
+  export interface UploadedFile {
   id: string;
   name: string;
   type: FileType | string;
@@ -24,7 +24,6 @@ export interface UploadedFile {
 }
 
 export type AcceptType = "document" | "image" | Accept;
-
 export interface TextOverrides {
   currentlyUploadingText?: string;
   fileTypeError?: string;
@@ -33,7 +32,6 @@ export interface TextOverrides {
   supportsTextShort?: string;
   tooManyFilesError?: string;
 }
-
 export interface ErrorMessage {
   inlineError: boolean;
   message: string;

--- a/src/lib/components/multiDropzone/types.ts
+++ b/src/lib/components/multiDropzone/types.ts
@@ -2,17 +2,13 @@ import { Accept } from "react-dropzone";
 
 export type UploadStatus = 'UPLOADING' | 'COMPLETE' | 'ERROR';
 
-export type FileType =
-  | 'heic'
-  | 'bmp'
-  | 'jpeg'
-  | 'jpg'
-  | 'png'
-  | 'doc'
-  | 'docx'
-  | 'pdf';
+export const DOCUMENT_FILES = ['doc', 'docx', 'pdf'];
+export const IMAGE_FILES = ['heic', 'bmp', 'jpeg', 'jpg', 'png'];
 
-  export interface UploadedFile {
+export const FILE_TYPES = [...DOCUMENT_FILES, ...IMAGE_FILES];
+export type FileType = typeof FILE_TYPES[number];
+
+export interface UploadedFile {
   id: string;
   name: string;
   type: FileType | string;
@@ -33,6 +29,6 @@ export interface TextOverrides {
   tooManyFilesError?: string;
 }
 export interface ErrorMessage {
-  inlineError: boolean;
+  id: string;
   message: string;
 }

--- a/src/lib/components/multiDropzone/types.ts
+++ b/src/lib/components/multiDropzone/types.ts
@@ -1,0 +1,40 @@
+import { Accept } from "react-dropzone";
+
+export type UploadStatus = 'UPLOADING' | 'COMPLETE' | 'ERROR';
+
+export type FileType =
+  | 'heic'
+  | 'bmp'
+  | 'jpeg'
+  | 'jpg'
+  | 'png'
+  | 'doc'
+  | 'docx'
+  | 'pdf';
+
+export interface UploadedFile {
+  id: string;
+  name: string;
+  type: FileType | string;
+  previewUrl?: string;
+  progress: number;
+  error?: string;
+  showProgressBar?: boolean;
+  showLoadingSpinner?: boolean;
+}
+
+export type AcceptType = "document" | "image" | Accept;
+
+export interface TextOverrides {
+  currentlyUploadingText?: string;
+  fileTypeError?: string;
+  instructionsText?: string;
+  supportsText?: string;
+  supportsTextShort?: string;
+  tooManyFilesError?: string;
+}
+
+export interface ErrorMessage {
+  inlineError: boolean;
+  message: string;
+}

--- a/src/lib/components/multiDropzone/utils.ts
+++ b/src/lib/components/multiDropzone/utils.ts
@@ -1,5 +1,5 @@
 import { Accept, ErrorCode, FileError } from "react-dropzone";
-import { AcceptType, ErrorMessage, TextOverrides, UploadStatus } from "./types";
+import { AcceptType, DOCUMENT_FILES, FileType, IMAGE_FILES, TextOverrides, UploadStatus } from "./types";
 
 export const getUploadStatus = (progress: number, error?: string): UploadStatus => {
   if (error) {
@@ -12,18 +12,27 @@ export const getUploadStatus = (progress: number, error?: string): UploadStatus 
 
   return 'COMPLETE';
 };
+
+const formatMimeType = (type: string, values: FileType[]): Accept  => {
+  const formatedValues = {} as Accept;
+
+  values.forEach((value) => {
+    formatedValues[`${type}/${value}`] = [`.${value}`];
+  });
+
+  return formatedValues;
+};
+
+export const DOCUMENT_FILES_ACCEPT = formatMimeType("application", DOCUMENT_FILES);
+export const IMAGE_FILES_ACCEPT = formatMimeType("image", IMAGE_FILES);
   
 export const getFormattedAcceptObject = (accept: AcceptType = {}): Accept => {
   if (accept === "document") {
-    return {
-      'application/*': [ '.doc', '.docx', '.pdf' ]
-    };
+    return DOCUMENT_FILES_ACCEPT;
   };
 
   if (accept === "image") {
-    return {
-      'image/*': [ '.heic', '.bmp', '.jpeg', '.jpg', '.png' ]
-    };
+    return IMAGE_FILES_ACCEPT;
   };
 
   return accept;
@@ -41,22 +50,11 @@ export const getErrorMessage = (
   { code, message }: FileError,
   { fileList }: { fileList?: string },
   textOverrides?: TextOverrides,
-): ErrorMessage => {
+): string => {
   switch (code) {
     case ErrorCode.FileInvalidType:
-      return {
-        message: `${textOverrides?.fileTypeError || "File type must be one of"} ${fileList}`,
-        inlineError: false
-      };
-    case ErrorCode.TooManyFiles:
-      return {
-        message: textOverrides?.tooManyFilesError || "Too many files.",
-        inlineError: true
-      };
+      return `${textOverrides?.fileTypeError || "File type must be one of"} ${fileList}`;
     default:
-      return {
-        message,
-        inlineError: true
-      };
+      return message;
   }
 }

--- a/src/lib/components/multiDropzone/utils.ts
+++ b/src/lib/components/multiDropzone/utils.ts
@@ -2,61 +2,61 @@ import { Accept, ErrorCode, FileError } from "react-dropzone";
 import { AcceptType, ErrorMessage, TextOverrides, UploadStatus } from "./types";
 
 export const getUploadStatus = (progress: number, error?: string): UploadStatus => {
-    if (error) {
-      return 'ERROR';
-    }
+  if (error) {
+    return 'ERROR';
+  }
+
+  if (progress < 100) {
+    return 'UPLOADING';
+  }
+
+  return 'COMPLETE';
+};
   
-    if (progress < 100) {
-      return 'UPLOADING';
-    }
-  
-    return 'COMPLETE';
+export const getFormattedAcceptObject = (accept: AcceptType = {}): Accept => {
+  if (accept === "document") {
+    return {
+      'application/*': [ '.doc', '.docx', '.pdf' ]
+    };
   };
-  
-  export const getFormattedAcceptObject = (accept: AcceptType = {}): Accept => {
-    if (accept === "document") {
-      return {
-        'application/*': [ '.doc', '.docx', '.pdf' ]
-      };
+
+  if (accept === "image") {
+    return {
+      'image/*': [ '.heic', '.bmp', '.jpeg', '.jpg', '.png' ]
     };
+  };
+
+  return accept;
+}
   
-    if (accept === "image") {
+export const formatAcceptFileList = (accept: Accept): string => (
+  Object.values(accept)
+    .reduce((acc, value) => [...acc, ...value], [])
+    .join(", ")
+    .replace(/\./g, '')
+    .toUpperCase()
+);
+
+export const getErrorMessage = (
+  { code, message }: FileError,
+  { fileList }: { fileList?: string },
+  textOverrides?: TextOverrides,
+): ErrorMessage => {
+  switch (code) {
+    case ErrorCode.FileInvalidType:
       return {
-        'image/*': [ '.heic', '.bmp', '.jpeg', '.jpg', '.png' ]
+        message: `${textOverrides?.fileTypeError || "File type must be one of"} ${fileList}`,
+        inlineError: false
       };
-    };
-  
-    return accept;
+    case ErrorCode.TooManyFiles:
+      return {
+        message: textOverrides?.tooManyFilesError || "Too many files.",
+        inlineError: true
+      };
+    default:
+      return {
+        message,
+        inlineError: true
+      };
   }
-  
-  export const formatAcceptFileList = (accept: Accept): string => (
-    Object.values(accept)
-      .reduce((acc, value) => [...acc, ...value], [])
-      .join(", ")
-      .replace(/\./g, '')
-      .toUpperCase()
-  );
-  
-  export const getErrorMessage = (
-    { code, message }: FileError,
-    { fileList }: { fileList?: string },
-    textOverrides?: TextOverrides,
-  ): ErrorMessage => {
-    switch (code) {
-      case ErrorCode.FileInvalidType:
-        return {
-          message: `${textOverrides?.fileTypeError || "File type must be one of"} ${fileList}`,
-          inlineError: false
-        };
-      case ErrorCode.TooManyFiles:
-        return {
-          message: textOverrides?.tooManyFilesError || "Too many files.",
-          inlineError: true
-        };
-      default:
-        return {
-          message,
-          inlineError: true
-        };
-    }
-  }
+}

--- a/src/lib/components/multiDropzone/utils.ts
+++ b/src/lib/components/multiDropzone/utils.ts
@@ -1,0 +1,62 @@
+import { Accept, ErrorCode, FileError } from "react-dropzone";
+import { AcceptType, ErrorMessage, TextOverrides, UploadStatus } from "./types";
+
+export const getUploadStatus = (progress: number, error?: string): UploadStatus => {
+    if (error) {
+      return 'ERROR';
+    }
+  
+    if (progress < 100) {
+      return 'UPLOADING';
+    }
+  
+    return 'COMPLETE';
+  };
+  
+  export const getFormattedAcceptObject = (accept: AcceptType = {}): Accept => {
+    if (accept === "document") {
+      return {
+        'application/*': [ '.doc', '.docx', '.pdf' ]
+      };
+    };
+  
+    if (accept === "image") {
+      return {
+        'image/*': [ '.heic', '.bmp', '.jpeg', '.jpg', '.png' ]
+      };
+    };
+  
+    return accept;
+  }
+  
+  export const formatAcceptFileList = (accept: Accept): string => (
+    Object.values(accept)
+      .reduce((acc, value) => [...acc, ...value], [])
+      .join(", ")
+      .replace(/\./g, '')
+      .toUpperCase()
+  );
+  
+  export const getErrorMessage = (
+    { code, message }: FileError,
+    { fileList }: { fileList?: string },
+    textOverrides?: TextOverrides,
+  ): ErrorMessage => {
+    switch (code) {
+      case ErrorCode.FileInvalidType:
+        return {
+          message: `${textOverrides?.fileTypeError || "File type must be one of"} ${fileList}`,
+          inlineError: false
+        };
+      case ErrorCode.TooManyFiles:
+        return {
+          message: textOverrides?.tooManyFilesError || "Too many files.",
+          inlineError: true
+        };
+      default:
+        return {
+          message,
+          inlineError: true
+        };
+    }
+  }

--- a/src/lib/components/multiDropzone/utils/index.test.ts
+++ b/src/lib/components/multiDropzone/utils/index.test.ts
@@ -36,13 +36,7 @@ describe('getUploadStatus', () => {
 
 describe('getFormattedAcceptObject', () => {
   it('Should return image accept object if is of type image', () => {
-    expect(getFormattedAcceptObject("image")).toEqual({
-      'image/heic': [".heic"],
-      'image/bmp': [".bmp"],
-      'image/jpeg': [".jpeg"],
-      'image/jpg': [".jpg"],
-      'image/png': [".png"]
-    });
+    expect(getFormattedAcceptObject("image")).toEqual(imagesAccept);
   });
 
   it('Should return documents accept object if is of type document', () => {

--- a/src/lib/components/multiDropzone/utils/index.test.ts
+++ b/src/lib/components/multiDropzone/utils/index.test.ts
@@ -1,0 +1,118 @@
+import { ErrorCode } from 'react-dropzone';
+import { 
+  formatAcceptFileList,
+  getErrorMessage,
+  getFormattedAcceptObject, 
+  getUploadStatus 
+} from '.';
+
+const documentsAccept = {
+  'application/doc': ['.doc'],
+  'application/docx': ['.docx'],
+  'application/pdf': ['.pdf']
+};
+
+const imagesAccept = {
+  'image/heic': [".heic"],
+  'image/bmp': [".bmp"],
+  'image/jpeg': [".jpeg"],
+  'image/jpg': [".jpg"],
+  'image/png': [".png"]
+};
+
+describe('getUploadStatus', () => {
+  it('Should return error status if error is passed', () => {
+    expect(getUploadStatus(0, "Error message")).toEqual("ERROR");
+  });
+
+  it("Should return uploading status if progress hasn't finished", () => {
+    expect(getUploadStatus(50)).toEqual("UPLOADING");
+  });
+
+  it("Should return complete status if progress has finished", () => {
+    expect(getUploadStatus(100)).toEqual("COMPLETE");
+  });
+});
+
+describe('getFormattedAcceptObject', () => {
+  it('Should return image accept object if is of type image', () => {
+    expect(getFormattedAcceptObject("image")).toEqual({
+      'image/heic': [".heic"],
+      'image/bmp': [".bmp"],
+      'image/jpeg': [".jpeg"],
+      'image/jpg': [".jpg"],
+      'image/png': [".png"]
+    });
+  });
+
+  it('Should return documents accept object if is of type document', () => {
+    expect(getFormattedAcceptObject("document")).toEqual(documentsAccept);
+  });
+
+  it('Should return accept object if it is manually defined', () => {
+    const accept = { "application/pdf": [".pdf"] };
+
+    expect(getFormattedAcceptObject(accept)).toEqual(accept);
+  });
+});
+
+describe('formatAcceptFileList', () => {
+  it('Should return empty object if accept is empty', () => {
+    expect(formatAcceptFileList({})).toEqual("");
+  });
+
+  it('Should return documents list if documents accept is passed', () => {
+    expect(formatAcceptFileList(documentsAccept)).toEqual("DOC, DOCX, PDF");
+  });
+
+  it('Should return images list if images accept is passed', () => {
+    expect(formatAcceptFileList(imagesAccept)).toEqual("HEIC, BMP, JPEG, JPG, PNG"); 
+  });
+
+  it('Should return extension based on accept passed', () => {
+    const accept = { 
+      "application/pdf": [".pdf"],
+      "image/jpg": [".jpg"]
+    };
+
+    expect(formatAcceptFileList(accept)).toEqual("PDF, JPG");
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('Should return default error message', () => {
+    const defaultMessage = "Default Error Message.";
+
+    expect(
+      getErrorMessage({
+        code: "UNKNOWN",
+        message: defaultMessage
+      }, { 
+        fileList: "" 
+      })
+    ).toEqual(defaultMessage);
+  });
+
+  it('Should return default FileInvalidType default message', () => {
+    const fileList = "JPG, PDF";
+
+    expect(
+      getErrorMessage({
+        code: ErrorCode.FileInvalidType,
+        message: ""
+      }, { fileList })
+    ).toEqual(`File type must be one of ${fileList}`);
+  });
+
+  it('Should return FileInvalidType with textOverride message', () => {
+    const fileTypeError = "File Invalid Error";
+    const fileList = "JPG, PDF";
+    
+    expect(
+      getErrorMessage({
+        code: ErrorCode.FileInvalidType,
+        message: ""
+      }, { fileList }, { fileTypeError })
+    ).toEqual(`${fileTypeError} ${fileList}`);
+  });
+});

--- a/src/lib/components/multiDropzone/utils/index.ts
+++ b/src/lib/components/multiDropzone/utils/index.ts
@@ -1,5 +1,11 @@
 import { Accept, ErrorCode, FileError } from "react-dropzone";
-import { AcceptType, DOCUMENT_FILES, FileType, IMAGE_FILES, TextOverrides, UploadStatus } from "./types";
+import { 
+  AcceptType, 
+  DOCUMENT_FILES, 
+  FileType, 
+  IMAGE_FILES, 
+  TextOverrides,
+  UploadStatus } from "../types";
 
 export const getUploadStatus = (progress: number, error?: string): UploadStatus => {
   if (error) {
@@ -48,7 +54,7 @@ export const formatAcceptFileList = (accept: Accept): string => (
 
 export const getErrorMessage = (
   { code, message }: FileError,
-  { fileList }: { fileList?: string },
+  { fileList = "" }: { fileList?: string },
   textOverrides?: TextOverrides,
 ): string => {
   switch (code) {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom';
+
 window.google = {
   maps: {
     StyledMapType: class {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -15002,6 +15002,11 @@ uuid@^8.3.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 uvu@^0.5.0:
   version "0.5.6"
   resolved "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14997,15 +14997,10 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
### What this PR does
Add accept filetype validation support to MultiDropZone component.

_Please include a summary of the change(s)._
1. Adds support to accept prop on MultiDropZone component, including helper states of `document` and `image`
2. Refactors component to have a separated file for utils and types
3. Supports showing file errors both inline and as a general state
4. Adds textOverrides support to error messages from react-dropzone

Solves:  
EMU-3320

https://user-images.githubusercontent.com/4015038/215064138-3886a175-eaf8-408b-8a6b-3d4faabbd12f.mov

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
