### PR TITLE
fix(icon-wrapper): Remove default color from icon wrapper

### DIFF
--- a/src/lib/components/icon/IconWrapper/IconWrapper.tsx
+++ b/src/lib/components/icon/IconWrapper/IconWrapper.tsx
@@ -14,7 +14,7 @@ export type IconWrapperProps = {
 const IconWrapper = ({
   children,
   size = 16,
-  color = 'primary-500',
+  color,
   className,
 }: IconWrapperProps) => (
   <span


### PR DESCRIPTION
### What this PR does
This PR removes the default color from IconWrapper component as the icons should show parent elements color by default.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
