### PR TITLE
fix(currency-input): [EMU-5966] Fix currencyInput selectionStart after value format

### DIFF
--- a/src/lib/components/input/currency/index.test.tsx
+++ b/src/lib/components/input/currency/index.test.tsx
@@ -53,4 +53,56 @@ describe('Currency input component', () => {
     await user.type(input, '1234567..34.4');
     expect(input.value).toBe('1 234 567.34');
   });
+
+  it('Should have correct selection start when no spaces are added', async () => {
+    const { input, user } = setup();
+
+    await user.type(input, '123');
+    // Should be: 123|
+    expect(input.selectionStart).toBe(3);
+  });
+
+  it('Should have correct selection start when spaces are added', async () => {
+    const { input, user } = setup();
+
+    await user.type(input, '1234');
+    // Should be: 123 4|
+    expect(input.selectionStart).toBe(5);
+  });
+
+  it('Should have correct selection start when typing in middle of input', async () => {
+    const { input, user } = setup();
+
+    await user.type(input, '123{arrowleft}4');
+
+    // Should be: 1 24|3
+    expect(input.selectionStart).toBe(4);
+  });
+
+  it('Should have correct selection start when typing in beginning of input', async () => {
+    const { input, user } = setup();
+
+    await user.type(input, '123{arrowleft}{arrowleft}{arrowleft}4');
+
+    // Should be: 4 |123
+    expect(input.selectionStart).toBe(2);
+  });
+
+  it('Should have correct selection start when typing in input and has currency values', async () => {
+    const { input, user } = setup();
+
+    await user.type(input, '123.2{arrowleft}{arrowleft}{arrowleft}24');
+
+    // Should be: 12 24|3.2
+    expect(input.selectionStart).toBe(5);
+  });
+
+  it('Should have correct selection start when deleting', async () => {
+    const { input, user } = setup();
+
+    await user.type(input, '12345{arrowleft}{backspace}67');
+
+    // Should be: 123 67|5
+    expect(input.selectionStart).toBe(6);
+  });
 });

--- a/src/lib/components/input/currency/index.tsx
+++ b/src/lib/components/input/currency/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { formatInput, reverseFormatInput } from './format';
 import Input, { InputProps } from '..';
@@ -13,6 +13,8 @@ const CurrencyInput = ({
   placeholder?: string;
   onChange?: (value: number) => void;
 } & Omit<InputProps, 'onChange' | 'value' | 'ref'>) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [cursor, setCursor] = useState<number | null>(null);
   const [shadowValue, setShadowValue] = useState('');
 
   const formattedShadowValue = formatInput(
@@ -37,12 +39,26 @@ const CurrencyInput = ({
     // eslint-disable-next-line
   }, [shadowValue]);
 
+  useEffect(() => {
+    if (!inputRef.current || !cursor) {
+      return;
+    }
+
+    const cursorDiff =  String(formattedShadowValue).length - String(shadowValue).length;
+    const newCursor = cursorDiff + cursor;
+
+    inputRef.current.selectionStart = newCursor;
+    inputRef.current.selectionEnd = newCursor;
+  },[cursor, formattedShadowValue, shadowValue])
+
   return (
     <Input
       prefix="€"
+      ref={inputRef}
       type="string"
       value={formattedShadowValue}
       onChange={(e) => {
+        setCursor(e.target.selectionStart);
         setShadowValue(e.target.value);
       }}
       {...props}


### PR DESCRIPTION
### What this PR does
Fix currencyInput selectionStart after value format, making the cursor stay in the expected position instead of going to the end of the input.

Solves:  
EMU-5966

https://user-images.githubusercontent.com/4015038/227987170-270f8522-dadb-4956-ab79-a21393561529.mov

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
