### PR TITLE
refactor(comparison table): [EMU-5713] Add TableButton to TableRowHeader component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,7 @@ export {
   TableRating,
   TableTrueFalse,
   TableRowHeader,
+  TableButton,
   TableInfoButton,
   SegmentedControl,
   DownloadButton,

--- a/src/lib/components/comparisonTable/components/TableButton/index.test.tsx
+++ b/src/lib/components/comparisonTable/components/TableButton/index.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '../../../../util/testUtils';
+import '@testing-library/jest-dom';
+
+import TableButton from '.';
+
+const mockOnClick = jest.fn();
+
+const buttonContent = "Table Button label";
+
+const setup = () => render(
+  <TableButton onClick={mockOnClick}>{buttonContent}</TableButton>
+);
+
+describe('TableButton component', () => {
+  it("should render button content", () => {
+    const { getByText } = setup();
+
+    expect(getByText(buttonContent)).toBeInTheDocument();
+  });
+
+  it("should call onClick", async () => {
+    const { getByText, user } = setup();
+
+    await user.click(getByText(buttonContent));
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/comparisonTable/components/TableButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableButton/index.tsx
@@ -10,15 +10,13 @@ const TableButton: React.FC<Props> = ({
   onClick,
   className = '',
 }) => (
-  <span
+  <button
     className={`${styles.button} ${className}`}
     data-testid="ds-table-button"
     onClick={onClick}
-    role="button"
-    tabIndex={0}
   >
     {children}
-  </span>
+  </button>
 );
 
 export default TableButton;

--- a/src/lib/components/comparisonTable/components/TableButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableButton/index.tsx
@@ -1,0 +1,24 @@
+import styles from './style.module.scss';
+
+interface Props {
+  onClick: () => void;
+  className?: string;
+}
+
+const TableButton: React.FC<Props> = ({
+  children,
+  onClick,
+  className = '',
+}) => (
+  <span
+    className={`${styles.button} ${className}`}
+    data-testid="ds-table-button"
+    onClick={onClick}
+    role="button"
+    tabIndex={0}
+  >
+    {children}
+  </span>
+);
+
+export default TableButton;

--- a/src/lib/components/comparisonTable/components/TableButton/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableButton/style.module.scss
@@ -1,10 +1,11 @@
 @use "../../../../scss/public/colors" as *;
 
 .button {
+  background-color: transparent;
   border-bottom: 2px dashed $ds-grey-600;
   color: $ds-grey-700;
   cursor: pointer;
-  padding: 2px 0;
+  padding: 2px;
   transition: 0.3s ease;
   transition-property: color, border-color;
 
@@ -12,5 +13,6 @@
   &:focus {
     border-color: $ds-primary-500;
     color: $ds-primary-500;
+    outline-color: $ds-primary-500;
   }
 }

--- a/src/lib/components/comparisonTable/components/TableButton/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableButton/style.module.scss
@@ -1,0 +1,16 @@
+@use "../../../../scss/public/colors" as *;
+
+.button {
+  border-bottom: 2px dashed $ds-grey-600;
+  color: $ds-grey-700;
+  cursor: pointer;
+  padding: 2px 0;
+  transition: 0.3s ease;
+  transition-property: color, border-color;
+
+  &:hover,
+  &:focus {
+    border-color: $ds-primary-500;
+    color: $ds-primary-500;
+  }
+}

--- a/src/lib/components/comparisonTable/components/TableRowHeader/index.test.tsx
+++ b/src/lib/components/comparisonTable/components/TableRowHeader/index.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '../../../../util/testUtils';
+import '@testing-library/jest-dom';
+
+import TableRowHeader, { TableRowHeaderProps } from '.';
+
+const mockOnClick = jest.fn();
+
+const label = "Table label";
+const subtitle = "Subtitle label";
+const icon = "🎉";
+const buttonTestId = "ds-table-button";
+
+const setup = (props: Partial<TableRowHeaderProps> = {}) => render(
+  <TableRowHeader 
+    label={label} 
+    {...props}
+  />
+);
+
+describe('TableRowHeader component', () => {
+  it("should render label", () => {
+    const { getByText } = setup();
+
+    expect(getByText(label)).toBeInTheDocument();
+  });
+
+  it("should not render subtitle", () => {
+    const { queryByText } = setup();
+
+    expect(queryByText(subtitle)).not.toBeInTheDocument();
+  });
+
+  it("should render subtitle", () => {
+    const { getByText } = setup({ subtitle });
+
+    expect(getByText(subtitle)).toBeInTheDocument();
+  });
+
+  it("should not render icon", () => {
+    const { queryByText } = setup();
+
+    expect(queryByText(icon)).not.toBeInTheDocument();
+  });
+
+  it("should render icon", () => {
+    const { getByText } = setup({ icon });
+
+    expect(getByText(icon)).toBeInTheDocument();
+  });
+
+  it("should not render button if onClickInfo is not defined", () => {
+    const { queryByTestId } = setup();
+
+    expect(queryByTestId(buttonTestId)).not.toBeInTheDocument();
+  });
+
+  it("should render button if onClickInfo is defined", () => {
+    const { getByTestId } = setup({ onClickInfo: mockOnClick });
+
+    expect(getByTestId(buttonTestId)).toBeInTheDocument();
+  });
+
+  it("should not call onClickInfo if not defined", async () => {
+    const { getByText, user } = setup();
+
+    await user.click(getByText(label));
+
+    expect(mockOnClick).not.toHaveBeenCalled();
+  });
+
+  it("should call onClickInfo if defined", async () => {
+    const { getByText, user } = setup({ onClickInfo: mockOnClick });
+
+    await user.click(getByText(label));
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/comparisonTable/components/TableRowHeader/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableRowHeader/index.tsx
@@ -1,35 +1,30 @@
-import React from 'react';
-import classNames from 'classnames';
-
-import TableInfoButton from '../TableInfoButton';
-
+import TableButton from '../TableButton';
 import styles from './style.module.scss';
 
-const TableRowHeader = (props: {
+interface TableRowHeaderProps {
   label: string;
   icon?: string;
   subtitle?: string;
   onClickInfo?: () => void;
-}) => {
-  const { icon, label, subtitle, onClickInfo } = props;
-  return (
-    <div className="d-flex">
-      <span className={`mr8 ${styles.icon}`}>{icon}</span>
-      <div>
-        <p className="p-p d-inline">
-          <span
-            className={classNames({
-              mr8: onClickInfo,
-            })}
-          >
-            {label}
-          </span>
-          {onClickInfo && <TableInfoButton onClick={onClickInfo} />}
-        </p>
-        {subtitle && <p className="p-p--small tc-grey-500">{subtitle}</p>}
-      </div>
-    </div>
-  );
-};
+}
 
+const TableRowHeader = ({ icon, label, subtitle, onClickInfo }: TableRowHeaderProps) => (
+  <div className="d-flex">
+    {icon && <span className={`mr8 ${styles.icon}`}>{icon}</span>}
+    <div>
+      <p className="p-p d-inline">
+        {!onClickInfo ? (
+          <span>{label}</span>
+        ) : (
+          <TableButton className="mr8" onClick={onClickInfo}>
+            {label}
+          </TableButton>
+        )}
+      </p>
+      {subtitle && <p className="p-p--small tc-grey-500">{subtitle}</p>}
+    </div>
+  </div>
+);
+
+export type { TableRowHeaderProps };
 export default TableRowHeader;

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
-import { ComparisonTable, TableRating, TableTrueFalse } from '.';
+import { ComparisonTable, TableRating, TableRowHeader, TableButton, TableTrueFalse } from '.';
 
 <Meta title="JSX/Comparison Table" component={ComparisonTable} />
 
@@ -81,8 +81,12 @@ export const ComparisonTableWithData = () => {
         {
           id: 3,
           key: 'rating',
-          label: 'Our rating',
-          render: (value) => <TableRating type="star" rating={value} />,
+          label: <TableRowHeader label="Our Rating" onClickInfo={console.log} />,
+          render: (value) => (
+            <TableButton className="jc-center" onClick={console.log}>
+              <TableRating type="star" rating={value} />
+            </TableButton>
+          ),
         },
         {
           id: 5,
@@ -297,8 +301,12 @@ export const ComparisonTableWithData = () => {
         {
           id: 3,
           key: 'rating',
-          label: 'Our rating',
-          render: (value) => <TableRating type="star" rating={value} />,
+          label: <TableRowHeader label="Our Rating" onClickInfo={console.log} />,
+          render: (value) => (
+            <TableButton className="jc-center" onClick={console.log}>
+              <TableRating type="star" rating={value} />
+            </TableButton>
+          ),
         },
         {
           id: 5,

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -5,6 +5,7 @@ import { AccordionItem } from './components/AccordionItem';
 import Chevron from './components/Chevron';
 import Row from './components/Row';
 import TableArrows from './components/TableArrows';
+import TableButton from './components/TableButton';
 import TableInfoButton from './components/TableInfoButton';
 import TableRating from './components/TableRating';
 import TableRowHeader from './components/TableRowHeader';
@@ -257,6 +258,7 @@ const ComparisonTable = <T extends { id: number }>(
 
 export {
   ComparisonTable,
+  TableButton,
   TableInfoButton,
   TableRating,
   TableRowHeader,

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -32,6 +32,7 @@ import {
   TableRating,
   TableTrueFalse,
   TableRowHeader,
+  TableButton,
   TableInfoButton,
   TableHeader,
 } from './components/comparisonTable';
@@ -70,6 +71,7 @@ export {
   TableRating,
   TableTrueFalse,
   TableRowHeader,
+  TableButton,
   TableInfoButton,
   SegmentedControl,
   Markdown,


### PR DESCRIPTION
### What this PR does

1. Adds TableButton component and exports it
2. Hides icon span when icon is not passed to TableRowHeader
3. Updates TableRowHeader to use TableButton instead of TableInfoButton
4. Adds tests to TableButton and TableRowHeader component
5. Adds an example of TableRowHeader and TableButton components to ComparisonTable story, as shown on the screenshot below

<img width="1051" alt="Screenshot 2023-02-07 at 13 45 15" src="https://user-images.githubusercontent.com/4015038/217262430-c2b05ed4-b5f5-4b57-beaf-549fc4ff8965.png">

### Why is this needed?

_Please include additional context of why this PR is necessary._

Solves:  
[EMU-5713](https://linear.app/feather-insurance/issue/EMU-5713/update-comparisontable-component-styles)

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
