### PR TITLE
feat(button): [RVN-212] Add spacing before outline in focus state

### DIFF
--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -59,7 +59,8 @@
 
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 2px rgba($color: $ds-primary-500, $alpha: 0.5);
+      box-shadow: 0 0 0 1px white,
+        0 0 0 3px rgba($color: $ds-primary-500, $alpha: 0.5);
     }
   }
 
@@ -86,7 +87,8 @@
 
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 2px rgba($color: $ds-primary-500, $alpha: 0.5);
+      box-shadow: 0 0 0 1px white,
+        0 0 0 3px rgba($color: $ds-primary-500, $alpha: 0.5);
     }
 
     &-grey {
@@ -115,7 +117,8 @@
 
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 2px rgba($color: $ds-red-500, $alpha: 0.5);
+      box-shadow: 0 0 0 1px white,
+        0 0 0 3px rgba($color: $ds-primary-500, $alpha: 0.5);
     }
   }
 


### PR DESCRIPTION
### What this PR does

* Adds space before outline in focus state of button

#### After
<img width="512" alt="Screenshot 2023-03-31 at 10 31 28" src="https://user-images.githubusercontent.com/25661767/229075451-6d1cfb8a-b037-4bc5-bbe2-68fec6c5cead.png">

#### Before
<img width="614" alt="Screenshot 2023-03-31 at 10 54 40" src="https://user-images.githubusercontent.com/25661767/229075452-a1460013-2d5d-4b12-a842-298ed6680f9b.png">

Solves:
RVN-212


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
