### PR TITLE
feat(radio): Add Radio component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ export {
   DownloadButton,
   Markdown,
   Checkbox,
+  Radio,
   Link,
   InformationBox,
   Badge,

--- a/src/lib/components/input/radio/index.stories.tsx
+++ b/src/lib/components/input/radio/index.stories.tsx
@@ -42,17 +42,13 @@ const story = {
       description: 'Property that defines if options should show inline instead of block. Check inline radio options story for examples.',
       defaultValue: false
     },
-    className: {
-      description: 'Wrapper classNames for custom styling',
-      defaultValue: ''
-    },
-    optionClassName: {
-      description: 'Option classNames for custom styling',
-      defaultValue: ''
-    },
-    labelClassName: {
-      description: 'Label classNames for custom styling',
-      defaultValue: ''
+    classNames: {
+      description: 'ClassNames for custom styling',
+      defaultValue: {
+        container: '',
+        label: '',
+        option: ''
+      }
     },
     bordered: {
       description: 'Property that defines if option should show with border',
@@ -65,9 +61,7 @@ export const RadioStory = ({
   onChange,
   options,
   wide,
-  className,
-  optionClassName,
-  labelClassName,
+  classNames,
   inlineLayout,
   bordered,
 }: RadioProps<string>) => {
@@ -84,9 +78,7 @@ export const RadioStory = ({
       options={options} 
       onChange={handleOnChange}
       value={checkedValues}
-      className={className}
-      labelClassName={labelClassName}
-      optionClassName={optionClassName}
+      classNames={classNames}
       inlineLayout={inlineLayout}
       bordered={bordered}
     />
@@ -109,7 +101,7 @@ export const RadioWithCustomWrapperStyles = ({ onChange }: RadioProps<string>) =
         CAT1: 'Cat',
         DOG1: 'Dog',
       }} 
-      className="p32 bg-primary-300 br24 bs-lg"
+      classNames={{ container: "p32 bg-primary-300 br24 bs-lg" }}
     />
   );
 }
@@ -130,7 +122,7 @@ export const RadioWithCustomOptionStyles = ({ onChange }: RadioProps<string>) =>
         CAT2: 'Cat',
         DOG2: 'Dog',
       }} 
-      optionClassName="mb32 p24 bg-green-100 br12 bs-lg"
+      classNames={{ option: "mb32 p24 bg-green-100 br12 bs-lg" }}
     />
   );
 }
@@ -151,7 +143,7 @@ export const RadioWithCustomLabelStyles = ({ onChange }: RadioProps<string>) => 
         CAT3: 'Cat',
         DOG3: 'Dog',
       }} 
-      labelClassName="bg-grey-900 tc-white"
+      classNames={{ label: "bg-grey-900 tc-white" }}
     />
   );
 }
@@ -176,14 +168,14 @@ export const RadioWithInlineLayout = ({ onChange }: RadioProps<string>) => {
         RAT: 'Rat',
         ANOTHER: 'Other',
       }} 
-      optionClassName="w30"
+      classNames={{ option: "w30" }}
       inlineLayout
       wide
     />
   );
 }
 
-export const RadioWithCustomLabel = ({ onChange, wide, className, optionClassName, inlineLayout }: RadioProps<string>) => {
+export const RadioWithCustomLabel = ({ onChange, wide, classNames, inlineLayout }: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {
@@ -209,7 +201,7 @@ export const RadioWithCustomLabel = ({ onChange, wide, className, optionClassNam
       }} 
       onChange={handleOnChange}
       value={checkedValues}
-      optionClassName="w30"
+      classNames={{ option: "w30" }}
       inlineLayout
     />
   );
@@ -217,7 +209,7 @@ export const RadioWithCustomLabel = ({ onChange, wide, className, optionClassNam
 
 RadioStory.storyName = 'Radio';
 
-export const RadioIconOnly = ({ onChange, wide, className, optionClassName, inlineLayout }: RadioProps<string>) => {
+export const RadioIconOnly = ({ onChange, wide, classNames, inlineLayout }: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {
@@ -229,7 +221,7 @@ export const RadioIconOnly = ({ onChange, wide, className, optionClassName, inli
     <Radio 
       options={{ NOTHING: '' }} 
       onChange={handleOnChange}
-      labelClassName='jc-start'
+      classNames={{ label: 'jc-start' }}
       value={checkedValues}
       bordered={false}
     />

--- a/src/lib/components/input/radio/index.stories.tsx
+++ b/src/lib/components/input/radio/index.stories.tsx
@@ -1,0 +1,241 @@
+
+import { useState } from 'react';
+import { Radio, RadioProps } from '.';
+import { images } from '../../../util/images';
+
+const story = {
+  title: 'JSX/Inputs/Radio',
+  component: Radio,
+  argTypes: {
+    options: {
+      description: 'Object that contains the possible options for rendering in the input.',
+      defaultValue: {
+        CAT:{
+          title: 'Cat',
+          description: 'At least 1'
+        },
+        DOG:{
+          title: 'Dog',
+          description: 'At least 2'
+        },
+        NONE:{
+          title: 'None',
+          description: 'No pets'
+        }
+      }
+    },
+    value: {
+      description: 'Current checked values.',
+    },
+    onChange: {
+      description: 'Function called everytime a value changes.',
+      action: true,
+      table: {
+        category: "Callbacks",
+      },
+    },
+    wide: {
+      description: 'Property that defines if options should fill 100% of available horizontal space',
+      defaultValue: false
+    },
+    inlineLayout: {
+      description: 'Property that defines if options should show inline instead of block. Check inline radio options story for examples.',
+      defaultValue: false
+    },
+    className: {
+      description: 'Wrapper classNames for custom styling',
+      defaultValue: ''
+    },
+    optionClassName: {
+      description: 'Option classNames for custom styling',
+      defaultValue: ''
+    },
+    labelClassName: {
+      description: 'Label classNames for custom styling',
+      defaultValue: ''
+    },
+    bordered: {
+      description: 'Property that defines if option should show with border',
+      defaultValue: true
+    },
+  }
+};
+
+export const RadioStory = ({ 
+  onChange,
+  options,
+  wide,
+  className,
+  optionClassName,
+  labelClassName,
+  inlineLayout,
+  bordered,
+}: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      wide={wide}
+      options={options} 
+      onChange={handleOnChange}
+      value={checkedValues}
+      className={className}
+      labelClassName={labelClassName}
+      optionClassName={optionClassName}
+      inlineLayout={inlineLayout}
+      bordered={bordered}
+    />
+  );
+}
+
+export const RadioWithCustomWrapperStyles = ({ onChange }: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT1: 'Cat',
+        DOG1: 'Dog',
+      }} 
+      className="p32 bg-primary-300 br24 bs-lg"
+    />
+  );
+}
+
+export const RadioWithCustomOptionStyles = ({ onChange }: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT2: 'Cat',
+        DOG2: 'Dog',
+      }} 
+      optionClassName="mb32 p24 bg-green-100 br12 bs-lg"
+    />
+  );
+}
+
+export const RadioWithCustomLabelStyles = ({ onChange }: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string  ) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT3: 'Cat',
+        DOG3: 'Dog',
+      }} 
+      labelClassName="bg-grey-900 tc-white"
+    />
+  );
+}
+
+export const RadioWithInlineLayout = ({ onChange }: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT4: 'Cat',
+        DOG4: 'Dog',
+        FISHER: 'Fish',
+        RABBIT: 'Rabbit',
+        RAT: 'Rat',
+        ANOTHER: 'Other',
+      }} 
+      optionClassName="w30"
+      inlineLayout
+      wide
+    />
+  );
+}
+
+export const RadioWithCustomLabel = ({ onChange, wide, className, optionClassName, inlineLayout }: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      options={{
+        BIGDOG: {
+          icon: () => <img src={images.bigDog} alt='' />,
+          title: 'Dog',
+        },
+        FISH:{
+          icon: () => <img src={images.brokenAquarium} alt='' />,
+          title: 'Fish',
+        },
+        OTHER:{
+          icon: () => <img src={images.brokenGlass} alt='' />,
+          title: 'Other',
+        }
+      }} 
+      onChange={handleOnChange}
+      value={checkedValues}
+      optionClassName="w30"
+      inlineLayout
+    />
+  );
+}
+
+RadioStory.storyName = 'Radio';
+
+export const RadioIconOnly = ({ onChange, wide, className, optionClassName, inlineLayout }: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      options={{ NOTHING: '' }} 
+      onChange={handleOnChange}
+      labelClassName='jc-start'
+      value={checkedValues}
+      bordered={false}
+    />
+  );
+}
+
+RadioStory.storyName = 'Radio';
+
+export default story;

--- a/src/lib/components/input/radio/index.test.tsx
+++ b/src/lib/components/input/radio/index.test.tsx
@@ -1,0 +1,94 @@
+import { render } from '../../../util/testUtils';
+
+import { Radio, RadioProps } from '.';
+
+const mockOnChange = jest.fn();
+
+const setup = (onChange: RadioProps<string>['onChange'], value?: string) => {
+  const utils = render(
+    <Radio
+      options={{
+        CAT: 'Cat',
+        DOG: 'Dog',
+        NONE: 'None',
+      }}
+      onChange={onChange}
+      value={value}
+    />
+  );
+
+  return utils;
+};
+
+describe('Radio component', () => {
+  it('Should render options', () => {
+    const { getByText } = setup(mockOnChange);
+
+    expect(getByText('Cat')).toBeInTheDocument();
+    expect(getByText('Dog')).toBeInTheDocument();
+    expect(getByText('None')).toBeInTheDocument();
+  });
+
+  it('Should call onchange on selecting an option', async () => {
+    const { getByTestId, user } = setup(mockOnChange);
+
+    await user.click(getByTestId('radio-DOG'));
+
+    expect(mockOnChange).toBeCalledWith("DOG");
+  });
+
+  it('Should render checked items when value is passed', async () => {
+    const { getByTestId } = setup(mockOnChange, 'CAT');
+
+    expect(getByTestId('radio-input-CAT')).toBeChecked();
+  });
+
+  it('Should render custom description', () => {
+      const { getByText } = render(
+        <Radio
+          options={{
+            CAT: {
+              title: 'Cat',
+              description: 'Cat description'
+            },
+          }}
+          onChange={mockOnChange}
+        />
+      );
+
+    expect(getByText('Cat description')).toBeInTheDocument();
+  });
+
+  it('Should render custom icon', () => {
+      const { getByText } = render(
+        <Radio
+          options={{
+            CAT: {
+              title: 'Cat',
+              icon: () => 'ICON'
+            },
+          }}
+          onChange={mockOnChange}
+        />
+      );
+
+    expect(getByText('ICON')).toBeInTheDocument();
+  });
+
+  it('Should render custom icon with selected', () => {
+      const { getByText } = render(
+        <Radio
+          options={{
+            CAT: {
+              title: 'Cat',
+              icon: (selected) => selected ? 'SELECTED-ICON' : 'ICON'
+            },
+          }}
+          onChange={mockOnChange}
+          value={'CAT'}
+        />
+      );
+
+    expect(getByText('SELECTED-ICON')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/input/radio/index.tsx
+++ b/src/lib/components/input/radio/index.tsx
@@ -1,0 +1,104 @@
+import classNames from "classnames";
+import { ReactNode } from "react";
+
+import styles from './styles.module.scss';
+export interface RadioWithDescription {
+  title: string;
+  description?: string;
+  icon?: (selected: boolean) => ReactNode;
+  hideBox?: boolean;
+}
+
+export interface RadioProps<ValueType extends string> {
+  options: Record<ValueType, string | RadioWithDescription>;
+  value?: ValueType;
+  onChange: (value: ValueType) => void;
+  wide?: boolean;
+  inlineLayout?: boolean;
+  className?: string;
+  labelClassName?: string;
+  optionClassName?: string
+  bordered?: boolean;
+}
+
+export const Radio = <ValueType extends string>({
+  options,
+  value,
+  onChange,
+  wide = false,
+  inlineLayout = false,
+  className = '',
+  labelClassName = '',
+  optionClassName = '',
+  bordered = true
+}: RadioProps<ValueType>) => {
+  const entries = Object.entries(options) as [
+    ValueType,
+    string | RadioWithDescription
+  ][];
+
+  return (
+    <div
+      className={classNames(className, styles.container, 'd-flex gap8', {
+        [styles.wide]: wide,
+        [styles.narrow]: !wide,
+        'fd-row': inlineLayout,
+        'f-wrap': inlineLayout,
+        'fd-column': !inlineLayout,
+      })}
+    >
+      {entries.map(([currentValue, label]) => {
+        const checked = value === currentValue;
+        const customIcon = (label as RadioWithDescription)?.icon;
+        const hideIcon = (label as RadioWithDescription)?.hideBox;
+
+        return (
+          <div className={optionClassName} key={currentValue}>
+            <input
+              className={classNames(
+                "p-radio", {
+                  'p-radio--no-icon': customIcon || hideIcon,
+                  'p-radio--centered': !label,
+                }
+              )}
+              id={currentValue}
+              type="radio"
+              value={currentValue}
+              onChange={() => onChange(currentValue)}
+              checked={checked}
+              data-testid={`radio-input-${currentValue}`}
+            />
+
+            <label
+              htmlFor={currentValue}
+              className={classNames(
+                labelClassName,
+                'p-label',
+                {
+                  'jc-center': customIcon,
+                  'fd-column': customIcon,
+                  'p-label--bordered': bordered
+                }
+              )}
+              data-cy={`radio-${currentValue}`}
+              data-testid={`radio-${currentValue}`}
+            >
+              {customIcon && (
+                <div className="mt8">{customIcon?.(checked)}</div>
+              )}
+
+              {typeof label === 'string' ? label : (
+                <div>
+                  <p className="p-p">{label.title}</p>
+                  <span className="d-block p-p p-p--small tc-grey-600">
+                    {label.description}
+                  </span>
+                </div>
+              )}
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/lib/components/input/radio/index.tsx
+++ b/src/lib/components/input/radio/index.tsx
@@ -15,9 +15,11 @@ export interface RadioProps<ValueType extends string> {
   onChange: (value: ValueType) => void;
   wide?: boolean;
   inlineLayout?: boolean;
-  className?: string;
-  labelClassName?: string;
-  optionClassName?: string
+  classNames?: {
+    container?: string;
+    label?: string;
+    option?: string;
+  };
   bordered?: boolean;
 }
 
@@ -27,9 +29,7 @@ export const Radio = <ValueType extends string>({
   onChange,
   wide = false,
   inlineLayout = false,
-  className = '',
-  labelClassName = '',
-  optionClassName = '',
+  classNames: classNamesObj,
   bordered = true
 }: RadioProps<ValueType>) => {
   const entries = Object.entries(options) as [
@@ -37,9 +37,10 @@ export const Radio = <ValueType extends string>({
     string | RadioWithDescription
   ][];
 
+
   return (
     <div
-      className={classNames(className, styles.container, 'd-flex gap8', {
+      className={classNames(classNamesObj?.container, styles.container, 'd-flex gap8', {
         [styles.wide]: wide,
         [styles.narrow]: !wide,
         'fd-row': inlineLayout,
@@ -53,7 +54,7 @@ export const Radio = <ValueType extends string>({
         const hideIcon = (label as RadioWithDescription)?.hideBox;
 
         return (
-          <div className={optionClassName} key={currentValue}>
+          <div className={classNamesObj?.option} key={currentValue}>
             <input
               className={classNames(
                 "p-radio", {
@@ -72,7 +73,7 @@ export const Radio = <ValueType extends string>({
             <label
               htmlFor={currentValue}
               className={classNames(
-                labelClassName,
+                classNamesObj?.label,
                 'p-label',
                 {
                   'jc-center': customIcon,

--- a/src/lib/components/input/radio/styles.module.scss
+++ b/src/lib/components/input/radio/styles.module.scss
@@ -1,0 +1,11 @@
+.container {
+  max-width: 100%;
+}
+
+.narrow {
+  max-width: 424px;
+}
+
+.wide {
+  max-width: 736px;
+}

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -15,6 +15,7 @@ import IbanInput from './components/input/iban';
 import CurrencyInput from './components/input/currency';
 import { Badge } from './components/badge';
 import { Checkbox } from './components/input/checkbox';
+import { Radio } from './components/input/radio';
 import {
   BottomModal,
   RegularModal,
@@ -77,6 +78,7 @@ export {
   SegmentedControl,
   Markdown,
   Checkbox,
+  Radio,
   Link,
   InformationBox,
   Badge,

--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -89,8 +89,15 @@
       transition: 0.3s background-color;
     }
   }
+
+  &.p-radio--centered + label::before {
+    margin-right: 0;
+  }
 }
 
+.p-radio--no-icon + label::before {
+  display: none!important;
+}
 .p-radio:checked {
   & + label::before {
     border-color: $ds-primary-500;


### PR DESCRIPTION
### What this PR does
This PR adds the Radio component.

### How to test?
Check the [radio story](http://localhost:9009/?path=/docs/jsx-inputs-radio--radio-story).

![Screenshot 2023-08-21 at 13 51 34](https://github.com/getPopsure/dirty-swan/assets/4015038/386b27db-a156-4ebc-a1db-8b5e86c78754)


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
