### PR TITLE
fix(modal): [EMU-6739] Fix BottomModal scrolling on safari

### DIFF
--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -47,30 +47,34 @@ export const BottomModal = ({
       className={isClosing ? styles['overlay--close'] : styles.overlay}
       onClick={handleOnOverlayClick}
     >
-      <div
-        className={`${
-          isClosing ? styles['container--close'] : styles.container
-        } ${className}`}
-        ref={containerRef}
-        style={{ top: `${containerXOffset}px` }}
-        onClick={handleContainerClick}
+    <div
+      className={styles.wrapper}
+      ref={containerRef}
+      onClick={handleContainerClick}
+      style={{ top: `${containerXOffset}px` }}
       >
-        <div className={classNames(styles.header, {
-          'jc-between': !!title,
-          'jc-end': !title
-        })}>
-          <div className={`p-h4 ${styles.title}`}>{title}</div>
-          {dismissible && (
-            <button
-              type="button"
-              className={styles.close}
-              onClick={handleOnClose}
-            >
-              <img src={imageClose} alt="Close" />
-            </button>
-          )}
+        <div
+          className={`${
+            isClosing ? styles['container--close'] : styles.container
+          } ${className}`}
+        >
+          <div className={classNames(styles.header, {
+            'jc-between': !!title,
+            'jc-end': !title
+          })}>
+            <div className={`p-h4 ${styles.title}`}>{title}</div>
+            {dismissible && (
+              <button
+                type="button"
+                className={styles.close}
+                onClick={handleOnClose}
+              >
+                <img src={imageClose} alt="Close" />
+              </button>
+            )}
+          </div>
+          <div className={styles.content}>{children}</div>
         </div>
-        <div className={styles.content}>{children}</div>
       </div>
     </div>
   );

--- a/src/lib/components/modal/bottomModal/style.module.scss
+++ b/src/lib/components/modal/bottomModal/style.module.scss
@@ -68,9 +68,14 @@
   }
 }
 
-.container {
+.wrapper {
   position: relative;
+  top: 0;
+  width: 100%;
+  overflow: hidden;
+}
 
+.container {
   background-color: white;
 
   border-top-left-radius: 8px;
@@ -82,8 +87,6 @@
   animation-duration: 0.4s;
   animation-fill-mode: both;
   animation-timing-function: ease-out;
-
-  top: 0;
 
   &--close {
     @extend .container;


### PR DESCRIPTION
### What this PR does
Fix unwantedBottomModal scrolling on safari.

### How to test?
Open [modal story](http://localhost:9009/?path=/story/jsx-modals--bottom-or-regular-modal-story) on safari and shrink the window to make sure it shows the bottom modal. Observe the behaviour below:

**Before:**
https://github.com/getPopsure/dirty-swan/assets/4015038/47e37a94-edb8-4b61-8b9f-4caefd4731ab

**After:**
https://github.com/getPopsure/dirty-swan/assets/4015038/433854c8-98ba-43cf-9d11-7af5d72bd71f


Solves:
EMU-6739

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
