### PR TITLE
refactor(checkbox): Refactor checkbox to use classnames object

### DIFF
--- a/src/lib/components/input/checkbox/index.stories.tsx
+++ b/src/lib/components/input/checkbox/index.stories.tsx
@@ -48,16 +48,12 @@ const story = {
       defaultValue: false
     },
     className: {
-      description: 'Wrapper classNames for custom styling',
-      defaultValue: ''
-    },
-    optionClassName: {
-      description: 'Option classNames for custom styling',
-      defaultValue: ''
-    },
-    labelClassName: {
-      description: 'Label classNames for custom styling',
-      defaultValue: ''
+      description: 'ClassNames for custom styling',
+      defaultValue: {
+        container: '',
+        label: '',
+        option: ''
+      }
     },
   }
 };
@@ -67,9 +63,7 @@ export const CheckboxStory = ({
   options,
   wide,
   bordered,
-  className,
-  optionClassName,
-  labelClassName,
+  classNames,
   inlineLayout,
 }: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
@@ -86,9 +80,7 @@ export const CheckboxStory = ({
       onChange={handleOnChange}
       value={checkedValues}
       bordered={bordered}
-      className={className}
-      labelClassName={labelClassName}
-      optionClassName={optionClassName}
+      classNames={classNames}
       inlineLayout={inlineLayout}
     />
   );
@@ -110,7 +102,7 @@ export const CheckboxWithCustomWrapperStyles = ({ onChange }: CheckboxProps<stri
         CAT1: 'Cat',
         DOG1: 'Dog',
       }} 
-      className="p32 bg-primary-300 br24 bs-lg"
+      classNames={{ container: "p32 bg-primary-300 br24 bs-lg" }}
     />
   );
 }
@@ -131,7 +123,7 @@ export const CheckboxWithCustomOptionStyles = ({ onChange }: CheckboxProps<strin
         CAT2: 'Cat',
         DOG2: 'Dog',
       }} 
-      optionClassName="mb32 p24 bg-green-100 br12 bs-lg"
+      classNames={{ option: "mb32 p24 bg-green-100 br12 bs-lg" }}
     />
   );
 }
@@ -152,7 +144,7 @@ export const CheckboxWithCustomLabelStyles = ({ onChange }: CheckboxProps<string
         CAT3: 'Cat',
         DOG3: 'Dog',
       }} 
-      labelClassName="bg-grey-900 tc-white"
+      classNames={{ label: "bg-grey-900 tc-white" }}
     />
   );
 }
@@ -177,14 +169,14 @@ export const CheckboxWithInlineLayout = ({ onChange }: CheckboxProps<string>) =>
         RAT: 'Rat',
         ANOTHER: 'Other',
       }} 
-      optionClassName="w30"
+      classNames={{ option: "w30" }}
       inlineLayout
       wide
     />
   );
 }
 
-export const CheckboxWithCustomLabel = ({ onChange, wide, className, optionClassName, inlineLayout }: CheckboxProps<string>) => {
+export const CheckboxWithCustomLabel = ({ onChange, wide, classNames, inlineLayout }: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
   const handleOnChange = (newValue: string[] = []) => {
@@ -210,7 +202,7 @@ export const CheckboxWithCustomLabel = ({ onChange, wide, className, optionClass
       }} 
       onChange={handleOnChange}
       value={checkedValues}
-      optionClassName="w30"
+      classNames={{ option: "w30" }}
       inlineLayout
     />
   );

--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -15,9 +15,11 @@ export interface CheckboxProps<ValueType extends string> {
   wide?: boolean;
   inlineLayout?: boolean;
   bordered?: Boolean,
-  className?: string;
-  labelClassName?: string;
-  optionClassName?: string
+  classNames?: {
+    container?: string;
+    label?: string;
+    option?: string;
+  }
 }
 
 export const Checkbox = <ValueType extends string>({
@@ -27,9 +29,7 @@ export const Checkbox = <ValueType extends string>({
   wide = false,
   inlineLayout = false,
   bordered = true,
-  className = '',
-  labelClassName = '',
-  optionClassName = '',
+  classNames: classNamesObj,
 }: CheckboxProps<ValueType> & {  }) => {
   const hasNoneValue = Object.keys(options).includes('NONE');
 
@@ -70,7 +70,7 @@ export const Checkbox = <ValueType extends string>({
 
   return (
     <div
-      className={classNames(className, styles.container, 'd-flex gap8', {
+      className={classNames(classNamesObj?.container, styles.container, 'd-flex gap8', {
         [styles.narrow]: !wide,
         'fd-row': inlineLayout,
         'f-wrap': inlineLayout,
@@ -82,7 +82,7 @@ export const Checkbox = <ValueType extends string>({
         const customIcon = (label as CheckboxWithDescription)?.icon;
 
         return (
-          <div className={optionClassName} key={currentValue}>
+          <div className={classNamesObj?.option} key={currentValue}>
             <input
               className={classNames(
                 "p-checkbox", {
@@ -100,7 +100,7 @@ export const Checkbox = <ValueType extends string>({
             <label
               htmlFor={currentValue}
               className={classNames(
-                labelClassName,
+                classNamesObj?.label,
                 'p-label pr16',
                 {
                   'p-label--bordered': bordered,


### PR DESCRIPTION
### What this PR does
Refactor checkbox to use classnames object instead of string, no visible changes apart from prop usage.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
