### PR TITLE
fix(multidropzone): [noticket] Remove unused uploaded filetype and export types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,13 @@ export {
   Markdown,
 } from './lib';
 
-export type { TableHeader, DownloadStatus } from './lib';
+export type {
+  DownloadStatus,
+  FileType,
+  MultiDropzoneProps,
+  TableHeader,
+  UploadedFile,
+  UploadStatus
+ } from './lib';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/lib/components/multiDropzone/types.ts
+++ b/src/lib/components/multiDropzone/types.ts
@@ -24,7 +24,6 @@ export const IMAGE_FILES: FileType[] = ['heic', 'bmp', 'jpeg', 'jpg', 'png'];
 export interface UploadedFile {
   id: string;
   name: string;
-  type?: FileType | string;
   previewUrl?: string;
   progress: number;
   error?: string;

--- a/src/lib/components/multiDropzone/types.ts
+++ b/src/lib/components/multiDropzone/types.ts
@@ -24,7 +24,7 @@ export const IMAGE_FILES: FileType[] = ['heic', 'bmp', 'jpeg', 'jpg', 'png'];
 export interface UploadedFile {
   id: string;
   name: string;
-  type?: FileType;
+  type?: FileType | string;
   previewUrl?: string;
   progress: number;
   error?: string;

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -39,13 +39,6 @@ import {
 import SegmentedControl from './components/segmentedControl';
 import Markdown from './components/markdown';
 
-export type {
-  FileType,
-  MultiDropzoneProps,
-  UploadedFile,
-  UploadStatus
-};
-
 export {
   DateSelector,
   SignaturePad,
@@ -77,6 +70,12 @@ export {
   Markdown,
 };
 
-export type { TableHeader };
+export type {
+  FileType,
+  MultiDropzoneProps,
+  TableHeader,
+  UploadedFile,
+  UploadStatus
+};
 
 export type { DownloadStatus } from './models/download';


### PR DESCRIPTION
### What this PR does
Removed uploaded as this value is not used anymore.
This also adds MultiDropzone types to be exported from lib index file.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
