### PR TITLE
fix(comparison-table): Fix child list unique id warning

### DIFF
--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { Fragment } from 'react';
 import { ScrollSync, ScrollSyncPane } from 'react-scroll-sync';
 
 import { AccordionItem } from './components/AccordionItem';
@@ -153,7 +154,7 @@ const ComparisonTable = <T extends { id: number }>(
                 const idString = `headerGroup-${headerGroup.id}`;
 
                 return (
-                  <>
+                  <Fragment key={idString}>
                     {headerGroup.label && collapsibleSections ? (
                       <AccordionItem
                         className="mt8"
@@ -162,7 +163,6 @@ const ComparisonTable = <T extends { id: number }>(
                         isOpen={selectedSection === idString}
                         onOpen={() => setSelectedSection(idString)}
                         onClose={() => setSelectedSection('')}
-                        key={idString}
                       >
                         <ScrollSyncPane>
                           <div
@@ -225,7 +225,7 @@ const ComparisonTable = <T extends { id: number }>(
                         </ScrollSyncPane>
                       </div>
                     )}
-                  </>
+                  </Fragment>
                 );
               })}
           {hideDetails && (


### PR DESCRIPTION
### What this PR does

Fix child list unique id warning on comparison table.

### How to test?

Run storybook, go to [comparison table story](http://localhost:9009/?path=/story/jsx-comparison-table--page) and open inspector console to see the error below is not showing:
<img width="1173" alt="Screenshot 2023-04-11 at 11 49 18" src="https://user-images.githubusercontent.com/4015038/231138387-e705fa1b-5226-49c4-9db7-ef49cb733470.png">


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
