### PR TITLE
fix(comparison-table): Fix comparisonTable maxWidth on mobile

### DIFF
--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -8,7 +8,7 @@ $cell-min-width: var(--cellWidth, 256px);
 
   & > div {
     width: var(--tableWidth);
-    max-width: var(--tableWidth);
+    max-width: 100vw;
 
     &:nth-child(n + 3) {
       margin: 0;
@@ -16,6 +16,7 @@ $cell-min-width: var(--cellWidth, 256px);
 
     @include p-size-tablet {
       width: $cell-min-width;
+      max-width: var(--tableWidth);
       scroll-snap-align: unset;
     }
   }


### PR DESCRIPTION
### What this PR does
Fix comparisonTable maxWidth on mobile, which doesn't trigger on mobile devices. This seems to be only visible on website, not on storybook.

### How to test?
`Spotted this issue on public LP on mobile. The name appears after scrolling horizontally a bit `
![File](https://github.com/getPopsure/dirty-swan/assets/4015038/9386e824-f818-47d0-bc1f-8f0656105fa3)

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
