### PR TITLE
fix(modal): Fix margin and overlay area

### DIFF
--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -15,7 +15,12 @@ export default ({
   dismissible = true,
 }: Props) => {
   const [containerXOffset, setContainerXOffset] = useState(0);
-  const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
+  const {
+    isClosing,
+    handleContainerClick,
+    handleOnClose,
+    handleOnOverlayClick
+   } = useOnClose(
     onClose,
     isOpen,
     dismissible
@@ -39,7 +44,7 @@ export default ({
   return (
     <div
       className={isClosing ? styles['overlay--close'] : styles.overlay}
-      onClick={handleOnClose}
+      onClick={handleOnOverlayClick}
     >
       <div
         className={`${

--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -1,10 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
+interface OnCloseReturn {
+  isClosing: boolean;
+  handleContainerClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  handleOnClose: () => void;
+  handleOnOverlayClick: () => void;
+}
+
 const useOnClose = (
   onClose: () => void,
   isOpen: boolean,
   dismissable: boolean
-) => {
+): OnCloseReturn => {
   const [isClosing, setIsClosing] = useState(false);
 
   const handleOnClose = useCallback(() => {
@@ -14,6 +21,14 @@ const useOnClose = (
       setIsClosing(false);
     }, 300);
   }, [setIsClosing, onClose]);
+
+  const handleOnOverlayClick = useCallback(() => {
+    if (!dismissable) {
+      return;
+    }
+
+    handleOnClose();
+  }, [dismissable, handleOnClose]);
 
   const handleEscKey = useCallback(
     (e: KeyboardEvent) => {
@@ -48,7 +63,7 @@ const useOnClose = (
     e.stopPropagation();
   };
 
-  return { isClosing, handleContainerClick, handleOnClose };
+  return { isClosing, handleContainerClick, handleOnClose, handleOnOverlayClick };
 };
 
 export default useOnClose;

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -15,7 +15,12 @@ export default ({
   className = '',
   dismissible = true,
 }: Props) => {
-  const { isClosing, handleContainerClick, handleOnClose } = useOnClose(
+  const {
+    isClosing,
+    handleContainerClick,
+    handleOnClose,
+    handleOnOverlayClick
+  } = useOnClose(
     onClose,
     isOpen,
     dismissible
@@ -28,7 +33,7 @@ export default ({
   return (
     <div
       className={isClosing ? styles['overlay--close'] : styles.overlay}
-      onClick={handleOnClose}
+      onClick={handleOnOverlayClick}
     >
       <div
         className={`${

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -34,9 +34,11 @@ export default ({
         className={`${
           isClosing ? styles['container--close'] : styles.container
         } ${className}`}
-        onClick={handleContainerClick}
       >
-        <div className={styles.body}>
+        <div
+          className={styles.body}
+          onClick={handleContainerClick}
+        >
           <div className={styles.header}>
             <div className={`p-h2 ${styles.title}`}>{title}</div>
             {dismissible && (

--- a/src/lib/components/modal/regularModal/style.module.scss
+++ b/src/lib/components/modal/regularModal/style.module.scss
@@ -97,7 +97,7 @@
 .body {
   background-color: white;
   border-radius: 8px;
-  margin: 32px auto;
+  margin: 80px auto;
 }
 
 .header {


### PR DESCRIPTION
### What this PR does
Fixes overlay area so that all clicks outside body close the modal (including margin). Also fixes if dismissable, making it not closable on overlay click.
Adds a bigger margin for bigger modals, so that they don't show over navbar. This only impacts modals with height bigger than window height.

**Note:** While this should be a zIndex fix on navbar side, it's an easy way to fix without impacting other content and adding a nice margin to content. Should still be checked on the other side of the application.

**Before:**
<img width="1188" alt="Screenshot 2023-02-24 at 11 55 54" src="https://user-images.githubusercontent.com/4015038/221217995-66792271-7a2d-4100-8f40-dfae8eeb2b38.png">

**After:**
<img width="1192" alt="Screenshot 2023-02-24 at 15 25 07" src="https://user-images.githubusercontent.com/4015038/221218008-3d287512-1d2f-4b57-bf47-a989a3f46751.png">


### Why is this needed?

_Please include additional context of why this PR is necessary._


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
