### PR TITLE
fix(comparison table): Update default header width size

### DIFF
--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -8,7 +8,7 @@ $cell-min-width: var(--cellWidth, 256px);
 
   & > div {
     width: var(--tableWidth);
-    max-width: var(--tableWidth);
+    max-width: calc(100vw - 32px);
 
     &:nth-child(n + 3) {
       margin: 0;

--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -8,6 +8,7 @@ $cell-min-width: var(--cellWidth, 256px);
 
   & > div {
     width: var(--tableWidth);
+    // 100% of viewport width minus 16px horizontal padding
     max-width: calc(100vw - 32px);
 
     &:nth-child(n + 3) {

--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -5,7 +5,7 @@ import { ArrowValues } from '../components/TableArrows';
 
 export const useComparisonTable = () => {
   const [showMore, setShowMore] = useState<boolean>(false);
-  const [headerWidth, setHeaderWidth] = useState(0);
+  const [headerWidth, setHeaderWidth] = useState(1400);
 
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 


### PR DESCRIPTION
### What this PR does
This PR updates the default header width size from 0 to 1400.
This doesn't break any layout as there are resize observers updating to the final size. However, this improves the initial rendering making the content not glitch/jump since 1400 is closer to 100% than 0 and content shouldn't grow over 100% of viewport anyway. The purpose of this is to fix flaky tests. Not using window width since it breaks on SSR.

### Checklist:

- [X] I reviewed my own code
- [X] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [X] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [X] I have updated the task(s) status on Linear
- [X] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [ ] Edge
