### PR TITLE
refactor(tsconfig): [EMU-5705] Add baseUrl to tsconfig allowing relative paths

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Install NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.10.0'
+          cache: 'yarn'
+
       - name: yarn install & build-storybook
         run: |
           yarn install

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "react-is": "^17.0.2",
     "react-scripts": "4.0.3",
     "rollup": "^2.52.2",
+    "rollup-plugin-includepaths": "^0.2.4",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import typescript from '@rollup/plugin-typescript';
 import commonjs from '@rollup/plugin-commonjs';
 import external from 'rollup-plugin-peer-deps-external';
+import includePaths from 'rollup-plugin-includepaths';
 import postcss from 'rollup-plugin-postcss';
 import resolve from 'rollup-plugin-node-resolve';
 import url from 'rollup-plugin-url';
@@ -28,6 +29,7 @@ const plugins = [
   }),
   url(),
   resolve(),
+  includePaths({ paths: ['src'] }),
   commonjs(),
 ];
 
@@ -49,7 +51,7 @@ export default [
       glob
         // we need to look into why adding ts breaks the build
         .sync('src/lib/**/*(*.tsx)')
-        .map((file) => [
+      .map((file) => [
           path.relative(
             'src/lib',
             file.slice(0, file.length - path.extname(file).length)

--- a/src/lib/components/autocompleteAddress/index.test.tsx
+++ b/src/lib/components/autocompleteAddress/index.test.tsx
@@ -1,5 +1,5 @@
 import { Address } from '@popsure/public-models';
-import { fireEvent, render } from '../../util/testUtils';
+import { fireEvent, render } from 'lib/util/testUtils';
 
 import AutoCompleteAddress from '.';
 

--- a/src/lib/components/chip/index.tsx
+++ b/src/lib/components/chip/index.tsx
@@ -1,7 +1,7 @@
 import styles from './style.module.scss';
 import removeButtonIcon from './icons/remove-button.svg';
 import removeButtonHighlightedIcon from './icons/remove-button-highlighted.svg';
-import { Option } from '../../models/autoSuggestInput';
+import { Option } from 'lib/models/autoSuggestInput';
 
 export default ({
   value,

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -8,7 +8,7 @@ import DayPicker from 'react-day-picker';
 import {
   calendarDateToISODate,
   isoStringtoCalendarDate,
-} from '../../util/calendarDate';
+} from 'lib/util/calendarDate';
 import styles from './style.module.scss';
 import './datepicker.scss';
 import calendarIcon from './icons/calendar.svg';

--- a/src/lib/components/downloadButton/index.tsx
+++ b/src/lib/components/downloadButton/index.tsx
@@ -1,5 +1,5 @@
 import Button from '../button';
-import { DownloadStatus } from '../../models/download';
+import { DownloadStatus } from 'lib/models/download';
 
 import checkIcon from './icons/check.svg';
 import downloadIcon from './icons/download.svg';

--- a/src/lib/components/input/autoSuggestInput/index.tsx
+++ b/src/lib/components/input/autoSuggestInput/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import Autosuggest from 'react-autosuggest';
 
 import styles from './style.module.scss';
-import { Option } from '../../../models/autoSuggestInput';
+import { Option } from 'lib/models/autoSuggestInput';
 import Input, { InputProps } from '../index';
 
 export default ({

--- a/src/lib/components/input/autoSuggestMultiSelect/index.tsx
+++ b/src/lib/components/input/autoSuggestMultiSelect/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Option } from '../../../models/autoSuggestInput';
+import { Option } from 'lib/models/autoSuggestInput';
 import Chip from '../../chip';
 import AutoSuggestInput from '../autoSuggestInput';
 import styles from './style.module.scss';

--- a/src/lib/components/input/currency/index.test.tsx
+++ b/src/lib/components/input/currency/index.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '../../../util/testUtils';
+import { render } from 'lib/util/testUtils';
 
 import CurrencyInput from '.';
 

--- a/src/lib/components/multiDropzone/index.test.tsx
+++ b/src/lib/components/multiDropzone/index.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render } from '../../util/testUtils';
+import { act, fireEvent, render } from 'lib/util/testUtils';
 import '@testing-library/jest-dom';
 
 import MultiDropzone, { MultiDropzoneProps } from '.';

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -21,8 +21,7 @@ import {
   UploadedFile, 
   UploadStatus 
 } from './types';
-
-import { formatBytes } from '../../util/formatBytes';
+import { formatBytes } from 'lib/util/formatBytes';
 
 interface MultiDropzoneProps {
   accept?: AcceptType;

--- a/src/lib/components/multiDropzone/utils/index.ts
+++ b/src/lib/components/multiDropzone/utils/index.ts
@@ -1,5 +1,5 @@
 import { Accept, ErrorCode, FileError } from "react-dropzone";
-import { formatBytes } from "../../../util/formatBytes";
+import { formatBytes } from "lib/util/formatBytes";
 import { 
   AcceptType, 
   DOCUMENT_FILES, 

--- a/src/lib/components/segmentedControl/index.test.tsx
+++ b/src/lib/components/segmentedControl/index.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '../../util/testUtils';
+import { render } from 'lib/util/testUtils';
 
 import SegmentedControl from '.';
 

--- a/src/lib/util/calendarDate/index.ts
+++ b/src/lib/util/calendarDate/index.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { CalendarDate } from '@popsure/public-models';
 
-import { zerofill } from '../../util/zeroFill';
+import { zerofill } from 'lib/util/zeroFill';
 
 dayjs.extend(customParseFormat);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./src",
     "rootDir": "src",
     "outDir": "dist",
     "module": "esnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13348,6 +13348,11 @@ rollup-plugin-babel@^4.3.3:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-includepaths@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-includepaths/-/rollup-plugin-includepaths-0.2.4.tgz#eb21d2d05ad410856a7c2f0612a85983fd11cc62"
+  integrity sha512-iZen+XKVExeCzk7jeSZPJKL7B67slZNr8GXSC5ROBXtDGXDBH8wdjMfdNW5hf9kPt+tHyIvWh3wlE9bPrZL24g==
+
 rollup-plugin-node-resolve@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz"


### PR DESCRIPTION
## What this PR does
Adds baseUrl to tsconfig allowing relative paths. This allows to use
```
import foo from "lib/utils/foo";
```
instead of

```
import bar from "../../../utils/bar";
```

Note: Not possible to add just `from "utils/foo"` as this is not supported by Create React App.

Solves:  
EMU-5705

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
