### PR TITLE
fix(icon): Replace padding with margin

### DIFF
--- a/src/lib/components/icon/IconWrapper/styles.module.scss
+++ b/src/lib/components/icon/IconWrapper/styles.module.scss
@@ -1,3 +1,3 @@
 .wrapper {
-  padding: 4px;
+  margin: 4px;
 }


### PR DESCRIPTION
### What this PR does
Replaces/reverts icon padding with margin as it was changed by mistake on the previous release.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
