### PR TITLE
refactor(auto-suggest-multi-select): [CHA-3762] Add entry animation to chip container

### DIFF
--- a/src/lib/components/chip/index.tsx
+++ b/src/lib/components/chip/index.tsx
@@ -4,13 +4,15 @@ import removeButtonHighlightedIcon from './icons/remove-button-highlighted.svg';
 import { Option } from '../../models/autoSuggestInput';
 
 export default ({
+  className,
   value,
   onRemove,
 }: {
   value: Option;
   onRemove: (value: Option) => void;
+  className?: string;
 }) => (
-  <div className={`p-p mr8 mb8 d-flex ${styles['chip']}`}>
+  <div className={`p-p mr8 mb8 d-flex ${className} ${styles['chip']}`}>
     {value.leftIcon && (
       <img
         className={`mr8 ${styles['chip-image']}`}

--- a/src/lib/components/input/autoSuggestMultiSelect/index.tsx
+++ b/src/lib/components/input/autoSuggestMultiSelect/index.tsx
@@ -4,6 +4,7 @@ import { Option } from '../../../models/autoSuggestInput';
 import Chip from '../../chip';
 import AutoSuggestInput from '../autoSuggestInput';
 import styles from './style.module.scss';
+import classNames from 'classnames';
 
 export default ({
   options,
@@ -24,27 +25,37 @@ export default ({
 }) => {
   const [suggestions, setSuggestions] = useState<Option[]>([]);
   const [currentOption, setCurrentOption] = useState('');
+  const hasChips = Boolean(selectedValues && selectedValues.length > 0);
 
   return (
     <>
-      {selectedValues && selectedValues.length > 0 && (
-        <div
-          className={`mb8 ${styles['chip-container']} ${chipsListClassName}`}
-        >
-          {selectedValues.map((value, index) => (
-            <Chip
-              key={`${value.value}-${index}`}
-              value={value}
-              onRemove={(value: Option) => {
-                const newValues = [...selectedValues].filter(
-                  (selectedValue) => selectedValue.value !== value.value
-                );
-                setValues(newValues);
-              }}
-            />
-          ))}
-        </div>
-      )}
+      <div
+        className={classNames(
+          styles['chip-container'],
+          chipsListClassName,
+          {
+            [styles.appearIn]: hasChips
+          },
+        )}
+      >
+        {selectedValues && hasChips && (
+          <>
+            {selectedValues.map((value, index) => (
+              <Chip
+                key={`${value.value}-${index}`}
+                className="mb16"
+                value={value}
+                onRemove={(value: Option) => {
+                  const newValues = [...selectedValues].filter(
+                    (selectedValue) => selectedValue.value !== value.value
+                  );
+                  setValues(newValues);
+                }}
+              />
+            ))}
+          </>
+        )}
+      </div>
       <AutoSuggestInput
         className={multiSelectClassName}
         placeholder={placeholder}

--- a/src/lib/components/input/autoSuggestMultiSelect/style.module.scss
+++ b/src/lib/components/input/autoSuggestMultiSelect/style.module.scss
@@ -1,4 +1,10 @@
 .chip-container {
   display: flex;
   flex-wrap: wrap;
+  max-height: 10px;
+  transition: 0.7s ease-in;
+}
+
+.appearIn {
+  max-height: 300px;
 }


### PR DESCRIPTION
### What this PR does
Add entry animation to chip container. This will be revisited once we have transition/animation pritives/utilities.

### Why is this needed?
CHA-3762

https://github.com/getPopsure/dirty-swan/assets/4015038/d3387e94-e0b1-4ff9-b44b-f98471539bd1


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
