### PR TITLE
fix(icon): Fix icon wrapper not centering SVG

### DIFF
--- a/src/lib/components/icon/IconWrapper/IconWrapper.tsx
+++ b/src/lib/components/icon/IconWrapper/IconWrapper.tsx
@@ -21,8 +21,12 @@ const IconWrapper = ({
     className={classNames('d-inline-block', styles.wrapper, className ?? '', {
       [`tc-${color}`]: !!color,
     })}
+    style={{
+      width: `${size}px`,
+      height: `${size}px`
+    }}
   >
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <svg className='w100' viewBox="0 0 24 24" fill="none">
       {children}
     </svg>
   </span>

--- a/src/lib/components/icon/IconWrapper/styles.module.scss
+++ b/src/lib/components/icon/IconWrapper/styles.module.scss
@@ -1,3 +1,3 @@
 .wrapper {
-  margin: 4px;
+  padding: 4px;
 }


### PR DESCRIPTION
### What this PR does
Icons paths were not centered withing SVG causing a slight disalignment:
**Before:**
<img width="100" alt="Screenshot 2023-09-14 at 13 48 33" src="https://github.com/getPopsure/dirty-swan/assets/4015038/e1f3d126-4b15-45ea-a2d4-b2b7f85c364a">

**After:**
<img width="100" alt="Screenshot 2023-09-14 at 13 47 19" src="https://github.com/getPopsure/dirty-swan/assets/4015038/7ae26a50-ec7d-45e0-9e38-37636c791d08">


Solves:
STO-XXX
EMU-XXX
RVN-XXX

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
