### PR TITLE
fix(card): use div to wrap children

### DIFF
--- a/src/lib/components/cards/cardWithLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithLeftIcon/index.tsx
@@ -1,5 +1,5 @@
 import { associatedClassForCardState, CardProps, headingForCardSize } from '..';
-import { Icon, IconSize, arrowRight } from '../icons';
+import { arrowRight, Icon, IconSize } from '../icons';
 
 import styles from './style.module.scss';
 
@@ -37,7 +37,7 @@ export type CardWithLeftIconProps = Omit<CardProps, 'title'> & {
   leftIconSize?: IconSize;
   title?: string;
   subtitle?: string;
-}
+};
 
 export const CardWithLeftIcon = ({
   className = '',
@@ -78,9 +78,7 @@ export const CardWithLeftIcon = ({
         <div className="d-flex">
           {(title || subtitle) && (
             <div>
-              {title && (
-                <div className={headingStyle}>{title}</div>
-              )}
+              {title && <div className={headingStyle}>{title}</div>}
               {subtitle && (
                 <div className={`tc-grey-500 ${headingStyle}`}>{subtitle}</div>
               )}
@@ -96,7 +94,7 @@ export const CardWithLeftIcon = ({
             />
           )}
         </div>
-        <p className={cardTextStyle}>{children}</p>
+        <div className={cardTextStyle}>{children}</div>
       </div>
     </div>
   );

--- a/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
+++ b/src/lib/components/cards/cardWithTopLeftIcon/index.tsx
@@ -1,9 +1,5 @@
-import {
-  associatedClassForCardState,
-  CardProps,
-  headingForCardSize,
-} from '..';
-import { Icon, arrowRight, featherLogo } from '../icons';
+import { associatedClassForCardState, CardProps, headingForCardSize } from '..';
+import { arrowRight, featherLogo, Icon } from '../icons';
 
 import styles from './style.module.scss';
 
@@ -43,7 +39,9 @@ export const CardWithTopLeftIcon = ({
   const titleContainerStyle = styles['title-container'];
   const headingStyle = headingForCardSize(cardSize);
   const iconStyle = styles['right-icon'];
-  const cardTextStyle = `p-p tc-grey-600 ${cardSize === 'xsmall' ? styles.indent : 'mt16'}`;
+  const cardTextStyle = `p-p tc-grey-600 ${
+    cardSize === 'xsmall' ? styles.indent : 'mt16'
+  }`;
 
   return (
     <div className={cardStyle} {...props}>
@@ -68,7 +66,7 @@ export const CardWithTopLeftIcon = ({
           />
         )}
       </div>
-      <p className={cardTextStyle}>{children}</p>
+      <div className={cardTextStyle}>{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
### What this PR does

This PR updates the `<CardWithLeftIcon />` and `<CardWithTopLeftIcon />` components to use a `div` to wrap children.

### Why is this needed?
In order to provide `p` tags and other more flexible content to the card and not get invalid HTML
![image](https://github.com/getPopsure/dirty-swan/assets/9904702/64256df1-bc2f-4da8-9edb-1df7beb67435)

Solves:
EMU-6678

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
No visual changes
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
No visual changes
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)
No new media

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
