### PR TITLE
fix(CurrencyInput): [EMU-6492] Don't exec onChange on initial render

### DIFF
--- a/src/lib/components/input/currency/index.tsx
+++ b/src/lib/components/input/currency/index.tsx
@@ -35,7 +35,9 @@ const CurrencyInput = ({
   }, [value]);
 
   useEffect(() => {
-    onChange?.(reverseFormatInput(shadowValue));
+    if (shadowValue) {
+      onChange?.(reverseFormatInput(shadowValue));
+    }
     // eslint-disable-next-line
   }, [shadowValue]);
 
@@ -44,12 +46,13 @@ const CurrencyInput = ({
       return;
     }
 
-    const cursorDiff =  String(formattedShadowValue).length - String(shadowValue).length;
+    const cursorDiff =
+      String(formattedShadowValue).length - String(shadowValue).length;
     const newCursor = cursorDiff + cursor;
 
     inputRef.current.selectionStart = newCursor;
     inputRef.current.selectionEnd = newCursor;
-  },[cursor, formattedShadowValue, shadowValue])
+  }, [cursor, formattedShadowValue, shadowValue]);
 
   return (
     <Input


### PR DESCRIPTION
### What this PR does

This PR fixes an issue with the `CurrencyInput` component that makes it run its `onChange` handler on initial render. 

Currently, if your code relies on checking if the value is in an `undefined` state initially (when no value was entered yet), it will be overwritten with `0` on first render and while there still won't be any value in the input, internally the value is already `0`. This breaks the logic on private LP calculator for example and will show "you are not eligible" prematurely.

### Why is this needed?

Solves:
EMU-6492


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
