### PR TITLE
feat(github workflow): [noticket] Add github action for generating release drafts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,84 @@
+name-template: 'dirty-swan: v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'Feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'Fix'
+  - title: '🛠 Maintenance'
+    labels:
+      - 'Build'
+      - 'CI'
+      - 'Test'
+      - 'Style'
+      - 'Refactor'
+  - title: '❓Misc'
+    labels:
+      - 'Documentation'
+      - 'Chore'
+      - 'Revert'
+autolabeler:
+  - label: 'Feature'
+    title:
+      - '/feat(\(.+\))?!?: .+/'
+  - label: 'Fix'
+    title:
+      - '/fix(\(.+\))?!?: .+/'
+  - label: 'Documentation'
+    title:
+      - '/docs(\(.+\))?!?: .+/'
+  - label: 'Style'
+    title:
+      - '/style(\(.+\))?!?: .+/'
+  - label: 'Refactor'
+    title:
+      - '/refactor(\(.+\))?!?: .+/'
+  - label: 'Performance'
+    title:
+      - '/perf(\(.+\))?!?: .+/'
+  - label: 'Test'
+    title:
+      - '/test(\(.+\))?!?: .+/'
+  - label: 'Build'
+    title:
+      - '/build(\(.+\))?!?: .+/'
+  - label: 'CI'
+    title:
+      - '/ci(\(.+\))?!?: .+/'
+  - label: 'Chore'
+    title:
+      - '/chore(\(.+\))?!?: .+/'
+  - label: 'Revert'
+    title:
+      - '/revert(\(.+\))?!?: .+/'
+  - label: 'Breaking'
+    title:
+      - '/^[a-z]+!: .+/'
+version-resolver:
+  major:
+    labels:
+      - 'Breaking'
+  minor:
+    labels:
+      - 'Feature'
+      - 'Style'
+  patch:
+    labels:
+      - 'Refactor'
+      - 'Performance'
+      - 'Fix'
+      - 'Documentation'
+      - 'Test'
+      - 'Build'
+      - 'CI'
+      - 'Chore'
+  default: patch
+
+template: |
+  # What’s Changed 🤩
+  _Please insert human readable changelog based on the raw changelog_
+
+  # Raw changelog 📃
+  $CHANGES

--- a/.github/workflows/generate-release-draft.yml
+++ b/.github/workflows/generate-release-draft.yml
@@ -1,0 +1,17 @@
+name: Generate release draft
+
+on:
+  push:
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What this PR does
Add github action for generating release drafts on PR being merged to main.

**Note:** Tests seem to be failing because of missing `.github/release-drafter.yml` file on default branch but it is included on this PR as well so should be working on main. If needed we can add the files in two separate PRs.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
