### PR TITLE
chore(comparison-table): Update react-scroll-sync to v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-day-picker": "^7.4.10",
     "react-dropzone": "^14.2.2",
     "react-markdown": "^8.0.3",
-    "react-scroll-sync": "^0.9.0",
+    "react-scroll-sync": "^0.11.0",
     "remark-directive": "^2.0.1",
     "sass": "^1.35.1",
     "signature_pad": "^3.0.0-beta.3"

--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -62,9 +62,7 @@ export const useComparisonTable = () => {
       headerRef.current.scrollLeft / headerWidth
     );
 
-    if (headerWidth < 544) {
-      setSelectedTabIndex(currentTabIndex);
-    }
+    setSelectedTabIndex(currentTabIndex);
   };
 
   const debouncedTableScroll = debounce(handleTableScroll, 150);

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -100,7 +100,7 @@ const ComparisonTable = <T extends { id: number }>(
   } as React.CSSProperties;
 
   return (
-    <ScrollSync>
+    <ScrollSync onSync={scrollContainerCallbackRef}>
       <div style={cssVariablesStyle}>
         <div className={classNames(baseStyles.header, styles?.header)}>
           <ScrollSyncPane>
@@ -108,7 +108,6 @@ const ComparisonTable = <T extends { id: number }>(
               className={classNames(baseStyles.container, {
                 [baseStyles.noScrollBars]: hideScrollBars,
               })}
-              ref={scrollContainerCallbackRef}
             >
               <div className={classNames(baseStyles['overflow-container'])}>
                 <div className={baseStyles['group-container']}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12806,10 +12806,10 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react-scroll-sync@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.9.0.tgz"
-  integrity sha512-IaMUSTbarj9mhjVtBl9I45Er8gQqV8rdb9A0eK77JJ8MvnLcFIlnoiXVx1NS9ACy9QELq7xCTxdIVEdhDV9R0Q==
+react-scroll-sync@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-scroll-sync/-/react-scroll-sync-0.11.0.tgz#eaeb55240d7cb07ab6ccab2fb483f46f2832b8c1"
+  integrity sha512-COfA885/2NAQPxusIU6sukKiSFXgAd9+OWD7iBWA4NF5Y1Np8poBKLwgZ3y4iywo5/+ch0PLGz887myIbm+fPw==
   dependencies:
     prop-types "^15.5.7"
 


### PR DESCRIPTION
### What this PR does

Update react-scroll-sync to v0.11.0 which uses the new context API.

### Why is this needed?

This should fix the rendering issues on visual regression tests.

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
