### PR TITLE
refactor(tsconfig): [EMU-5705] Add baseUrl to tsconfig allowing relative paths

### DIFF
--- a/src/lib/components/autocompleteAddress/index.test.tsx
+++ b/src/lib/components/autocompleteAddress/index.test.tsx
@@ -1,5 +1,5 @@
 import { Address } from '@popsure/public-models';
-import { fireEvent, render } from '../../util/testUtils';
+import { fireEvent, render } from 'lib/util/testUtils';
 
 import AutoCompleteAddress from '.';
 

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -8,7 +8,7 @@ import DayPicker from 'react-day-picker';
 import {
   calendarDateToISODate,
   isoStringtoCalendarDate,
-} from '../../util/calendarDate';
+} from 'lib/util/calendarDate';
 import styles from './style.module.scss';
 import './datepicker.scss';
 import calendarIcon from './icons/calendar.svg';

--- a/src/lib/components/downloadButton/index.tsx
+++ b/src/lib/components/downloadButton/index.tsx
@@ -1,5 +1,5 @@
 import Button from '../button';
-import { DownloadStatus } from '../../models/download';
+import { DownloadStatus } from 'lib/models/download';
 
 import checkIcon from './icons/check.svg';
 import downloadIcon from './icons/download.svg';

--- a/src/lib/components/input/autoSuggestInput/index.tsx
+++ b/src/lib/components/input/autoSuggestInput/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import Autosuggest from 'react-autosuggest';
 
 import styles from './style.module.scss';
-import { Option } from '../../../models/autoSuggestInput';
+import { Option } from 'lib/models/autoSuggestInput';
 import Input, { InputProps } from '../index';
 
 export default ({

--- a/src/lib/components/input/autoSuggestMultiSelect/index.tsx
+++ b/src/lib/components/input/autoSuggestMultiSelect/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Option } from '../../../models/autoSuggestInput';
+import { Option } from 'lib/models/autoSuggestInput';
 import Chip from '../../chip';
 import AutoSuggestInput from '../autoSuggestInput';
 import styles from './style.module.scss';

--- a/src/lib/components/input/currency/index.test.tsx
+++ b/src/lib/components/input/currency/index.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '../../../util/testUtils';
+import { render } from 'lib/util/testUtils';
 
 import CurrencyInput from '.';
 

--- a/src/lib/components/multiDropzone/index.test.tsx
+++ b/src/lib/components/multiDropzone/index.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render } from '../../util/testUtils';
+import { act, fireEvent, render } from 'lib/util/testUtils';
 import '@testing-library/jest-dom';
 
 import MultiDropzone, { MultiDropzoneProps } from '.';

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -21,7 +21,7 @@ import {
   UploadedFile, 
   UploadStatus 
 } from './types';
-import { formatBytes } from '../../util/formatBytes';
+import { formatBytes } from 'lib/util/formatBytes';
 
 interface MultiDropzoneProps {
   accept?: AcceptType;

--- a/src/lib/components/multiDropzone/utils/index.ts
+++ b/src/lib/components/multiDropzone/utils/index.ts
@@ -1,5 +1,5 @@
 import { Accept, ErrorCode, FileError } from "react-dropzone";
-import { formatBytes } from "../../../util/formatBytes";
+import { formatBytes } from "lib/util/formatBytes";
 import { 
   AcceptType, 
   DOCUMENT_FILES, 

--- a/src/lib/components/segmentedControl/index.test.tsx
+++ b/src/lib/components/segmentedControl/index.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '../../util/testUtils';
+import { render } from 'lib/util/testUtils';
 
 import SegmentedControl from '.';
 

--- a/src/lib/util/calendarDate/index.ts
+++ b/src/lib/util/calendarDate/index.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { CalendarDate } from '@popsure/public-models';
 
-import { zerofill } from '../../util/zeroFill';
+import { zerofill } from 'lib/util/zeroFill';
 
 dayjs.extend(customParseFormat);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./src",
     "rootDir": "src",
     "outDir": "dist",
     "module": "esnext",


### PR DESCRIPTION
## What this PR does
Adds baseUrl to tsconfig allowing relative paths. This allows to use
```
import foo from "lib/utils/foo";
```
instead of

```
import bar from "../../../utils/bar";
```

Note: Not possible to add just `from "utils/foo"` as this is not supported by Create React App.

Solves:  
EMU-5705

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
