### PR TITLE
fix(address): prevent infinite loop when initial address is not provided

### DIFF
--- a/src/lib/components/autocompleteAddress/index.stories.tsx
+++ b/src/lib/components/autocompleteAddress/index.stories.tsx
@@ -9,49 +9,55 @@ const story = {
     address: {
       description: 'The address properties',
       table: {
-        type: { 
-          summary: 'Partial<Address>'
+        type: {
+          summary: 'Partial<Address>',
         },
       },
     },
     apiKey: {
       defaultValue: 'AIzaSyDg0DSrjYKt5smmsjkVasDz7c4T5rbOXT8',
-      description: 'Your private API key for the [Google Places API](https://developers.google.com/maps/documentation/places/web-service/overview)',
+      description:
+        'Your private API key for the [Google Places API](https://developers.google.com/maps/documentation/places/web-service/overview)',
       table: {
-        type: { 
-          summary: 'Partial<Address>'
+        type: {
+          summary: 'Partial<Address>',
         },
       },
     },
     onAddressChange: {
-      description: 'Callback with the updated address, this function will get called everytime the address gets updated',
+      description:
+        'Callback with the updated address, this function will get called everytime the address gets updated',
       action: true,
       table: {
-        category: "Callbacks",
+        category: 'Callbacks',
       },
     },
     manualAddressEntryTexts: {
-      description: 'The CTA that enables manual address entry and the text preceding it',
+      description:
+        'The CTA that enables manual address entry and the text preceding it',
       table: {
         type: {
-            summary: '{ preText?: string; cta: string?; }'
-        }
-      }
+          summary: '{ preText?: string; cta: string?; }',
+        },
+      },
     },
     placeholders: {
       description: 'Placeholder text',
       table: {
         type: {
-            summary: '{ manualAddressEntry?: string; street: string?; houseNumber?: string; additionalInformation?: string; postcode?: string; city?: string; }'
-        }
-      }
-    }
+          summary:
+            '{ manualAddressEntry?: string; street: string?; houseNumber?: string; additionalInformation?: string; postcode?: string; city?: string; }',
+        },
+      },
+    },
   },
   parameters: {
-    componentSubtitle: 'Autocomplete Address are user interface elements which allow users start typing an address and get autocompletion suggestions on the address.',
+    componentSubtitle:
+      'Autocomplete Address are user interface elements which allow users start typing an address and get autocompletion suggestions on the address.',
     docs: {
       description: {
-          component: 'This component is for now only restricted to "address" types and will restrict every query to Germany.',
+        component:
+          'This component is for now only restricted to "address" types and will restrict every query to Germany.',
       },
     },
     customTypes: {
@@ -62,8 +68,8 @@ const story = {
           city: string;
           additionalInformation?: string;
           country: string;
-      }`
-    }
+      }`,
+    },
   },
 };
 
@@ -74,9 +80,11 @@ export const AutocompleteAddressStory = ({
   onAddressChange,
   placeholders,
 }: AutocompleteAddressProps) => {
-  const [address, setAddress] = useState<Partial<Address> | undefined>(defaultAddress);
+  const [address, setAddress] = useState<Partial<Address> | undefined>(
+    defaultAddress
+  );
   const handleOnAddressChange = (newAddress: Partial<Address>) => {
-    onAddressChange(newAddress);
+    onAddressChange?.(newAddress);
     setAddress(newAddress);
   };
 
@@ -91,24 +99,24 @@ export const AutocompleteAddressStory = ({
   );
 };
 
-AutocompleteAddressStory.storyName = "AutocompleteAddress";
+AutocompleteAddressStory.storyName = 'AutocompleteAddress';
 
 export const WithAddress = ({
   apiKey,
   onAddressChange,
   placeholders,
 }: AutocompleteAddressProps) => (
-    <AutocompleteAddress
-      address={{
-        street: 'Lohmuehlenstraße',
-        houseNumber: '65',
-        city: 'Berlin',
-        country: 'DE',
-        additionalInformation: 'c/o Factory',
-      }}
-      apiKey={apiKey}
-      onAddressChange={onAddressChange}
-    />
+  <AutocompleteAddress
+    address={{
+      street: 'Lohmuehlenstraße',
+      houseNumber: '65',
+      city: 'Berlin',
+      country: 'DE',
+      additionalInformation: 'c/o Factory',
+    }}
+    apiKey={apiKey}
+    onAddressChange={onAddressChange}
+  />
 );
 
 export const WithLocalisationEntryText = ({


### PR DESCRIPTION
### What this PR does

1. This PR removes the `onAddressChange` callback from the `useEffect` to prevent an infinite loop when `address` prop is not provided.
2. It adds the `name` attribute to the inputs to better improve a11y
3. It provides an `inputProps` prop in order to modify the `name` attribute and any other future values we seem necessary in the future
4. It also reformats the AutocompleteAddress story

Solves:
EMU-6719

### How to test?
1. To test this, you have to modify the `AutocompleteAddressStory` function and remove the address prop:
```tsx
  return (
    <AutocompleteAddress
      // address={address}
      apiKey={apiKey}
      manualAddressEntryTexts={manualAddressEntryTexts}
      onAddressChange={handleOnAddressChange}
      placeholders={placeholders}
    />
  );
```
2. Go go the storypage on Storybook and enter an address
6. The autocomplete should work and no infinite loop should be triggered.
If you try this same steps on the `main` branch you'd get an infinite loop.


### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
No visual changes
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is No visual changes
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)
No new media

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
