### PR TITLE
refactor(auto-suggest-input): Allow to pass input props to AutoSuggestInput

### DIFF
--- a/src/lib/components/input/autoSuggestInput/index.stories.mdx
+++ b/src/lib/components/input/autoSuggestInput/index.stories.mdx
@@ -32,6 +32,7 @@ export interface Option {
 | placeholder                  | string   | Placeholder for DirtySwan Input component                                                 | n/a           | true     |
 | className                    | string   | Class name for the most parent element                                                    | undefined     | false    |
 | wrapText                     | boolean  | Wether or not wrap the entries in the dropdown or hide overflown text                     | false         | false    |
+| inputProps                   | InputHTMLAttributes  | Pass through arbitrary props to the input.                                    | n/a           | false    |
 
 ## Example
 

--- a/src/lib/components/input/autoSuggestInput/index.tsx
+++ b/src/lib/components/input/autoSuggestInput/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import Autosuggest from 'react-autosuggest';
+import Autosuggest, { RenderInputComponentProps } from 'react-autosuggest';
 
 import styles from './style.module.scss';
 import { Option } from '../../../models/autoSuggestInput';
@@ -15,6 +15,7 @@ export default ({
   placeholder,
   className,
   wrapText,
+  inputProps
 }: {
   currentOption: string;
   suggestions: Option[];
@@ -25,6 +26,7 @@ export default ({
   placeholder: string;
   className?: string;
   wrapText?: boolean;
+  inputProps?: RenderInputComponentProps;
 }) => {
   const renderSuggestion = (suggestion: Option) => (
     <div className={`${styles['suggestion-option']}`}>
@@ -47,9 +49,9 @@ export default ({
 
   const getSuggestionValue = (suggestion: Option) => suggestion.value;
 
-  const renderInputComponent = (inputProps: Omit<InputProps, 'ref'>) => (
+  const renderInputComponent = (autoSuggestsInputProps: Omit<InputProps, 'ref'>) => (
     <Input
-      {...inputProps}
+      {...autoSuggestsInputProps}
       placeholder={placeholder}
       data-cy="suggest-multi-select-input"
     />
@@ -66,6 +68,7 @@ export default ({
         renderSuggestion={renderSuggestion}
         highlightFirstSuggestion={true}
         inputProps={{
+          ...inputProps,
           value: currentOption,
           onChange: (_, { newValue }) => {
             onChange(newValue);

--- a/src/lib/components/input/autoSuggestInput/index.tsx
+++ b/src/lib/components/input/autoSuggestInput/index.tsx
@@ -49,9 +49,9 @@ export default ({
 
   const getSuggestionValue = (suggestion: Option) => suggestion.value;
 
-  const renderInputComponent = (autoSuggestsInputProps: Omit<InputProps, 'ref'>) => (
+  const renderInputComponent = (autoSuggestInputProps: Omit<InputProps, 'ref'>) => (
     <Input
-      {...autoSuggestsInputProps}
+      {...autoSuggestInputProps}
       placeholder={placeholder}
       data-cy="suggest-multi-select-input"
     />


### PR DESCRIPTION
### What this PR does
Allow to pass input props to AutoSuggestInput.
This can be useful, as an example, to set autocomplete property off.

### How to test?
Pass a valid HTML input prop and see that it's rendered on the input component.

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
