### PR TITLE
feat(button): add secondary grey button style

### DIFF
--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -88,6 +88,11 @@
       outline: none;
       box-shadow: 0 0 0 2px rgba($color: $ds-primary-500, $alpha: 0.5);
     }
+
+    &-grey {
+      @extend .p-btn--secondary;
+      background-color: $ds-primary-50;
+    }
   }
 
   &--danger {

--- a/src/lib/scss/private/components/button.stories.mdx
+++ b/src/lib/scss/private/components/button.stories.mdx
@@ -52,6 +52,22 @@ You are looking at the css definition of the Button component, if you want you c
   <button className="p-btn--secondary p-btn--loading">Secondary button</button>
 </Preview>
 
+## Secondary grey button
+
+### Default
+
+<Preview>
+  <button className="p-btn--secondary-grey">Secondary grey button</button>
+</Preview>
+
+### Disabled
+
+<Preview>
+  <button className="p-btn--secondary-grey" disabled={true}>
+    Secondary grey button
+  </button>
+</Preview>
+
 ## Danger button
 
 ### Default


### PR DESCRIPTION
### What this PR does

Add `p-btn--secondary-grey` button class
<img width="945" alt="image" src="https://user-images.githubusercontent.com/26237320/228188419-93829663-560b-427c-8be3-d2018d7a7b05.png">


### Why is this needed?

Solves:  
This is a sub-issue of [STO-5437](https://linear.app/feather-insurance/issue/STO-5437/no-hover-on-secondary-button-light-grey-background)

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
