### PR TITLE
feat(toggle): Add Toggle component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,6 +37,7 @@ export {
   Badge,
   images,
   Spinner,
+  Toggle
 } from './lib';
 
 export * from './lib/components/icon';

--- a/src/lib/components/input/radio/index.stories.tsx
+++ b/src/lib/components/input/radio/index.stories.tsx
@@ -209,7 +209,7 @@ export const RadioWithCustomLabel = ({ onChange, wide, classNames, inlineLayout 
 
 RadioStory.storyName = 'Radio';
 
-export const RadioIconOnly = ({ onChange, wide, classNames, inlineLayout }: RadioProps<string>) => {
+export const RadioIconOnly = ({ onChange }: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {

--- a/src/lib/components/input/toggle/index.stories.tsx
+++ b/src/lib/components/input/toggle/index.stories.tsx
@@ -1,0 +1,191 @@
+
+import { useState } from 'react';
+import { Toggle, ToggleProps } from '.';
+
+const story = {
+  title: 'JSX/Inputs/Toggle',
+  component: Toggle,
+  argTypes: {
+    options: {
+      description: 'Object that contains the possible options for rendering in the input.',
+      defaultValue: {
+        CAT:{
+          title: 'Cat',
+          description: 'At least 1'
+        },
+        DOG:{
+          title: 'Dog',
+          description: 'At least 2'
+        },
+        NONE:{
+          title: 'None',
+          description: 'No pets'
+        }
+      }
+    },
+    value: {
+      description: 'Current checked values.',
+    },
+    onChange: {
+      description: 'Function called everytime a value changes.',
+      action: true,
+      table: {
+        category: "Callbacks",
+      },
+    },
+    bordered: {
+      control: { type: 'boolean' },
+      description: 'Property that defines if checkbox should show the border around each label',
+      defaultValue: true
+    },
+    inlineLayout: {
+      description: 'Property that defines if options should show inline instead of block. Check inline checkbox options story for examples.',
+      defaultValue: false
+    },
+    className: {
+      description: 'ClassNames for custom styling',
+      defaultValue: {
+        container: '',
+        label: '',
+        option: ''
+      }
+    },
+  }
+};
+
+export const ToggleStory = ({ 
+  onChange,
+  options,
+  bordered,
+  classNames,
+  inlineLayout,
+}: ToggleProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[]) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Toggle 
+      options={options} 
+      onChange={handleOnChange}
+      value={checkedValues}
+      bordered={bordered}
+      classNames={classNames}
+      inlineLayout={inlineLayout}
+    />
+  );
+}
+
+export const ToggleWithCustomWrapperStyles = ({ onChange }: ToggleProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Toggle 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT1: 'Cat',
+        DOG1: 'Dog',
+      }} 
+      classNames={{ container: "p32 bg-primary-300 br24 bs-lg" }}
+    />
+  );
+}
+
+export const ToggleWithCustomOptionStyles = ({ onChange }: ToggleProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Toggle 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT2: 'Cat',
+        DOG2: 'Dog',
+      }} 
+      classNames={{ option: "mb32 p24 bg-green-100 br12 bs-lg" }}
+    />
+  );
+}
+
+export const ToggleWithCustomLabelStyles = ({ onChange }: ToggleProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Toggle 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT3: 'Cat',
+        DOG3: 'Dog',
+      }} 
+      classNames={{ label: "bg-grey-900 tc-white" }}
+    />
+  );
+}
+
+export const ToggleWithInlineLayout = ({ onChange }: ToggleProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Toggle 
+      onChange={handleOnChange}
+      value={checkedValues}
+      options={{
+        CAT4: 'Cat',
+        DOG4: 'Dog',
+        FISHER: 'Fish',
+        RABBIT: 'Rabbit',
+        RAT: 'Rat',
+        ANOTHER: 'Other',
+      }} 
+      classNames={{ option: "w30" }}
+      inlineLayout
+    />
+  );
+}
+
+export const ToggleIconOnly = ({ onChange }: ToggleProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleOnChange = (newValue: string[] = []) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Toggle 
+      options={{ CAT: '' }} 
+      onChange={handleOnChange}
+      value={checkedValues}
+      bordered={false}
+    />
+  );
+}
+
+ToggleStory.storyName = 'Toggle';
+
+export default story;

--- a/src/lib/components/input/toggle/index.test.tsx
+++ b/src/lib/components/input/toggle/index.test.tsx
@@ -1,0 +1,77 @@
+import { render } from '../../../util/testUtils';
+
+import { Toggle, ToggleProps } from '.';
+
+const mockOnChange = jest.fn();
+
+const setup = (onChange: ToggleProps<string>['onChange'], value?: string[]) => {
+  const utils = render(
+    <Toggle
+      options={{
+        CAT: 'Cat',
+        DOG: 'Dog',
+        NONE: 'None',
+      }}
+      onChange={onChange}
+      value={value}
+    />
+  );
+
+  return utils;
+};
+
+describe('toggle component', () => {
+  it('Should render options', () => {
+    const { getByText } = setup(mockOnChange);
+
+    expect(getByText('Cat')).toBeInTheDocument();
+    expect(getByText('Dog')).toBeInTheDocument();
+    expect(getByText('None')).toBeInTheDocument();
+  });
+
+  it('Should call onchange on selecting an option', async () => {
+    const { getByTestId, user } = setup(mockOnChange);
+
+    await user.click(getByTestId('toggle-DOG'));
+
+    expect(mockOnChange).toBeCalledWith(["DOG"]);
+  });
+
+  it('Should render checked items when value is passed', async () => {
+    const { getByTestId } = setup(mockOnChange, ['CAT']);
+
+    expect(getByTestId('toggle-input-CAT')).toBeChecked();
+  });
+
+  it('Should call onchange with NONE and removing other items on selecting NONE option', async () => {
+    const { getByTestId, user } = setup(mockOnChange, ['CAT', 'DOG']);
+
+    await user.click(getByTestId('toggle-NONE'));
+
+    expect(mockOnChange).toBeCalledWith(["NONE"]);
+  });
+
+  it('Should call onchange empty when removing NONE option', async () => {
+    const { getByTestId, user } = setup(mockOnChange, ['NONE']);
+
+    await user.click(getByTestId('toggle-NONE'));
+
+    expect(mockOnChange).toBeCalledWith([]);
+  });
+
+  it('Should render custom description', () => {
+      const { getByText } = render(
+        <Toggle
+          options={{
+            CAT: {
+              title: 'Cat',
+              description: 'Cat description'
+            },
+          }}
+          onChange={mockOnChange}
+        />
+      );
+
+    expect(getByText('Cat description')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/input/toggle/index.tsx
+++ b/src/lib/components/input/toggle/index.tsx
@@ -1,0 +1,118 @@
+import classNames from "classnames";
+
+import styles from './styles.module.scss';
+export interface ToggleWithDescription {
+  title: string;
+  description?: string;
+}
+
+export interface ToggleProps<ValueType extends string> {
+  options: Record<ValueType, string | ToggleWithDescription>;
+  value?: ValueType[];
+  onChange: (value: ValueType[]) => void;
+  inlineLayout?: boolean;
+  bordered?: Boolean,
+  classNames?: {
+    container?: string;
+    label?: string;
+    option?: string;
+  }
+}
+
+export const Toggle = <ValueType extends string>({
+  options,
+  value = [],
+  onChange,
+  inlineLayout = false,
+  bordered = true,
+  classNames: classNamesObj,
+}: ToggleProps<ValueType> & {  }) => {
+  const hasNoneValue = Object.keys(options).includes('NONE');
+
+  const handleOnChange = (newValue: ValueType) => {
+    if (value?.includes(newValue)) {
+      const filteredToggleValues = value.filter(
+        (selectedValue) => selectedValue !== newValue
+      );
+
+      onChange(filteredToggleValues);
+      return;
+    }
+
+    if (hasNoneValue && newValue === 'NONE') {
+      onChange([newValue]);
+      return;
+    }
+
+    if (hasNoneValue && newValue !== 'NONE') {
+      const newValues = value
+        ? [...value.filter((v) => v !== 'NONE'), newValue]
+        : [newValue];
+      onChange(newValues);
+      return;
+    }
+
+    const newValues = value
+      ? [...value, newValue]
+      : [newValue];
+    onChange(newValues);
+  };
+
+
+  const entries = Object.entries(options) as [
+    ValueType,
+    string | ToggleWithDescription
+  ][];
+
+  return (
+    <div
+      className={classNames(classNamesObj?.container, styles.container, 'd-flex gap8', {
+        'fd-row': inlineLayout,
+        'f-wrap': inlineLayout,
+        'fd-column': !inlineLayout,
+      })}
+    >
+      {entries.map(([currentValue, label]) => {
+        const checked = value?.includes(currentValue);
+
+        return (
+          <div className={classNamesObj?.option} key={currentValue}>
+            <label
+              className={classNames(
+                styles.label,
+                classNamesObj?.label,
+                'p-label pr16 gap16',
+                {
+                  'p-label--bordered': bordered,
+                }
+              )}
+              data-cy={`toggle-${currentValue}`}
+              data-testid={`toggle-${currentValue}`}
+            >
+              <span className={classNames(styles.toggleContainer, 'd-inline-block')}>
+                <input 
+                  checked={checked}
+                  className={styles.input}
+                  data-testid={`toggle-input-${currentValue}`}
+                  onChange={() => handleOnChange(currentValue)}
+                  type="checkbox" 
+                  value={currentValue}
+                />
+                <span className={styles.toggle} />
+              </span>
+              
+              {typeof label === 'string' ? label : (
+                <div>
+                  <p className="p-p">{label.title}</p>
+                  <span className="d-block p-p p-p--small tc-grey-600">
+                    {label.description}
+                  </span>
+                </div>
+              )}
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/lib/components/input/toggle/styles.module.scss
+++ b/src/lib/components/input/toggle/styles.module.scss
@@ -1,0 +1,68 @@
+.container {
+  max-width: 100%;
+}
+
+.toggleContainer {
+  position: relative;
+  width: 40px;
+  height: 12px;
+}
+
+.label {
+  align-items: center;
+}
+
+.toggle {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--ds-grey-400);
+  transition: all 0.3s ease-in-out;
+  border-radius: 100px;
+  
+  &:before {
+    position: absolute;
+    content: '';
+    height: 20px;
+    width: 20px;
+    left: 0;
+    bottom: -4px;
+    background: var(--ds-grey-500);
+    transition: 0.3s ease-in-out;
+    transition-property: background-color, outline, transform;
+    outline-color: var(--ds-purple-300);
+    border-radius: 50%;
+  }
+}
+
+.input {
+  opacity: 0;
+
+  &:checked {
+    & + .toggle {
+      background: var(--ds-purple-100);
+    }
+    + .toggle:before {
+      background: var(--ds-purple-500);
+    }
+  }
+
+  &:disabled + .toggle {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+
+  &:focus-visible ~ .toggle:before {
+    outline: 4px solid var(--ds-purple-300);
+  }
+
+  &:checked + .toggle:before {
+    // Toggle width - thumb width = 40px - 20px = 20px
+    transform: translateX(20px);
+  }
+}
+
+

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -46,6 +46,7 @@ import { Markdown } from './components/markdown';
 import { Link } from './components/link';
 import { images } from './util/images';
 import { Spinner } from './components/spinner';
+import { Toggle } from './components/input/toggle';
 
 export * from './components/icon';
 
@@ -85,6 +86,7 @@ export {
   Badge,
   images,
   Spinner,
+  Toggle,
 };
 
 export type {


### PR DESCRIPTION
### What this PR does
This PR adds the Toggle component.

### How to test?
Run `yarn storybook` and check [toggle component story](http://localhost:9009/?path=/docs/jsx-inputs-toggle--toggle-story).

**Preview:**
<img width="600" alt="Screenshot 2023-10-18 at 16 02 51" src="https://github.com/getPopsure/dirty-swan/assets/4015038/6526ddc2-09d6-4f7c-8ea7-32183987b6f4">
<img width="600" alt="Screenshot 2023-10-18 at 16 02 58" src="https://github.com/getPopsure/dirty-swan/assets/4015038/5dd7b97c-780f-4a0c-ba4b-cca9203ea374">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
