### PR TITLE
fix(address-autocomplete): [EMU-5932] make “enter address manually" accessible

### DIFF
--- a/src/lib/components/autocompleteAddress/index.test.tsx
+++ b/src/lib/components/autocompleteAddress/index.test.tsx
@@ -62,13 +62,13 @@ describe('AutocompleteAddress component', () => {
     });
 
     expect(getAllByTestId(inputTestId).length).toEqual(5);
-    expect(getByDisplayValue("Köpeniker Strasse")).toBeVisible();
+    expect(getByDisplayValue('Köpeniker Strasse')).toBeVisible();
   });
 
   it('Should enable to enter the address manually', async () => {
     const callback = jest.fn();
     const { findByText, getAllByTestId, user } = setup(undefined, callback);
-    const btn = await findByText('Enter address manually');
+    const btn = await findByText('enter address manually');
 
     await user.click(btn);
 
@@ -87,9 +87,9 @@ describe('AutocompleteAddress component', () => {
   it('Should prefill fields if an address is provided', async () => {
     const { getByDisplayValue } = setup(address);
 
-    expect(getByDisplayValue("Köpeniker Strasse")).toBeVisible();
-    expect(getByDisplayValue("4000")).toBeVisible();
-    expect(getByDisplayValue("10179")).toBeVisible();
-    expect(getByDisplayValue("Berlin")).toBeVisible();
+    expect(getByDisplayValue('Köpeniker Strasse')).toBeVisible();
+    expect(getByDisplayValue('4000')).toBeVisible();
+    expect(getByDisplayValue('10179')).toBeVisible();
+    expect(getByDisplayValue('Berlin')).toBeVisible();
   });
 });

--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -343,7 +343,7 @@ const AutocompleteAddress = ({
         <div className="p-p mt8">
           {manualAddressEntryTexts?.preText || 'Or '}
           <button
-            className={classNames(`p-a p-p fw-bold c-pointer bg-transparent`)}
+            className={'p-a p-p fw-bold c-pointer bg-transparent'}
             onClick={handleEnterAddressManually}
             type="button"
           >

--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -239,7 +239,10 @@ const AutocompleteAddress = ({
               ref={autocompleteElement}
             />
             {hasLoadedGoogleAPI === false && (
-              <div data-cy="google-api-loader" className={styles['loading-spinner']}>
+              <div
+                data-cy="google-api-loader"
+                className={styles['loading-spinner']}
+              >
                 <div className="ds-spinner ds-spinner__m" />
               </div>
             )}
@@ -339,12 +342,13 @@ const AutocompleteAddress = ({
       {manualAddressEntry === false && (
         <div className="p-p mt8">
           {manualAddressEntryTexts?.preText || 'Or '}
-          <span
-            className="p-a fw-bold c-pointer"
+          <button
+            className={classNames(`p-a p-p fw-bold c-pointer bg-transparent`)}
             onClick={handleEnterAddressManually}
+            type="button"
           >
-            {manualAddressEntryTexts?.cta || 'Enter address manually'}
-          </span>
+            {manualAddressEntryTexts?.cta || 'enter address manually'}
+          </button>
         </div>
       )}
     </>


### PR DESCRIPTION
### What this PR does

1. Replaces the `<span>` element with a `<button>`
2. Adds additional styling to the button for it to align with the original design
3. Updates to lowercase the first letter of the button copy in English - both in JSX and in the test file (in German it should stay uppercase)


<img width="611" alt="EMU-5932-eng" src="https://github.com/getPopsure/dirty-swan/assets/113006001/659905f2-3668-4e1c-b693-4f9e6b7d01d2">
<img width="614" alt="EMU-5932-deu" src="https://github.com/getPopsure/dirty-swan/assets/113006001/188174f6-3c66-467a-8477-455f3fb17216">


### Why is this needed?

Solves:
[EMU-5932](https://linear.app/feather-insurance/issue/EMU-5932/address-autocomplete-component-make-enter-address-manually-accessible)

### How to test?

In the JSX/AutocompleteAddress component.

### Checklist:

- [x] I reviewed my own code
- [x]The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge
