### PR TITLE
refactor(multidropzone): [EMU-5671] Add file maxSize validation support

### DIFF
--- a/src/lib/components/multiDropzone/index.stories.mdx
+++ b/src/lib/components/multiDropzone/index.stories.mdx
@@ -156,6 +156,19 @@ MultiDropzone component allows upload of multiple documents / files.
   />
 </Preview>
 
+### Limiting file size to 2MB
+
+<Preview>
+  <MultiDropzone
+    isCondensed
+    uploadedFiles={[]}
+    onFileSelect={() => {}}
+    uploading={false}
+    onRemoveFile={() => {}}
+    maxSize={2096000}
+  />
+</Preview>
+
 ### i18n support
 
 <Preview>

--- a/src/lib/components/multiDropzone/index.test.tsx
+++ b/src/lib/components/multiDropzone/index.test.tsx
@@ -60,6 +60,21 @@ describe('MultiDropzone component', () => {
       expect(screen.getByText("Too many files.")).toBeVisible();
     });
 
+    it("should show max file size error message", async () => {
+      const screen = setup({maxSize: 10 });
+      const input = screen.getByTestId(inputTestId);
+      const bigFile = file;
+      Object.defineProperty(bigFile, 'size', { value: 1024 });
+
+      await act(async () => {
+        fireEvent.change(input, { target: { files: [bigFile] } });
+      });
+
+      expect(
+        screen.getByText("File is too large. It must be less than 10 Bytes.")
+      ).toBeInTheDocument();
+    });
+
     it("should show wrong filetype error message", async () => {
       const screen = setup({ accept: "document" });
       const input = screen.getByTestId(inputTestId);

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -21,6 +21,7 @@ import {
   UploadedFile, 
   UploadStatus 
 } from './types';
+import { formatBytes } from '../../util/formatBytes';
 
 interface MultiDropzoneProps {
   accept?: AcceptType;
@@ -30,6 +31,7 @@ interface MultiDropzoneProps {
   onRemoveFile: (id: string) => void;
   isCondensed?: boolean;
   maxFiles?: number;
+  maxSize?: number;
   textOverrides?: TextOverrides;
 }
 
@@ -41,12 +43,16 @@ const MultiDropZone = ({
   onRemoveFile,
   isCondensed = false,
   maxFiles = 0,
+  maxSize,
   textOverrides,
 }: MultiDropzoneProps) => {
   const [errors, setErrors] = useState<ErrorMessage[]>([]);
   const formattedAccept = getFormattedAcceptObject(accept);
   const fileList = formatAcceptFileList(formattedAccept);
-  const placeholder = `${textOverrides?.supportsTextShort || "Supports"} ${fileList || "JPEG, PNG, PDF"}`;
+  const maxSizePlaceholder = maxSize && maxSize > 0
+  ? `${textOverrides?.sizeUpToText || "up to"} ${formatBytes(maxSize)}`
+  : "";
+const placeholder = `${textOverrides?.supportsTextShort || "Supports"} ${fileList || "JPEG, PNG, PDF"} ${maxSizePlaceholder}`;
   const isOverMaxFiles = maxFiles > 0 && uploadedFiles.length > maxFiles;
 
   const removeError = (removeId: string) => (
@@ -63,19 +69,20 @@ const MultiDropZone = ({
           id: uuidv4(),
           message: getErrorMessage(
             errors[0],
-            { fileList },
+            { fileList, maxSize },
             textOverrides
           ),
         }))
       ]));
     },
-    [fileList, onFileSelect, textOverrides]
+    [fileList, maxSize, onFileSelect, textOverrides]
   );
 
 
   const { getRootProps, getInputProps } = useDropzone({
     accept: formattedAccept,
     disabled: uploading,
+    maxSize,
     onDrop,
   });
 

--- a/src/lib/components/multiDropzone/types.ts
+++ b/src/lib/components/multiDropzone/types.ts
@@ -23,7 +23,9 @@ export type AcceptType = "document" | "image" | Accept;
 export interface TextOverrides {
   currentlyUploadingText?: string;
   fileTypeError?: string;
+  fileTooLargeError?: string;
   instructionsText?: string;
+  sizeUpToText?: string;
   supportsText?: string;
   supportsTextShort?: string;
   tooManyFilesError?: string;

--- a/src/lib/components/multiDropzone/utils/index.ts
+++ b/src/lib/components/multiDropzone/utils/index.ts
@@ -1,4 +1,5 @@
 import { Accept, ErrorCode, FileError } from "react-dropzone";
+import { formatBytes } from "../../../util/formatBytes";
 import { 
   AcceptType, 
   DOCUMENT_FILES, 
@@ -54,12 +55,14 @@ export const formatAcceptFileList = (accept: Accept): string => (
 
 export const getErrorMessage = (
   { code, message }: FileError,
-  { fileList = "" }: { fileList?: string },
+  { fileList = "", maxSize }: { fileList?: string, maxSize?: number },
   textOverrides?: TextOverrides,
 ): string => {
   switch (code) {
     case ErrorCode.FileInvalidType:
       return `${textOverrides?.fileTypeError || "File type must be one of"} ${fileList}`;
+    case ErrorCode.FileTooLarge:
+      return `${textOverrides?.fileTooLargeError || "File is too large. It must be less than"} ${formatBytes(maxSize || 0)}.`;
     default:
       return message;
   }

--- a/src/lib/util/formatBytes/index.test.ts
+++ b/src/lib/util/formatBytes/index.test.ts
@@ -1,0 +1,19 @@
+import { formatBytes } from '.';
+
+describe('Format bytes', () => {
+  it('Should format to 1KB with no decimals', () => {
+    expect(formatBytes(1024)).toEqual("1 KB");
+  });
+
+  it('Should format to 1KB with two decimals', () => {
+    expect(formatBytes(1234)).toEqual("1.21 KB");
+  });
+
+  it('Should format to 0 bytes', () => {
+    expect(formatBytes(0)).toEqual("0 bytes");
+  });
+
+  it('Should format to 1MB', () => {
+    expect(formatBytes(1049000)).toEqual("1 MB");
+  });
+});

--- a/src/lib/util/formatBytes/index.test.ts
+++ b/src/lib/util/formatBytes/index.test.ts
@@ -6,11 +6,11 @@ describe('Format bytes', () => {
   });
 
   it('Should format to 1KB with two decimals', () => {
-    expect(formatBytes(1234)).toEqual("1.21 KB");
+    expect(formatBytes(1234, 2)).toEqual("1.21 KB");
   });
 
   it('Should format to 0 bytes', () => {
-    expect(formatBytes(0)).toEqual("0 bytes");
+    expect(formatBytes(0)).toEqual("0 Bytes");
   });
 
   it('Should format to 1MB', () => {

--- a/src/lib/util/formatBytes/index.ts
+++ b/src/lib/util/formatBytes/index.ts
@@ -1,0 +1,13 @@
+const k = 1024;
+const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+export function formatBytes(bytes: number, decimals = 0): string {
+  if (!+bytes) {
+    return '0 Bytes';
+  }
+
+  const dm = decimals < 0 ? 0 : decimals;
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+}


### PR DESCRIPTION
### What this PR does
Add file maxSize validation support to MultiDropZone component.

_Please include a summary of the change(s)._
1. Added support to maxSize prop and internal validation of size
2. Added formatBytes util to show more human readable information on file size

Solves:  
EMU-5671

<img width="1040" alt="Screenshot 2023-01-27 at 10 45 04" src="https://user-images.githubusercontent.com/4015038/215069994-1290b7af-4e44-4049-8226-729d2815bfb2.png">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
