### PR TITLE
feat(button): add secondary grey variation to button component

### DIFF
--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -2,11 +2,17 @@ import React from 'react';
 
 import styles from './styles.module.scss';
 
-type ButtonType = 'primary' | 'secondary' | 'outline' | 'outlineGrey';
+type ButtonType =
+  | 'primary'
+  | 'secondary'
+  | 'secondaryGrey'
+  | 'outline'
+  | 'outlineGrey';
 
 const buttonTypeClassNameMap: { [K in ButtonType]: string } = {
   primary: 'p-btn--primary',
   secondary: 'p-btn--secondary',
+  secondaryGrey: 'p-btn--secondary-grey',
   outline: 'p-btn--outline',
   outlineGrey: 'p-btn--outline-grey',
 };


### PR DESCRIPTION
### What this PR does

Add the new secondary grey variation to button component

### Why is this needed?

Solves:  
[STO-5437](https://linear.app/feather-insurance/issue/STO-5437/no-hover-on-secondary-button-light-grey-background)

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
