### PR TITLE
feat(spinner): [EMU-6599] add spinner component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,7 @@ export {
   InformationBox,
   Badge,
   images,
+  Spinner,
 } from './lib';
 
 export * from './lib/components/icon';
@@ -46,6 +47,6 @@ export type {
   TableHeader,
   UploadedFile,
   UploadStatus,
- } from './lib';
+} from './lib';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/lib/components/spinner/index.stories.tsx
+++ b/src/lib/components/spinner/index.stories.tsx
@@ -1,0 +1,19 @@
+import { Spinner, SpinnerProps } from '.';
+
+const story = {
+  title: 'JSX/Spinner',
+  component: Spinner,
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      defaultValue: 's',
+      description: 'Property that allows to customize the size of the spinner.',
+    },
+  },
+};
+
+export const SpinnerStory = ({ size }: SpinnerProps) => <Spinner size={size} />;
+
+SpinnerStory.storyName = 'Spinner';
+
+export default story;

--- a/src/lib/components/spinner/index.test.tsx
+++ b/src/lib/components/spinner/index.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '../../util/testUtils';
+
+import { Spinner } from '.';
+
+describe('Spinner component', () => {
+  it('Should render spinner', async () => {
+    render(<Spinner></Spinner>);
+
+    expect(screen.getByTestId('ds-spinner')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/spinner/index.tsx
+++ b/src/lib/components/spinner/index.tsx
@@ -1,0 +1,14 @@
+import classNames from 'classnames';
+
+export interface SpinnerProps {
+  size?: 's' | 'm' | 'l';
+}
+
+const Spinner = ({ size = 's' }: SpinnerProps) => (
+  <div
+    className={classNames('ds-spinner', `ds-spinner__${size}`)}
+    data-testid="ds-spinner"
+  ></div>
+);
+
+export { Spinner };

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -2,12 +2,12 @@ import { DateSelector } from './components/dateSelector';
 import { SignaturePad } from './components/signaturePad';
 import { AutocompleteAddress } from './components/autocompleteAddress';
 import { Input } from './components/input';
-import { 
+import {
   MultiDropzone,
   FileType,
   MultiDropzoneProps,
   UploadedFile,
-  UploadStatus
+  UploadStatus,
 } from './components/multiDropzone';
 import { DownloadButton } from './components/downloadButton';
 import { InformationBox } from './components/informationBox';
@@ -44,6 +44,7 @@ import { SegmentedControl } from './components/segmentedControl';
 import { Markdown } from './components/markdown';
 import { Link } from './components/link';
 import { images } from './util/images';
+import { Spinner } from './components/spinner';
 
 export * from './components/icon';
 
@@ -81,6 +82,7 @@ export {
   InformationBox,
   Badge,
   images,
+  Spinner,
 };
 
 export type {
@@ -88,7 +90,7 @@ export type {
   MultiDropzoneProps,
   TableHeader,
   UploadedFile,
-  UploadStatus
+  UploadStatus,
 };
 
 export type { DownloadStatus } from './models/download';


### PR DESCRIPTION
### What this PR does

1. Creates a spinner React-based component using classes from the CSS version.

<img width="700" alt="EMU-6599" src="https://github.com/getPopsure/dirty-swan/assets/113006001/0a4bad94-4fcc-4bd8-8237-b4bd8199b2ea">

### Why is this needed?

Solves:
[EMU-6599](https://linear.app/feather-insurance/issue/EMU-6599/create-spinner-component)

### How to test?
In the new Spinner component within the JSX section of Dirty Swan, try updating the size property using the dropdown menu in the Docs. The spinner size should increase or decrease based on your selection.

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge
