### PR TITLE
refactor(card-left-icon): Update CardWithLeftIcon icon size and text

### DIFF
--- a/src/lib/components/cards/cardWithLeftIcon/index.stories.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.stories.tsx
@@ -9,6 +9,10 @@ const story = {
       defaultValue: 'Lorem Ipsum',
       description: 'Title text that needs to be displayed',
     },
+    subtitle: {
+      defaultValue: 'Lorem Ipsum dolorem',
+      description: 'Subitle text that needs to be displayed',
+    },
     children: {
       type: 'text',
       defaultValue: 'Mountain or rock climbing, Bouldering, Martial arts, Extreme sports, Scuba diving, Sky diving, Bungee jumping, Mountain or rock climbing, Bouldering, Martial arts,',
@@ -24,6 +28,13 @@ const story = {
         alt: 'Image alt'
       },
       description: 'Icon displayed on the left of the card.',
+    },
+    leftIconSize: {
+      defaultValue: {
+        width: 48,
+        height: 48
+      },
+      description: 'Size of the left icon',
     },
     rightIcon: {
       defaultValue: {
@@ -51,11 +62,13 @@ const story = {
 
 export const CardWithLeftIconStory = ({
   title,
+  subtitle,
   dropshadow,
   children,
   className,
   cardSize,
   leftIcon,
+  leftIconSize,
   rightIcon,
   state,
 }: CardWithLeftIconProps) => {
@@ -66,8 +79,10 @@ export const CardWithLeftIconStory = ({
       dropshadow={dropshadow}
       state={state}
       leftIcon={leftIcon}
+      leftIconSize={leftIconSize}
       rightIcon={rightIcon}
       title={title}
+      subtitle={subtitle}
     >
       {children}
     </CardWithLeftIcon>

--- a/src/lib/components/cards/cardWithLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.tsx
@@ -1,5 +1,5 @@
 import { associatedClassForCardState, CardProps, headingForCardSize } from '..';
-import { Icon, arrowRight } from '../icons';
+import { Icon, IconSize, arrowRight } from '../icons';
 
 import styles from './style.module.scss';
 
@@ -30,21 +30,26 @@ const cardTextStyleFromCardSize = (
   }
 };
 
-export type CardWithLeftIconProps = CardProps & {
+export type CardWithLeftIconProps = Omit<CardProps, 'title'> & {
   cardSize?: 'xsmall' | 'small' | 'medium' | 'big';
   leftIcon?: Icon;
   rightIcon?: 'arrow' | Icon;
+  leftIconSize?: IconSize;
+  title?: string;
+  subtitle?: string;
 }
 
 export const CardWithLeftIcon = ({
   className = '',
   title,
+  subtitle,
   cardSize = 'medium',
   children,
   leftIcon,
   rightIcon,
   state = 'actionable',
   dropshadow = true,
+  leftIconSize,
   ...props
 }: CardWithLeftIconProps) => {
   const cardStyle = `d-flex ai-center ${className} ${associatedClassForCardState(
@@ -62,8 +67,8 @@ export const CardWithLeftIcon = ({
     <div className={cardStyle} {...props}>
       {leftIcon && (
         <img
-          width="48px"
-          height="48px"
+          width={`${leftIconSize?.width || 48}px`}
+          height={`${leftIconSize?.height || 48}px`}
           className={iconStyle}
           src={leftIcon.src}
           alt={leftIcon.alt}
@@ -71,7 +76,16 @@ export const CardWithLeftIcon = ({
       )}
       <div>
         <div className="d-flex">
-          <div className={headingStyle}>{title}</div>
+          {(title || subtitle) && (
+            <div>
+              {title && (
+                <div className={headingStyle}>{title}</div>
+              )}
+              {subtitle && (
+                <div className={`tc-grey-500 ${headingStyle}`}>{subtitle}</div>
+              )}
+            </div>
+          )}
           {rightIcon && (
             <img
               className="ml-auto"


### PR DESCRIPTION
### What this PR does
 Update CardWithLeftIcon:
- allow customisation of left icon size
- add subtitle
- make subtitle optional

<img width="1273" alt="Screenshot 2023-07-13 at 16 49 10" src="https://github.com/getPopsure/dirty-swan/assets/4015038/98ff21c8-d9f9-45d5-9834-d6eb8ea310f6">
<img width="1283" alt="Screenshot 2023-07-13 at 16 48 56" src="https://github.com/getPopsure/dirty-swan/assets/4015038/f4f658cd-3999-4532-9635-d5bce946f9dc">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
