### PR TITLE
fix(checkbox): [EMU-4092] update vertical padding

### DIFF
--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -146,7 +146,7 @@
 }
 
 .p-checkbox--no-icon + label::before {
-  display: none!important;
+  display: none !important;
 }
 
 .p-label {
@@ -162,7 +162,7 @@
   &--bordered {
     align-items: center;
 
-    padding: 8px 16px;
+    padding: 12px 16px;
 
     border-radius: 8px;
     border: 1px solid $ds-grey-400;


### PR DESCRIPTION
### What this PR does

1. Updates the bordered checkbox component's vertical padding (from `8px` to `12px`)
2. This change is also reflected on the CSS radio button component since it also uses the `p-label--bordered` class.

Current:
<img width="433" alt="EMU-4092-current" src="https://github.com/getPopsure/dirty-swan/assets/113006001/6294f1ec-b6c7-48e8-9f24-a7d4bf0d44d8">

Updated:
<img width="446" alt="EMU-4092-updated" src="https://github.com/getPopsure/dirty-swan/assets/113006001/de824e6c-fd87-4c91-8b03-7bc41af4ba2a">

### Why is this needed?

Solves:
[EMU-4092](https://linear.app/feather-insurance/issue/EMU-4092/update-padding-on-checkbox-component) 

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge
