### PR TITLE
feat(component): Add Checkbox component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ export {
   SegmentedControl,
   DownloadButton,
   Markdown,
+  Checkbox,
   images
 } from './lib';
 

--- a/src/lib/components/input/checkbox/index.stories.tsx
+++ b/src/lib/components/input/checkbox/index.stories.tsx
@@ -1,0 +1,214 @@
+
+import { useState } from 'react';
+import { Checkbox, CheckboxProps } from '.';
+import { images } from '../../../util/images';
+
+const story = {
+  title: 'JSX/Inputs/Checkbox',
+  component: Checkbox,
+  argTypes: {
+    options: {
+      description: 'Object that contains the possible options for rendering in the input.',
+      defaultValue: {
+        CAT:{
+          title: 'Cat',
+          description: 'At least 1'
+        },
+        DOG:{
+          title: 'Dog',
+          description: 'At least 2'
+        },
+        NONE:{
+          title: 'None',
+          description: 'No pets'
+        }
+      }
+    },
+    value: {
+      description: 'Current checked values.',
+    },
+    onChange: {
+      description: 'Function called everytime a value changes.',
+      action: true,
+      table: {
+        category: "Callbacks",
+      },
+    },
+    wide: {
+      description: 'Property that defines if options should fill 100% of available horizontal space',
+      defaultValue: false
+    },
+    inlineLayout: {
+      description: 'Property that defines if options should show inline instead of block. Check inline checkbox options story for examples.',
+      defaultValue: false
+    },
+    className: {
+      description: 'Wrapper classNames for custom styling',
+      defaultValue: ''
+    },
+    optionClassName: {
+      description: 'Option classNames for custom styling',
+      defaultValue: ''
+    },
+    labelClassName: {
+      description: 'Label classNames for custom styling',
+      defaultValue: ''
+    },
+  }
+};
+
+export const CheckboxStory = ({ 
+  onChange,
+  options,
+  wide,
+  className,
+  optionClassName,
+  labelClassName,
+  inlineLayout,
+}: CheckboxProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[]) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Checkbox 
+      wide={wide}
+      options={options} 
+      onChange={handleOnChange}
+      value={checkedValues}
+      className={className}
+      labelClassName={labelClassName}
+      optionClassName={optionClassName}
+      inlineLayout={inlineLayout}
+    />
+  );
+}
+
+export const CheckboxWithCustomWrapperStyles = ({ onChange }: CheckboxProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Checkbox 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT1: 'Cat',
+        DOG1: 'Dog',
+      }} 
+      className="p32 bg-primary-300 br24 bs-lg"
+    />
+  );
+}
+
+export const CheckboxWithCustomOptionStyles = ({ onChange }: CheckboxProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Checkbox 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT2: 'Cat',
+        DOG2: 'Dog',
+      }} 
+      optionClassName="mb32 p24 bg-green-100 br12 bs-lg"
+    />
+  );
+}
+
+export const CheckboxWithCustomLabelStyles = ({ onChange }: CheckboxProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Checkbox 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT3: 'Cat',
+        DOG3: 'Dog',
+      }} 
+      labelClassName="bg-grey-900 tc-white"
+    />
+  );
+}
+
+export const CheckboxWithInlineLayout = ({ onChange }: CheckboxProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Checkbox 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT4: 'Cat',
+        DOG4: 'Dog',
+        FISHER: 'Fish',
+        RABBIT: 'Rabbit',
+        RAT: 'Rat',
+        ANOTHER: 'Other',
+      }} 
+      optionClassName="w30"
+      inlineLayout
+      wide
+    />
+  );
+}
+
+export const CheckboxWithCustomLabel = ({ onChange, wide, className, optionClassName, inlineLayout }: CheckboxProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Checkbox 
+      options={{
+        BIGDOG: {
+          icon: () => <img src={images.bigDog} alt='' />,
+          title: 'Dog',
+        },
+        FISH:{
+          icon: () => <img src={images.brokenAquarium} alt='' />,
+          title: 'Fish',
+        },
+        OTHER:{
+          icon: () => <img src={images.brokenGlass} alt='' />,
+          title: 'Other',
+        }
+      }} 
+      onChange={handleOnChange}
+      value={checkedValues}
+      optionClassName="w30"
+      inlineLayout
+    />
+  );
+}
+
+CheckboxStory.storyName = 'Checkbox';
+
+export default story;

--- a/src/lib/components/input/checkbox/index.test.tsx
+++ b/src/lib/components/input/checkbox/index.test.tsx
@@ -1,0 +1,110 @@
+import { render } from '../../../util/testUtils';
+
+import { Checkbox, CheckboxProps } from '.';
+
+const mockOnChange = jest.fn();
+
+const setup = (onChange: CheckboxProps<string>['onChange'], value?: string[]) => {
+  const utils = render(
+    <Checkbox
+      options={{
+        CAT: 'Cat',
+        DOG: 'Dog',
+        NONE: 'None',
+      }}
+      onChange={onChange}
+      value={value}
+    />
+  );
+
+  return utils;
+};
+
+describe('Checkbox component', () => {
+  it('Should render options', () => {
+    const { getByText } = setup(mockOnChange);
+
+    expect(getByText('Cat')).toBeInTheDocument();
+    expect(getByText('Dog')).toBeInTheDocument();
+    expect(getByText('None')).toBeInTheDocument();
+  });
+
+  it('Should call onchange on selecting an option', async () => {
+    const { getByTestId, user } = setup(mockOnChange);
+
+    await user.click(getByTestId('checkbox-DOG'));
+
+    expect(mockOnChange).toBeCalledWith(["DOG"]);
+  });
+
+  it('Should render checked items when value is passed', async () => {
+    const { getByTestId } = setup(mockOnChange, ['CAT']);
+
+    expect(getByTestId('checkbox-input-CAT')).toBeChecked();
+  });
+
+  it('Should call onchange with NONE and removing other items on selecting NONE option', async () => {
+    const { getByTestId, user } = setup(mockOnChange, ['CAT', 'DOG']);
+
+    await user.click(getByTestId('checkbox-NONE'));
+
+    expect(mockOnChange).toBeCalledWith(["NONE"]);
+  });
+
+  it('Should call onchange empty when removing NONE option', async () => {
+    const { getByTestId, user } = setup(mockOnChange, ['NONE']);
+
+    await user.click(getByTestId('checkbox-NONE'));
+
+    expect(mockOnChange).toBeCalledWith([]);
+  });
+
+  it('Should render custom description', () => {
+      const { getByText } = render(
+        <Checkbox
+          options={{
+            CAT: {
+              title: 'Cat',
+              description: 'Cat description'
+            },
+          }}
+          onChange={mockOnChange}
+        />
+      );
+
+    expect(getByText('Cat description')).toBeInTheDocument();
+  });
+
+  it('Should render custom icon', () => {
+      const { getByText } = render(
+        <Checkbox
+          options={{
+            CAT: {
+              title: 'Cat',
+              icon: () => 'ICON'
+            },
+          }}
+          onChange={mockOnChange}
+        />
+      );
+
+    expect(getByText('ICON')).toBeInTheDocument();
+  });
+
+  it('Should render custom icon with selected', () => {
+      const { getByText } = render(
+        <Checkbox
+          options={{
+            CAT: {
+              title: 'Cat',
+              icon: (selected) => selected ? 'SELECTED-ICON' : 'ICON'
+            },
+          }}
+          onChange={mockOnChange}
+          value={['CAT']}
+        />
+      );
+
+    expect(getByText('SELECTED-ICON')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -1,0 +1,129 @@
+import classNames from "classnames";
+import { ReactNode } from "react";
+
+export interface CheckboxWithDescription {
+  title: string;
+  description?: string;
+  icon?: (selected: boolean) => ReactNode;
+}
+
+export interface CheckboxProps<ValueType extends string> {
+  options: Record<ValueType, string | CheckboxWithDescription>;
+  value?: ValueType[];
+  onChange: (value: ValueType[]) => void;
+  wide?: boolean;
+  inlineLayout?: boolean;
+  className?: string;
+  labelClassName?: string;
+  optionClassName?: string
+}
+
+export const Checkbox = <ValueType extends string>({
+  options,
+  value = [],
+  onChange,
+  wide = false,
+  inlineLayout = false,
+  className = '',
+  labelClassName = '',
+  optionClassName = '',
+}: CheckboxProps<ValueType> & {  }) => {
+  const hasNoneValue = Object.keys(options).includes('NONE');
+
+  const handleOnChange = (newValue: ValueType) => {
+    if (value?.includes(newValue)) {
+      const filteredCheckboxValues = value.filter(
+        (selectedValue) => selectedValue !== newValue
+      );
+
+      onChange(filteredCheckboxValues);
+      return;
+    }
+
+    if (hasNoneValue && newValue === 'NONE') {
+      onChange([newValue]);
+      return;
+    }
+
+    if (hasNoneValue && newValue !== 'NONE') {
+      const newValues = value
+        ? [...value.filter((v) => v !== 'NONE'), newValue]
+        : [newValue];
+      onChange(newValues);
+      return;
+    }
+
+    const newValues = value
+      ? [...value, newValue]
+      : [newValue];
+    onChange(newValues);
+  };
+
+
+  const entries = Object.entries(options) as [
+    ValueType,
+    string | CheckboxWithDescription
+  ][];
+
+  return (
+    <div
+      className={classNames(className, 'd-flex gap8', {
+        ws10: wide,
+        ws6: !wide,
+        'fd-row': inlineLayout,
+        'f-wrap': inlineLayout,
+        'fd-column': !inlineLayout,
+      })}
+    >
+      {entries.map(([currentValue, label]) => {
+        const checked = value?.includes(currentValue);
+        const customIcon = (label as CheckboxWithDescription)?.icon;
+
+        return (
+          <div className={optionClassName} key={currentValue}>
+            <input
+              className={classNames(
+                "p-checkbox", {
+                  'p-checkbox--no-icon': customIcon
+                }
+              )}
+              id={currentValue}
+              type="checkbox"
+              value={currentValue}
+              onChange={() => handleOnChange(currentValue)}
+              checked={checked}
+              data-testid={`checkbox-input-${currentValue}`}
+            />
+
+            <label
+              htmlFor={currentValue}
+              className={classNames(
+                labelClassName,
+                'p-label p-label--bordered pr16',
+                {
+                  'jc-center': customIcon,
+                  'fd-column': customIcon
+                }
+              )}
+              data-cy={`checkbox-${currentValue}`}
+              data-testid={`checkbox-${currentValue}`}
+            >
+              {customIcon && (
+                <div className="mt8">{customIcon?.(checked)}</div>
+              )}
+
+              {typeof label === 'string' ? label : (
+                <div>
+                  <p className="p-p">{label.title}</p>
+                  <span className="d-block p-p p-p--small tc-grey-600">
+                    {label.description}
+                  </span>
+                </div>
+              )}
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -11,6 +11,7 @@ import MultiDropzone, {
 import { DownloadButton } from './components/downloadButton';
 import IbanInput from './components/input/iban';
 import CurrencyInput from './components/input/currency';
+import { Checkbox } from './components/input/checkbox';
 import {
   BottomModal,
   RegularModal,
@@ -69,6 +70,7 @@ export {
   TableInfoButton,
   SegmentedControl,
   Markdown,
+  Checkbox,
   images,
 };
 

--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -145,6 +145,10 @@
   }
 }
 
+.p-checkbox--no-icon + label::before {
+  display: none!important;
+}
+
 .p-label {
   cursor: pointer;
 


### PR DESCRIPTION
### What this PR does
This PR adds the Checkbox component with custom styles abilities.

### Why is this needed?
There is a need for a checkbox with icons, and since this isn't a react component yet, it's a good chance to move it here.

### How to test?
Run storybook and go to [Checkbox story](http://localhost:9009/?path=/docs/jsx-inputs-checkbox--checkbox-story).

**Preview:**
<img width="968" alt="Screenshot 2023-06-09 at 10 10 57" src="https://github.com/getPopsure/dirty-swan/assets/4015038/dbfbab45-6feb-4439-9d31-1e766529ea9e">
<img width="888" alt="Screenshot 2023-06-09 at 10 11 03" src="https://github.com/getPopsure/dirty-swan/assets/4015038/f8dbecce-c075-47a7-b59d-93d22c571be7">


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
