### PR TITLE
fix(comparison-table): revert header width style change

### DIFF
--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -8,8 +8,7 @@ $cell-min-width: var(--cellWidth, 256px);
 
   & > div {
     width: var(--tableWidth);
-    // 100% of viewport width minus 16px horizontal padding
-    max-width: calc(100vw - 32px);
+    max-width: var(--tableWidth);
 
     &:nth-child(n + 3) {
       margin: 0;


### PR DESCRIPTION
### What this PR does

Revert previous header style change to ensure that comparison tables look concise on mobile

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
