### PR TITLE
refactor(uuid): [noticket]: Replace uuid package with generateId util

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "react-scroll-sync": "^0.9.0",
     "remark-directive": "^2.0.1",
     "sass": "^1.35.1",
-    "signature_pad": "^3.0.0-beta.3",
-    "uuid": "^8.3.2"
+    "signature_pad": "^3.0.0-beta.3"
   },
   "peerDependencies": {
     "react": "^16.12.0",
@@ -98,7 +97,6 @@
     "@types/react-dom": "^17.0.8",
     "@types/react-scroll-sync": "^0.8.2",
     "@types/sass": "^1.16.0",
-    "@types/uuid": "^9.0.0",
     "babel-core": "^6.26.3",
     "babel-runtime": "^6.26.0",
     "cross-env": "^7.0.3",

--- a/src/lib/components/input/index.tsx
+++ b/src/lib/components/input/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import classnames from 'classnames';
-import { v4 as uuidv4 } from 'uuid';
+import generateId from '../../util/generateId';
 
 import styles from './style.module.scss';
 
@@ -29,7 +29,7 @@ export default React.forwardRef(
     }: InputProps,
     ref?: React.ForwardedRef<HTMLInputElement>
   ) => {
-    const [uniqueId] = useState(id ?? uuidv4());
+    const [uniqueId] = useState(id ?? generateId());
     return (
       <div className={`${styles.container} ${className ?? ''}`}>
         {label && (

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import classnames from 'classnames';
 import { useDropzone, FileRejection } from 'react-dropzone';
 import AnimateHeight from 'react-animate-height';
-import { v4 as uuidv4 } from 'uuid';
+import generateId from '../../util/generateId';
 import styles from './style.module.scss';
 import icons from './icons/index'; // TODO: inline all of the svgs
 import UploadFileCell from './UploadFileCell';
@@ -67,7 +67,7 @@ const placeholder = `${textOverrides?.supportsTextShort || "Supports"} ${fileLis
       setErrors((previousErrors) => ([
         ...previousErrors,
         ...filesRejected.map(({ errors }) => ({
-          id: uuidv4(),
+          id: generateId(),
           message: getErrorMessage(
             errors[0],
             { fileList, maxSize },

--- a/src/lib/util/generateId/index.test.ts
+++ b/src/lib/util/generateId/index.test.ts
@@ -1,0 +1,10 @@
+import generateId from '.';
+
+describe('generateId', () => {
+  it('should return two different ids', () => {
+    const firstId = generateId();
+    const secondId = generateId();
+
+    expect(firstId).not.toEqual(secondId);
+  });
+});

--- a/src/lib/util/generateId/index.ts
+++ b/src/lib/util/generateId/index.ts
@@ -1,0 +1,7 @@
+function generateId(): string {  
+  return 'xxxx-xxxx-xxx-xxxx'.replace(/[x]/g, () => (
+    Math.floor(Math.random() * 16).toString(16)
+  ));  
+}
+
+export default generateId;

--- a/src/lib/util/generateId/index.ts
+++ b/src/lib/util/generateId/index.ts
@@ -1,7 +1,11 @@
 function generateId(): string {  
-  return 'xxxx-xxxx-xxx-xxxx'.replace(/[x]/g, () => (
-    Math.floor(Math.random() * 16).toString(16)
-  ));  
+  if (!window?.crypto?.randomUUID) {
+    return 'xxxx-xxxx-xxx-xxxx'.replace(/[x]/g, () => (
+      Math.floor(Math.random() * 16).toString(16)
+    ));
+  }
+
+  return crypto.randomUUID();
 }
 
 export default generateId;

--- a/src/lib/util/generateId/index.ts
+++ b/src/lib/util/generateId/index.ts
@@ -1,11 +1,15 @@
-function generateId(): string {  
-  if (!window?.crypto?.randomUUID) {
-    return 'xxxx-xxxx-xxx-xxxx'.replace(/[x]/g, () => (
-      Math.floor(Math.random() * 16).toString(16)
-    ));
+function generateId(): string {
+  if (window?.crypto?.getRandomValues) {
+    return (
+      `${[1e7]}-${1e3}-${4e3}-${8e3}-${1e11}`).replace(/[018]/g,
+      (c: any) =>
+        (((c ^ window.crypto.getRandomValues(new Uint8Array(1))[0]) & 15) >> c / 4).toString(16)
+    );
   }
 
-  return crypto.randomUUID();
+  return 'xxxx-xxxx-xxx-xxxx'.replace(/[x]/g, () => (
+    Math.floor(Math.random() * 16).toString(16)
+  ));
 }
 
 export default generateId;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,11 +3049,6 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/uuid@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
-  integrity sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==
-
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
   resolved "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.0.tgz"
@@ -15256,7 +15251,7 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
### What this PR does
Replaces uuid package with a custom and simpler generateId util.

### Why is this needed?
uuid package can't be tree-shaked and was adding a giant additional size to repos where it was being imported.
Usually, using random for random ids is not the most efficient way but since this ids are not persistent and used for runtime only (generate label/input ids, temporary ids for error entries) this downgrade from uuid might make sense.

Named the util generateId so it doesn't suggest it is a fully and standardised uuid and replaces the function.
The id generated is based on a random number that is then parsed into an hex string for each of the characters.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
