### PR TITLE
fix(comparison-table): Prevent scroll to update tab index on above mobile breakpoints

### DIFF
--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -56,12 +56,15 @@ export const useComparisonTable = () => {
       return;
     }
 
+    const headerWidth = headerRef.current.getBoundingClientRect().width;
+
     const currentTabIndex = Math.round(
-      headerRef.current.scrollLeft /
-        headerRef.current.getBoundingClientRect().width
+      headerRef.current.scrollLeft / headerWidth
     );
 
-    setSelectedTabIndex(currentTabIndex);
+    if (headerWidth < 544) {
+      setSelectedTabIndex(currentTabIndex);
+    }
   };
 
   const debouncedTableScroll = debounce(handleTableScroll, 150);


### PR DESCRIPTION
### What this PR does

This prevents scrolling on table to update tab index on above mobile breakpoints. This means that on resize, we always have a same consistent result. This is specially important for visual regression testing as resizing the page would show the current tab randomly.

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
