### PR TITLE
fix(test-build-storybook): Set fixed version of node

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Install NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.10.0'
+          cache: 'yarn'
+
       - name: yarn install & build-storybook
         run: |
           yarn install


### PR DESCRIPTION
### What this PR does
Set fixed `v16.10.0` version of node when running `test-build-storybook`.

### Why is this needed?
Current PRs were[ failing when building storybook](https://github.com/getPopsure/dirty-swan/actions/runs/4231087840/jobs/7349172627) since github actions were somehow using node v17 instead of the ones used previously. No changes were made before to trigger this error.

### Checklist:

- [X] I reviewed my own code
- [X] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [X] Firefox
- [X] Chrome
- [X] Safari
- [X] Edge
