### PR TITLE
fix(comparison table): [noticket] Fix addon to be full width

### DIFF
--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -112,12 +112,12 @@ h4.cell {
   }
 }
 
-.addon {
-  width: 100%;
+h4.addon {
   border-right: none;
-  max-width: 100vw;
+  max-width: calc(100vw - 64px);
+  width: 100vw;
 
   @include p-size-desktop {
-    max-width: 944px;
+    max-width: 976px;
   }
 }

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -1,6 +1,14 @@
 import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
-import { ComparisonTable, TableRating, TableRowHeader, TableButton, TableTrueFalse } from '.';
+import { CardButton } from '../cards';
+
+import {
+  ComparisonTable,
+  TableButton,
+  TableRating,
+  TableRowHeader,
+  TableTrueFalse,
+} from '.';
 
 <Meta title="JSX/Comparison Table" component={ComparisonTable} />
 
@@ -81,9 +89,9 @@ export const ComparisonTableWithData = () => {
         {
           id: 3,
           key: 'rating',
-          label: <TableRowHeader label="Our Rating" onClickInfo={console.log} />,
+          label: <TableRowHeader label="Our Rating" onClickInfo={() => {}} />,
           render: (value) => (
-            <TableButton className="jc-center" onClick={console.log}>
+            <TableButton className="jc-center" onClick={() => {}}>
               <TableRating type="star" rating={value} />
             </TableButton>
           ),
@@ -158,6 +166,16 @@ export const ComparisonTableWithData = () => {
               style: 'currency',
               currency: 'EUR',
             }),
+        },
+        {
+          addonId: 'addon-movies',
+          label: (
+            <CardButton
+              title="All Review"
+              description="Click here to read all reviews"
+              onClick={() => {}}
+            />
+          ),
         },
       ],
     },
@@ -301,9 +319,9 @@ export const ComparisonTableWithData = () => {
         {
           id: 3,
           key: 'rating',
-          label: <TableRowHeader label="Our Rating" onClickInfo={console.log} />,
+          label: <TableRowHeader label="Our Rating" onClickInfo={() => {}} />,
           render: (value) => (
-            <TableButton className="jc-center" onClick={console.log}>
+            <TableButton className="jc-center" onClick={() => {}}>
               <TableRating type="star" rating={value} />
             </TableButton>
           ),
@@ -329,6 +347,16 @@ export const ComparisonTableWithData = () => {
               style: 'currency',
               currency: 'EUR',
             }),
+        },
+        {
+          addonId: 'addon-movies',
+          label: (
+            <CardButton
+              title="All Review"
+              description="Click here to read all reviews"
+              onClick={() => {}}
+            />
+          ),
         },
       ],
     },


### PR DESCRIPTION
### What this PR does
Fix comparison table addon to be full width. 
Since `.cell` styles had an `h4` preffix, it was needed to add the same preffix to addon as well so that styles weren't overriden.
This PR also fine tunes the addon width styles.


![Screenshot 2023-02-13 at 11 55 07](https://user-images.githubusercontent.com/4015038/218451657-7e6469ac-62bc-45d5-8429-c796d1861749.png)
![Screenshot 2023-02-13 at 11 54 26](https://user-images.githubusercontent.com/4015038/218451650-73503458-71f9-4665-a454-fdf992686784.png)

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
