### PR TITLE
refactor(fonts): switch from import to font-face

### DIFF
--- a/src/lib/scss/private/base/_typography.scss
+++ b/src/lib/scss/private/base/_typography.scss
@@ -5,8 +5,25 @@
 
 @font-face {
   font-family: 'Merriweather';
+  font-style: normal;
+  font-weight: 700;
   font-display: swap;
-  src: url('https://fonts.googleapis.com/css?family=Merriweather:700&display=swap');
+  src: url(https://fonts.gstatic.com/s/merriweather/v30/u-4n0qyriQwlOrhSvowK_l52xwNZVsf6hPvhPUWH.woff2)
+    format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
+    U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: 'Merriweather';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/merriweather/v30/u-4n0qyriQwlOrhSvowK_l52xwNZWMf6hPvhPQ.woff2)
+    format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
 }
 
 body {

--- a/src/lib/scss/private/base/_typography.scss
+++ b/src/lib/scss/private/base/_typography.scss
@@ -3,7 +3,11 @@
 @use '../../public/grid' as *;
 @use '../../public/font' as *;
 
-@import url('https://fonts.googleapis.com/css?family=Merriweather:700&display=swap');
+@font-face {
+  font-family: 'Merriweather';
+  font-display: swap;
+  src: url('https://fonts.googleapis.com/css?family=Merriweather:700&display=swap');
+}
 
 body {
   font-family: $font-family;

--- a/src/lib/scss/public/font/default.scss
+++ b/src/lib/scss/public/font/default.scss
@@ -1,7 +1,24 @@
 @font-face {
   font-family: 'Lato';
+  font-style: normal;
+  font-weight: 700;
   font-display: swap;
-  src: url('https://fonts.googleapis.com/css?family=Lato:400,700&display=swap');
+  src: url(https://fonts.gstatic.com/s/lato/v23/S6u9w4BMUTPHh6UVSwaPGQ3q5d0N7w.woff2)
+    format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
+    U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: 'Lato';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/lato/v23/S6u9w4BMUTPHh6UVSwiPGQ3q5d0.woff2)
+    format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
 }
 
 $font-family: 'Lato', sans-serif !default;

--- a/src/lib/scss/public/font/default.scss
+++ b/src/lib/scss/public/font/default.scss
@@ -1,3 +1,7 @@
-@import url('https://fonts.googleapis.com/css?family=Lato:400,700&display=swap');
+@font-face {
+  font-family: 'Lato';
+  font-display: swap;
+  src: url('https://fonts.googleapis.com/css?family=Lato:400,700&display=swap');
+}
 
 $font-family: 'Lato', sans-serif !default;


### PR DESCRIPTION
### What this PR does

Switch from @import to @font-face when loading fonts to prevent blocking

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
