### PR TITLE
fix (table-info-button): [EMU-6047] Make TableInfoButton focusable

### DIFF
--- a/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
@@ -11,6 +11,7 @@ const TableInfoButton = ({
     role="button"
     className={`p-btn--secondary ${styles.button} ${className}`}
     onClick={onClick}
+    tabIndex={0}
   >
     <svg
       width="20"

--- a/src/lib/components/comparisonTable/components/TableInfoButton/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/style.module.scss
@@ -9,6 +9,7 @@
 
   vertical-align: bottom;
 
+  border-radius: 12px;
   width: 24px;
   height: 24px;
 
@@ -26,5 +27,9 @@
   svg {
     fill: $ds-primary-100;
     transition: all 0.3s ease;
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px $ds-primary-500;
   }
 }


### PR DESCRIPTION
### What this PR does

Make TableInfoButton focusable.

Solves:
EMU-6047

Non focused state:
<img width="74" alt="Screenshot 2023-03-31 at 10 33 44" src="https://user-images.githubusercontent.com/4015038/229084180-dd158274-3f97-48ac-b396-176f738dab54.png">

Focused state:
<img width="64" alt="Screenshot 2023-03-31 at 10 33 42" src="https://user-images.githubusercontent.com/4015038/229084192-4198f054-efc4-4a22-ac18-652a50a1abf8.png">



### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
