### PR TITLE
fix(uploader): [EMU-6747] Fix file uploader cell with large names

### DIFF
--- a/src/lib/components/multiDropzone/UploadFileCell/index.tsx
+++ b/src/lib/components/multiDropzone/UploadFileCell/index.tsx
@@ -8,7 +8,7 @@ import { UploadStatus, UploadedFile } from '../types';
 interface Props {
   uploadStatus: UploadStatus;
   file: UploadedFile;
-  onRemoveFile: (id: string) => void;
+  onRemoveFile?: (id: string) => void;
   uploading: boolean;
 }
 
@@ -38,11 +38,11 @@ const UploadFileCell: React.FC<Props> = ({
     ERROR: icons.fileErrorIcon,
   };
 
-  const mapDisplayText: { [s in UploadStatus]: string } = {
+  const displayText = {
     UPLOADING: 'Uploading...',
     COMPLETE: name,
     ERROR: error ?? 'Something went wrong. Try uploading again.',
-  };
+  }[uploadStatus];
 
   return (
     <div
@@ -57,8 +57,8 @@ const UploadFileCell: React.FC<Props> = ({
           alt=""
         />
         <div className="w100">
-          <div className={`p-p ${styles['upload-display-text']}`}>
-            {mapDisplayText[uploadStatus]}
+          <div className={`p-p ${styles['upload-display-text']}`} title={displayText}>
+            {displayText}
           </div>
 
           {isUploading && showProgressBar && (
@@ -100,14 +100,16 @@ const UploadFileCell: React.FC<Props> = ({
               </a>
             )}
 
-            <img
-              className={classnames(styles['remove-icon'], {
-                [styles.disabled]: uploading,
-              })}
-              src={hasError ? icons.trashErrorIcon : icons.trashIcon}
-              onClick={() => onRemoveFile(id)}
-              alt="remove"
-            />
+            {onRemoveFile && (
+              <img
+                className={classnames(styles['remove-icon'], {
+                  [styles.disabled]: uploading,
+                })}
+                src={hasError ? icons.trashErrorIcon : icons.trashIcon}
+                onClick={() => onRemoveFile(id)}
+                alt="remove"
+              />
+            )}
           </div>
         )}
       </div>

--- a/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
+++ b/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
@@ -5,7 +5,7 @@
   align-items: center;
   justify-content: space-between;
 
-  height: 64px;
+  min-height: 64px;
   padding: 8px 16px;
 
   border: 1px solid $ds-grey-400;
@@ -34,7 +34,10 @@
 }
 
 .upload-display-text {
-  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;  
+  overflow: hidden;
 }
 
 .progress-bar-container {

--- a/src/lib/components/multiDropzone/index.stories.tsx
+++ b/src/lib/components/multiDropzone/index.stories.tsx
@@ -9,7 +9,7 @@ const story = {
     uploadedFiles: {
       defaultValue: [{
         id: '123456789',
-        name: 'dummyfile.png'
+        name: 'my-code-doesnt-work-i-have-no-idea-why-my-code-works.jpg'
       }],
       description: 'List of files to be displayed on the component.',
     },
@@ -75,7 +75,7 @@ export const MultiDropzoneStory = ({
   const [localFiles, setLocalFiles] = useState<UploadedFile[]>(uploadedFiles);
 
   const handleOnRemoveFile = (id: string) => {
-    onRemoveFile(id);
+    onRemoveFile?.(id);
     setLocalFiles((prevFiles) => prevFiles.filter((file) => file.id !== id));
   };
 

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -28,7 +28,7 @@ interface MultiDropzoneProps {
   uploadedFiles: UploadedFile[];
   uploading: boolean;
   onFileSelect: (files: File[]) => void;
-  onRemoveFile: (id: string) => void;
+  onRemoveFile?: (id: string) => void;
   accept?: AcceptType;
   isCondensed?: boolean;
   maxFiles?: number;
@@ -152,7 +152,8 @@ const MultiDropzone = ({
               uploadStatus={getUploadStatus(file.progress, file.error)}
               file={file}
               key={file.id}
-              onRemoveFile={onRemoveFile}
+              
+              {...!onRemoveFile ? {} : {onRemoveFile}}
               uploading={uploading}
             />
           ))}


### PR DESCRIPTION
### What this PR does
- Removes on removeFile icon if there isnt a remove file function passed.
- Fixes file uploader cell with large names

**Before:**
<img width="385" alt="Screenshot 2023-09-21 at 14 32 45" src="https://github.com/getPopsure/dirty-swan/assets/4015038/8f70d60d-b491-4f21-a312-43611e249060">


**After:**
<img width="343" alt="Screenshot 2023-09-21 at 14 30 54" src="https://github.com/getPopsure/dirty-swan/assets/4015038/42568a01-85c5-44aa-8b17-8d78ab526a76">

Solves:
EMU-6747

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
