### PR TITLE
fix(table-info-button): [EMU-6047] Make TableInfoButton click happen on enter

### DIFF
--- a/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
@@ -12,7 +12,9 @@ const TableInfoButton = ({
     className={`p-btn--secondary ${styles.button} ${className}`}
     onClick={onClick}
     onKeyDown={(e) => {
-      if (e.key === 'Enter') {
+      e.stopPropagation();
+
+      if (e.key === 'Enter' || e.key === " ") {
         onClick();
       }
     }}

--- a/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
@@ -11,6 +11,11 @@ const TableInfoButton = ({
     role="button"
     className={`p-btn--secondary ${styles.button} ${className}`}
     onClick={onClick}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter') {
+        onClick();
+      }
+    }}
     tabIndex={0}
   >
     <svg


### PR DESCRIPTION
### What this PR does

Related to https://github.com/getPopsure/dirty-swan/pull/209. This made the component focusable but since it's not a default browser button, it doesn't allow to trigger using keyboarding only which is a far from optimal user experience.

Solves:
EMU-6047

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
