### PR TITLE
fix(checkbox): Fix max width on mobile

### DIFF
--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { ReactNode } from "react";
 
+import styles from './styles.module.scss';
 export interface CheckboxWithDescription {
   title: string;
   description?: string;
@@ -67,7 +68,7 @@ export const Checkbox = <ValueType extends string>({
 
   return (
     <div
-      className={classNames(className, 'd-flex gap8', {
+      className={classNames(className, styles.container, 'd-flex gap8', {
         ws10: wide,
         ws6: !wide,
         'fd-row': inlineLayout,

--- a/src/lib/components/input/checkbox/styles.module.scss
+++ b/src/lib/components/input/checkbox/styles.module.scss
@@ -1,0 +1,3 @@
+.container {
+  max-width: 100%;
+}


### PR DESCRIPTION
### What this PR does
Fix checkbox max width on mobile (rookie mistake 😅 ).

**Before:**
<img width="370" alt="Screenshot 2023-06-09 at 14 01 46" src="https://github.com/getPopsure/dirty-swan/assets/4015038/844b0627-6f4f-400a-ad72-1517aeb61362">


**After:**
<img width="375" alt="Screenshot 2023-06-09 at 14 01 32" src="https://github.com/getPopsure/dirty-swan/assets/4015038/99eb56ee-ac9c-45d0-86b8-7e12e13f86c2">



### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
