### PR TITLE
refactor(bottom-modal): [EMU-5924] Add bottom padding to BottomModal

### DIFF
--- a/src/lib/components/modal/bottomModal/style.module.scss
+++ b/src/lib/components/modal/bottomModal/style.module.scss
@@ -1,3 +1,5 @@
+@use "../../../scss/public/grid" as *;
+
 @keyframes fade-in {
   0% {
     background-color: rgba($color: #000000, $alpha: 0);
@@ -100,4 +102,10 @@
   align-items: center;
 
   padding: 0 16px;
+}
+
+.content {
+  @include p-size-mobile {
+    padding-bottom: 48px;
+  }
 }


### PR DESCRIPTION
### What this PR does

Add bottom padding to BottomModal component. This adds an extra div so that when manual padding is set (which is currently happening, this spacing is always there).

### Why is this needed?

On mobile there are some widgets (like intercom) that are over the modal component text.

Solves:
EMU-5924

Before:
<img width="396" alt="Screenshot 2023-04-05 at 10 15 00" src="https://user-images.githubusercontent.com/4015038/230037783-47fa93dc-4dd0-4e6f-8c1d-1cf97e16d302.png">


After:
<img width="397" alt="Screenshot 2023-04-05 at 10 13 28" src="https://user-images.githubusercontent.com/4015038/230037796-e4790730-840c-404c-8e81-13465f4ccb0c.png">


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
