### PR TITLE
feat(link): [EMU-5965] Add Link component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ export {
   DownloadButton,
   Markdown,
   Checkbox,
+  Link,
   images
 } from './lib';
 

--- a/src/lib/components/link/index.stories.tsx
+++ b/src/lib/components/link/index.stories.tsx
@@ -1,0 +1,29 @@
+import { Link, LinkProps } from '.';
+
+const story = {
+  title: 'JSX/Link',
+  component: Link,
+  argTypes: {
+    children: {
+      control: 'text',
+      defaultValue: 'Click here to go to Feather Insurance',
+      description: 'Content that is displayed as clickable inside the link',
+    },
+    href: {
+      control: 'text',
+      defaultValue: 'https://feather-insurance.com',
+      description: 'Specifies the URL of the page the link goes to',
+    },
+  },
+  parameters: {
+    componentSubtitle: 'Links are a styled helper component for anchor (<a />) tags.',
+  },
+};
+
+export const LinkStory = ({ children, href, ...rest }: LinkProps) => (
+  <Link href={href} {...rest}>{children}</Link>
+);
+
+LinkStory.storyName = "Link";
+
+export default story;

--- a/src/lib/components/link/index.tsx
+++ b/src/lib/components/link/index.tsx
@@ -1,0 +1,9 @@
+import classnames from 'classnames';
+
+export type LinkProps = JSX.IntrinsicElements['a'];
+
+export const Link = ({ children, className, ...rest }: LinkProps) => (
+  <a className={classnames(className, 'p-a c-pointer')} {...rest}>
+    {children}
+  </a>
+);

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -40,6 +40,7 @@ import {
 } from './components/comparisonTable';
 import { SegmentedControl } from './components/segmentedControl';
 import { Markdown } from './components/markdown';
+import { Link } from './components/link';
 import { images } from './util/images';
 
 export {
@@ -72,6 +73,7 @@ export {
   SegmentedControl,
   Markdown,
   Checkbox,
+  Link,
   images,
 };
 


### PR DESCRIPTION
### What this PR does
This PR adds the `Link` component to dirty swan.

![Screenshot 2023-07-04 at 14 27 17](https://github.com/getPopsure/dirty-swan/assets/4015038/4b09ccc4-de73-4596-82e1-b7c44f04e17c)

Solves:
EMU-5965

### How to test?
Run `yarn storybook` and go to [Link story](http://localhost:9009/?path=/docs/jsx-link--link-story)


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
