### PR TITLE
fix(modal): [EMU-5698] Fix Modal not centred vertically when content grows

### DIFF
--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -36,19 +36,21 @@ export default ({
         } ${className}`}
         onClick={handleContainerClick}
       >
-        <div className={styles.header}>
-          <div className={`p-h2 ${styles.title}`}>{title}</div>
-          {dismissible && (
-            <button
-              type="button"
-              className={styles.close}
-              onClick={handleOnClose}
-            >
-              <img src={imageClose} alt="Close" />
-            </button>
-          )}
+        <div className={styles.body}>
+          <div className={styles.header}>
+            <div className={`p-h2 ${styles.title}`}>{title}</div>
+            {dismissible && (
+              <button
+                type="button"
+                className={styles.close}
+                onClick={handleOnClose}
+              >
+                <img src={imageClose} alt="Close" />
+              </button>
+            )}
+          </div>
+          {children}
         </div>
-        {children}
       </div>
     </div>
   );

--- a/src/lib/components/modal/regularModal/style.module.scss
+++ b/src/lib/components/modal/regularModal/style.module.scss
@@ -22,12 +22,12 @@
 
 @keyframes appear-in {
   0% {
-    transform: translateY(24px) translateX(-50%);
+    transform: translateY(24px);
     opacity: 0;
     visibility: hidden;
   }
   100% {
-    transform: translateY(0) translateX(-50%);
+    transform: translateY(0);
     opacity: 1;
     visibility: visible;
   }
@@ -35,12 +35,12 @@
 
 @keyframes disappear-out {
   0% {
-    transform: translateY(0) translateX(-50%);
+    transform: translateY(0);
     opacity: 1;
     visibility: visible;
   }
   100% {
-    transform: translateY(24px) translateX(-50%);
+    transform: translateY(24px);
     opacity: 0;
     visibility: hidden;
   }
@@ -70,24 +70,19 @@
 .container {
   position: relative;
 
-  background-color: white;
-
-  border-radius: 8px;
+  display: flex;
+  align-items: center;
 
   max-width: 592px;
-  width: fit-content;
-  width: -moz-fit-content;
+  width: 100%;
+  min-height: 100%;
+
+  margin: 0 auto;
 
   animation-name: appear-in;
   animation-duration: 0.4s;
   animation-fill-mode: both;
   animation-timing-function: ease-out;
-
-  top: calc(100vh / 2 - 50% / 2);
-  left: 50%;
-  transform: translateX(-50%);
-
-  margin-bottom: 80px;
 
   &--close {
     @extend .container;
@@ -97,6 +92,12 @@
     animation-fill-mode: both;
     animation-timing-function: ease-out;
   }
+}
+
+.body {
+  background-color: white;
+  border-radius: 8px;
+  margin: 32px auto;
 }
 
 .header {


### PR DESCRIPTION
### What this PR does
Fixes Modal not centred vertically when content grows

Solves:  
EMU-5698

<img width="814" alt="Screenshot 2023-02-02 at 15 25 45" src="https://user-images.githubusercontent.com/4015038/216554776-5fcbf167-493d-4ce1-9800-07c45f20919b.png">
<img width="1006" alt="Screenshot 2023-02-03 at 08 52 24" src="https://user-images.githubusercontent.com/4015038/216555025-aceabc61-43d1-4c52-8759-1febe3f81dbe.png">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
