### PR TITLE
fix(checkbox): Update checkbox to use max-width instead of width

### DIFF
--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -69,8 +69,8 @@ export const Checkbox = <ValueType extends string>({
   return (
     <div
       className={classNames(className, styles.container, 'd-flex gap8', {
-        ws10: wide,
-        ws6: !wide,
+        [styles.wide]: wide,
+        [styles.narrow]: !wide,
         'fd-row': inlineLayout,
         'f-wrap': inlineLayout,
         'fd-column': !inlineLayout,

--- a/src/lib/components/input/checkbox/styles.module.scss
+++ b/src/lib/components/input/checkbox/styles.module.scss
@@ -1,3 +1,11 @@
 .container {
   max-width: 100%;
 }
+
+.narrow {
+  max-width: 424px;
+}
+
+.wide {
+  max-width: 736px;
+}


### PR DESCRIPTION
### What this PR does
Update checkbox to use max-width instead of width.
While nothing major changes, this ensures stability with previous styles of checkbox meaning no visible changes from previous usage.