### PR TITLE
feat(information-box): Add InformationBox component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,7 @@ export {
   Markdown,
   Checkbox,
   Link,
+  InformationBox,
   images
 } from './lib';
 

--- a/src/lib/components/informationBox/index.stories.tsx
+++ b/src/lib/components/informationBox/index.stories.tsx
@@ -1,0 +1,51 @@
+import { InformationBox, InformationBoxProps } from '.';
+
+const story = {
+  title: 'JSX/InformationBox',
+  component: InformationBox,
+  argTypes: {
+    children: {
+      control: { type: 'text' },
+      defaultValue: 'It seems that you already have an account with us! Sign in now',
+      description: 'Content that is displayed inside the information box',
+    },
+    title: {
+      defaultValue: 'Log in to your account',
+      description: 'Title of the information box',
+    },
+    showIcon: {
+      defaultValue: false,
+      description: 'Whether or not to show the info icon',
+    },
+    size: {
+      defaultValue: 'default',
+      description: 'Size to display the component',
+    },
+    variant: {
+      defaultValue: 'information',
+      description: 'Variant that defines the style of the InformationBox',
+    },
+  }
+};
+
+export const InformationBoxStory = ({
+  children,
+  showIcon,
+  title,
+  size,
+  variant,
+}: InformationBoxProps) => (
+  <div className='wmx6'>
+    <InformationBox
+      children={children}
+      showIcon={showIcon}
+      title={title}
+      size={size}
+      variant={variant}
+    />
+  </div>
+);
+
+InformationBoxStory.storyName = "InformationBox";
+
+export default story;

--- a/src/lib/components/informationBox/index.test.tsx
+++ b/src/lib/components/informationBox/index.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '../../util/testUtils';
+
+import { InformationBox } from '.';
+
+describe('InformationBox component', () => {
+  it('Should render title', async () => {
+    render(
+      <InformationBox title={'Title'}>
+        Content
+      </InformationBox>
+    )
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+  });
+
+  it('Should not render title when title prop is not passed', async () => {
+    render(
+      <InformationBox>
+        Content
+      </InformationBox>
+    )
+
+    expect(screen.queryByTestId('information-box-title')).not.toBeInTheDocument();
+  });
+  
+  it('Should render content', async () => {
+    render(
+      <InformationBox>
+        Content
+      </InformationBox>
+    )
+
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+  
+  it('Should show icon when showIcon is true', async () => {
+    render(
+      <InformationBox showIcon>
+        Content
+      </InformationBox>
+    )
+
+    expect(screen.getByTestId('information-box-icon')).toBeInTheDocument();
+  });
+  
+  it('Should not show icon when showIcon is false', async () => {
+    render(
+      <InformationBox showIcon={false}>
+        Content
+      </InformationBox>
+    )
+
+    expect(screen.queryByTestId('information-box-icon')).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/components/informationBox/index.tsx
+++ b/src/lib/components/informationBox/index.tsx
@@ -1,0 +1,65 @@
+import { ReactNode } from 'react';
+import classNames from 'classnames';
+import styles from './style.module.scss';
+
+type Variant = 'warning' | 'error' | 'success' | 'information' | 'neutral';
+
+export interface InformationBoxProps {
+  className?: string;
+  variant?: Variant;
+  title?: string;
+  children: ReactNode;
+  showIcon?: boolean;
+  size?: 'default' | 'small';
+}
+
+const InformationBox = ({
+  className = '',
+  variant = 'information',
+  title,
+  children,
+  showIcon,
+  size = 'default'
+}: InformationBoxProps) => (
+  <div
+    className={classNames(
+      className, 
+      'p16 br8 color-black', 
+      styles.informationBox,
+      styles[`informationBox--${variant}`]
+    )}
+    role="alert"
+  >
+    <div className='d-flex'>
+      {showIcon && 
+        <span
+          data-testid="information-box-icon"
+          className={classNames(
+            styles.icon,
+            styles[`icon--${variant}`],
+            'mr8'
+          )}
+        />
+      }
+      <div>
+        {title && (
+          <h4 
+            data-testid="information-box-title"
+            className={classNames(
+              size === 'default'? 'p-h4' : 'p-h5',
+              'mb8'
+            )}
+          >
+            {title}
+          </h4>
+        )}
+
+        <p className={size === 'default' ? 'p-p' : 'p-p--small'}>
+          {children}
+        </p>
+      </div>
+    </div>
+  </div>
+);
+
+export { InformationBox };

--- a/src/lib/components/informationBox/info.svg
+++ b/src/lib/components/informationBox/info.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none">
+  <g clip-path="url(#a)">
+    <path stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10ZM12 16v-4"/>
+    <circle cx="12" cy="8" r="1" fill="#000"/>
+  </g>
+  <defs>
+    <clipPath id="a">
+      <path fill="#fff" d="M0 0h24v24H0z"/>
+    </clipPath>
+  </defs>
+  </svg>

--- a/src/lib/components/informationBox/style.module.scss
+++ b/src/lib/components/informationBox/style.module.scss
@@ -1,0 +1,62 @@
+
+@use "../../scss/public/colors" as *;
+
+.informationBox {
+  border: 1px solid;
+
+  &--information {
+    background-color: $ds-blue-100;
+    border-color: $ds-blue-500;
+  }
+
+  &--error {
+    background-color: $ds-red-100;
+    border-color: $ds-red-500;
+  }
+
+  &--warning {
+    background-color: $ds-yellow-100;
+    border-color: $ds-yellow-500;
+  }
+
+  &--success {
+    background-color: $ds-green-100;
+    border-color: $ds-green-500;
+  }
+
+  &--neutral {
+    background-color: $ds-white;
+    border-color: $ds-white;
+  }
+}
+
+.icon {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+
+  mask-image: url('./info.svg');
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+
+  &--information {
+    background-color: $ds-blue-500;
+  }
+
+  &--error {
+    background-color: $ds-red-500;
+  }
+
+  &--warning {
+    background-color: $ds-yellow-500;
+  }
+
+  &--success {
+    background-color: $ds-green-500;
+  }
+
+  &--neutral {
+    background-color: $ds-primary-500;
+  }
+}

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -10,6 +10,7 @@ import {
   UploadStatus
 } from './components/multiDropzone';
 import { DownloadButton } from './components/downloadButton';
+import { InformationBox } from './components/informationBox';
 import IbanInput from './components/input/iban';
 import CurrencyInput from './components/input/currency';
 import { Checkbox } from './components/input/checkbox';
@@ -74,6 +75,7 @@ export {
   Markdown,
   Checkbox,
   Link,
+  InformationBox,
   images,
 };
 


### PR DESCRIPTION
### What this PR does
This PR adds the InformationBox component.

Figma:
https://www.figma.com/file/MKs4cbojdVOBKUxv7okb93/Dirty-Swan-Design-System?node-id=830%3A23&mode=dev

Storybook:
http://localhost:9009/?path=/docs/jsx-informationbox--information-box-story


**Preview:**
![Screenshot 2023-07-07 at 14 59 46](https://github.com/getPopsure/dirty-swan/assets/4015038/cccd95c2-23c9-4064-8060-e39b11134a81)


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
