### PR TITLE
fix(checkbox): Add bordered prop and fix wide true size

### DIFF
--- a/src/lib/components/input/checkbox/index.stories.tsx
+++ b/src/lib/components/input/checkbox/index.stories.tsx
@@ -38,6 +38,11 @@ const story = {
       description: 'Property that defines if options should fill 100% of available horizontal space',
       defaultValue: false
     },
+    bordered: {
+      control: { type: 'boolean' },
+      description: 'Property that defines if checkbox should show the border around each label',
+      defaultValue: true
+    },
     inlineLayout: {
       description: 'Property that defines if options should show inline instead of block. Check inline checkbox options story for examples.',
       defaultValue: false
@@ -61,6 +66,7 @@ export const CheckboxStory = ({
   onChange,
   options,
   wide,
+  bordered,
   className,
   optionClassName,
   labelClassName,
@@ -79,6 +85,7 @@ export const CheckboxStory = ({
       options={options} 
       onChange={handleOnChange}
       value={checkedValues}
+      bordered={bordered}
       className={className}
       labelClassName={labelClassName}
       optionClassName={optionClassName}

--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -14,6 +14,7 @@ export interface CheckboxProps<ValueType extends string> {
   onChange: (value: ValueType[]) => void;
   wide?: boolean;
   inlineLayout?: boolean;
+  bordered?: Boolean,
   className?: string;
   labelClassName?: string;
   optionClassName?: string
@@ -25,6 +26,7 @@ export const Checkbox = <ValueType extends string>({
   onChange,
   wide = false,
   inlineLayout = false,
+  bordered = true,
   className = '',
   labelClassName = '',
   optionClassName = '',
@@ -69,7 +71,6 @@ export const Checkbox = <ValueType extends string>({
   return (
     <div
       className={classNames(className, styles.container, 'd-flex gap8', {
-        [styles.wide]: wide,
         [styles.narrow]: !wide,
         'fd-row': inlineLayout,
         'f-wrap': inlineLayout,
@@ -100,8 +101,9 @@ export const Checkbox = <ValueType extends string>({
               htmlFor={currentValue}
               className={classNames(
                 labelClassName,
-                'p-label p-label--bordered pr16',
+                'p-label pr16',
                 {
+                  'p-label--bordered': bordered,
                   'jc-center': customIcon,
                   'fd-column': customIcon
                 }

--- a/src/lib/components/input/checkbox/styles.module.scss
+++ b/src/lib/components/input/checkbox/styles.module.scss
@@ -5,7 +5,3 @@
 .narrow {
   max-width: 424px;
 }
-
-.wide {
-  max-width: 736px;
-}


### PR DESCRIPTION
### What this PR does
This PR updates the checkbox component:
- adds a bordered prop allowing to have a checkbox without the bordered label:
<img width="304" alt="Screenshot 2023-09-05 at 11 03 43" src="https://github.com/getPopsure/dirty-swan/assets/4015038/a5133d29-9454-49dc-8b27-077d39fa3841">

- fixes the wide prop, making it full width when wide is true. Fixed wide pixel widths should be defined in usage, not at the design system level:
**Before**
<img width="500" alt="Screenshot 2023-09-05 at 11 03 29" src="https://github.com/getPopsure/dirty-swan/assets/4015038/f157dec2-34df-4ac0-8345-2d3ed16fc758">

**After**
<img width="500" alt="Screenshot 2023-09-05 at 11 03 10" src="https://github.com/getPopsure/dirty-swan/assets/4015038/9894baa1-d2ef-4ea9-8c6b-9fe311fae657">



### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
