### PR TITLE
fix(comparison-table): Fix comparison table not setting ref on load

### DIFF
--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ArrowValues } from '../components/TableArrows';
 
+const headerId = 'comparison-table-header';
+
 export const useComparisonTable = () => {
   const [showMore, setShowMore] = useState<boolean>(false);
   const [headerWidth, setHeaderWidth] = useState(1400);
@@ -110,8 +112,21 @@ export const useComparisonTable = () => {
     setShowMore(!showMore);
   };
 
+  useEffect(() => {
+    if (headerRef.current) {
+      return;
+    }
+
+    const headerById = document.getElementById(headerId);
+console.log('headerById :>> ', headerById);
+    if (headerById) {
+      scrollContainerCallbackRef(headerById);
+    }
+  }, [scrollContainerCallbackRef]);
+
   return {
     headerWidth,
+    headerId,
     contentContainerRef,
     selectedSection,
     setSelectedSection,

--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -118,7 +118,7 @@ export const useComparisonTable = () => {
     }
 
     const headerById = document.getElementById(headerId);
-console.log('headerById :>> ', headerById);
+
     if (headerById) {
       scrollContainerCallbackRef(headerById);
     }

--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -2,15 +2,13 @@ import debounce from 'lodash.debounce';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ArrowValues } from '../components/TableArrows';
-
-const headerId = 'comparison-table-header';
+import generateId from '../../../util/generateId';
 
 export const useComparisonTable = () => {
   const [showMore, setShowMore] = useState<boolean>(false);
   const [headerWidth, setHeaderWidth] = useState(1400);
-
+  const [headerId, setHeaderId] = useState('');
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
-
   const [selectedSection, setSelectedSection] = useState('');
 
   const headerRef = useRef<HTMLDivElement | null>(null);
@@ -122,7 +120,11 @@ export const useComparisonTable = () => {
     if (headerById) {
       scrollContainerCallbackRef(headerById);
     }
-  }, [scrollContainerCallbackRef]);
+  }, [headerId, scrollContainerCallbackRef]);
+
+  useEffect(() => {
+    setHeaderId(generateId());
+  }, []);
 
   return {
     headerWidth,

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Fragment } from 'react';
+import { Fragment, useEffect } from 'react';
 import { ScrollSync, ScrollSyncPane } from 'react-scroll-sync';
 
 import { AccordionItem } from './components/AccordionItem';
@@ -85,6 +85,7 @@ const ComparisonTable = <T extends { id: number }>(
     handleArrowsClick,
     toggleMoreRows,
     showMore,
+    headerId,
   } = useComparisonTable();
 
   const cssVariablesStyle = {
@@ -105,6 +106,7 @@ const ComparisonTable = <T extends { id: number }>(
         <div className={classNames(baseStyles.header, styles?.header)}>
           <ScrollSyncPane>
             <div
+              id={headerId}
               className={classNames(baseStyles.container, {
                 [baseStyles.noScrollBars]: hideScrollBars,
               })}


### PR DESCRIPTION
### What this PR does
This PR fixes comparison table not setting ref on load.

This is a **temporary solution as react-scroll-sync isn't maintained anymore**. 
There is an active issue in the repo that fixes our needs https://github.com/okonet/react-scroll-sync/issues/79 and we should be able to use ref and not IDs once this is released.

### How to test?
Go to a comparison table component on mobile, hard refresh and click on the right arrow (it will only work after you swipe on the content). 
This happens because onSync only triggers after scrolling changes and not on load and the way react-scroll-sync works, we cannot use refs for internal divs 😭 



### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
