### PR TITLE
fix(deploy-storybook): Set fixed version of node

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Install NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: '16.10.0'
+          node-version: '16'
           cache: 'yarn'
 
       - name: yarn install & build-storybook


### PR DESCRIPTION
### What this PR does
Set fixed `v16.10.0` version of node when running `deploy-storybook-to-gh-pages`.

Why is this needed?
Current deploy is [failing when deploying storybook](https://github.com/getPopsure/dirty-swan/actions/runs/4232126452) since github actions were somehow using node v17 instead of the ones used previously. No changes were made before to trigger this error.

Solves:  
STO-XXX  
EMU-XXX

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
