### PR TITLE
refactor(input): [STO-6165] update type for checkbox and radio options

### DIFF
--- a/src/lib/components/input/checkbox/index.test.tsx
+++ b/src/lib/components/input/checkbox/index.test.tsx
@@ -4,7 +4,10 @@ import { Checkbox, CheckboxProps } from '.';
 
 const mockOnChange = jest.fn();
 
-const setup = (onChange: CheckboxProps<string>['onChange'], value?: string[]) => {
+const setup = (
+  onChange: CheckboxProps<string>['onChange'],
+  value?: string[]
+) => {
   const utils = render(
     <Checkbox
       options={{
@@ -34,7 +37,7 @@ describe('Checkbox component', () => {
 
     await user.click(getByTestId('checkbox-DOG'));
 
-    expect(mockOnChange).toBeCalledWith(["DOG"]);
+    expect(mockOnChange).toBeCalledWith(['DOG']);
   });
 
   it('Should render checked items when value is passed', async () => {
@@ -48,7 +51,7 @@ describe('Checkbox component', () => {
 
     await user.click(getByTestId('checkbox-NONE'));
 
-    expect(mockOnChange).toBeCalledWith(["NONE"]);
+    expect(mockOnChange).toBeCalledWith(['NONE']);
   });
 
   it('Should call onchange empty when removing NONE option', async () => {
@@ -60,51 +63,67 @@ describe('Checkbox component', () => {
   });
 
   it('Should render custom description', () => {
-      const { getByText } = render(
-        <Checkbox
-          options={{
-            CAT: {
-              title: 'Cat',
-              description: 'Cat description'
-            },
-          }}
-          onChange={mockOnChange}
-        />
-      );
+    const { getByText } = render(
+      <Checkbox
+        options={{
+          CAT: {
+            title: 'Cat',
+            description: 'Cat description',
+          },
+        }}
+        onChange={mockOnChange}
+      />
+    );
 
     expect(getByText('Cat description')).toBeInTheDocument();
   });
 
   it('Should render custom icon', () => {
-      const { getByText } = render(
-        <Checkbox
-          options={{
-            CAT: {
-              title: 'Cat',
-              icon: () => 'ICON'
-            },
-          }}
-          onChange={mockOnChange}
-        />
-      );
+    const { getByText } = render(
+      <Checkbox
+        options={{
+          CAT: {
+            title: 'Cat',
+            icon: () => 'ICON',
+          },
+        }}
+        onChange={mockOnChange}
+      />
+    );
 
     expect(getByText('ICON')).toBeInTheDocument();
   });
 
   it('Should render custom icon with selected', () => {
-      const { getByText } = render(
-        <Checkbox
-          options={{
-            CAT: {
-              title: 'Cat',
-              icon: (selected) => selected ? 'SELECTED-ICON' : 'ICON'
-            },
-          }}
-          onChange={mockOnChange}
-          value={['CAT']}
-        />
-      );
+    const { getByText } = render(
+      <Checkbox
+        options={{
+          CAT: {
+            title: 'Cat',
+            icon: (selected) => (selected ? 'SELECTED-ICON' : 'ICON'),
+          },
+        }}
+        onChange={mockOnChange}
+        value={['CAT']}
+      />
+    );
 
     expect(getByText('SELECTED-ICON')).toBeInTheDocument();
+  });
+
+  it('Should render label text passed in HTML format', () => {
+    const { getByText } = render(
+      <Checkbox
+        options={{
+          CAT: {
+            title: <p>Cat</p>,
+            description: 'Cat description',
+          },
+        }}
+        onChange={mockOnChange}
+      />
+    );
+
+    expect(getByText('Cat')).toBeInTheDocument();
   });
 });

--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -1,25 +1,25 @@
-import classNames from "classnames";
-import { ReactNode } from "react";
+import classNames from 'classnames';
+import { ReactNode } from 'react';
 
 import styles from './styles.module.scss';
 export interface CheckboxWithDescription {
-  title: string;
+  title: ReactNode;
   description?: string;
   icon?: (selected: boolean) => ReactNode;
 }
 
 export interface CheckboxProps<ValueType extends string> {
-  options: Record<ValueType, string | CheckboxWithDescription>;
+  options: Record<ValueType, ReactNode | CheckboxWithDescription>;
   value?: ValueType[];
   onChange: (value: ValueType[]) => void;
   wide?: boolean;
   inlineLayout?: boolean;
-  bordered?: Boolean,
+  bordered?: Boolean;
   classNames?: {
     container?: string;
     label?: string;
     option?: string;
-  }
+  };
 }
 
 export const Checkbox = <ValueType extends string>({
@@ -30,7 +30,7 @@ export const Checkbox = <ValueType extends string>({
   inlineLayout = false,
   bordered = true,
   classNames: classNamesObj,
-}: CheckboxProps<ValueType> & {  }) => {
+}: CheckboxProps<ValueType> & {}) => {
   const hasNoneValue = Object.keys(options).includes('NONE');
 
   const handleOnChange = (newValue: ValueType) => {
@@ -56,26 +56,34 @@ export const Checkbox = <ValueType extends string>({
       return;
     }
 
-    const newValues = value
-      ? [...value, newValue]
-      : [newValue];
+    const newValues = value ? [...value, newValue] : [newValue];
     onChange(newValues);
   };
 
-
   const entries = Object.entries(options) as [
     ValueType,
-    string | CheckboxWithDescription
+    ReactNode | CheckboxWithDescription
   ][];
+
+  const isLabelObject = (
+    label: ReactNode | CheckboxWithDescription
+  ): label is CheckboxWithDescription => {
+    return (label as CheckboxWithDescription).title !== undefined;
+  };
 
   return (
     <div
-      className={classNames(classNamesObj?.container, styles.container, 'd-flex gap8', {
-        [styles.narrow]: !wide,
-        'fd-row': inlineLayout,
-        'f-wrap': inlineLayout,
-        'fd-column': !inlineLayout,
-      })}
+      className={classNames(
+        classNamesObj?.container,
+        styles.container,
+        'd-flex gap8',
+        {
+          [styles.narrow]: !wide,
+          'fd-row': inlineLayout,
+          'f-wrap': inlineLayout,
+          'fd-column': !inlineLayout,
+        }
+      )}
     >
       {entries.map(([currentValue, label]) => {
         const checked = value?.includes(currentValue);
@@ -84,11 +92,9 @@ export const Checkbox = <ValueType extends string>({
         return (
           <div className={classNamesObj?.option} key={currentValue}>
             <input
-              className={classNames(
-                "p-checkbox", {
-                  'p-checkbox--no-icon': customIcon
-                }
-              )}
+              className={classNames('p-checkbox', {
+                'p-checkbox--no-icon': customIcon,
+              })}
               id={currentValue}
               type="checkbox"
               value={currentValue}
@@ -99,29 +105,25 @@ export const Checkbox = <ValueType extends string>({
 
             <label
               htmlFor={currentValue}
-              className={classNames(
-                classNamesObj?.label,
-                'p-label pr16',
-                {
-                  'p-label--bordered': bordered,
-                  'jc-center': customIcon,
-                  'fd-column': customIcon
-                }
-              )}
+              className={classNames(classNamesObj?.label, 'p-label pr16', {
+                'p-label--bordered': bordered,
+                'jc-center': customIcon,
+                'fd-column': customIcon,
+              })}
               data-cy={`checkbox-${currentValue}`}
               data-testid={`checkbox-${currentValue}`}
             >
-              {customIcon && (
-                <div className="mt8">{customIcon?.(checked)}</div>
-              )}
+              {customIcon && <div className="mt8">{customIcon?.(checked)}</div>}
 
-              {typeof label === 'string' ? label : (
+              {isLabelObject(label) ? (
                 <div>
                   <p className="p-p">{label.title}</p>
                   <span className="d-block p-p p-p--small tc-grey-600">
                     {label.description}
                   </span>
                 </div>
+              ) : (
+                label
               )}
             </label>
           </div>

--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -65,7 +65,7 @@ export const Checkbox = <ValueType extends string>({
     ReactNode | CheckboxWithDescription
   ][];
 
-  const isLabelObject = (
+  const isCheckboxLabelObject = (
     label: ReactNode | CheckboxWithDescription
   ): label is CheckboxWithDescription => {
     return (label as CheckboxWithDescription).title !== undefined;
@@ -115,7 +115,7 @@ export const Checkbox = <ValueType extends string>({
             >
               {customIcon && <div className="mt8">{customIcon?.(checked)}</div>}
 
-              {isLabelObject(label) ? (
+              {isCheckboxLabelObject(label) ? (
                 <div>
                   <p className="p-p">{label.title}</p>
                   <span className="d-block p-p p-p--small tc-grey-600">

--- a/src/lib/components/input/radio/index.test.tsx
+++ b/src/lib/components/input/radio/index.test.tsx
@@ -34,7 +34,7 @@ describe('Radio component', () => {
 
     await user.click(getByTestId('radio-DOG'));
 
-    expect(mockOnChange).toBeCalledWith("DOG");
+    expect(mockOnChange).toBeCalledWith('DOG');
   });
 
   it('Should render checked items when value is passed', async () => {
@@ -44,51 +44,67 @@ describe('Radio component', () => {
   });
 
   it('Should render custom description', () => {
-      const { getByText } = render(
-        <Radio
-          options={{
-            CAT: {
-              title: 'Cat',
-              description: 'Cat description'
-            },
-          }}
-          onChange={mockOnChange}
-        />
-      );
+    const { getByText } = render(
+      <Radio
+        options={{
+          CAT: {
+            title: 'Cat',
+            description: 'Cat description',
+          },
+        }}
+        onChange={mockOnChange}
+      />
+    );
 
     expect(getByText('Cat description')).toBeInTheDocument();
   });
 
   it('Should render custom icon', () => {
-      const { getByText } = render(
-        <Radio
-          options={{
-            CAT: {
-              title: 'Cat',
-              icon: () => 'ICON'
-            },
-          }}
-          onChange={mockOnChange}
-        />
-      );
+    const { getByText } = render(
+      <Radio
+        options={{
+          CAT: {
+            title: 'Cat',
+            icon: () => 'ICON',
+          },
+        }}
+        onChange={mockOnChange}
+      />
+    );
 
     expect(getByText('ICON')).toBeInTheDocument();
   });
 
   it('Should render custom icon with selected', () => {
-      const { getByText } = render(
-        <Radio
-          options={{
-            CAT: {
-              title: 'Cat',
-              icon: (selected) => selected ? 'SELECTED-ICON' : 'ICON'
-            },
-          }}
-          onChange={mockOnChange}
-          value={'CAT'}
-        />
-      );
+    const { getByText } = render(
+      <Radio
+        options={{
+          CAT: {
+            title: 'Cat',
+            icon: (selected) => (selected ? 'SELECTED-ICON' : 'ICON'),
+          },
+        }}
+        onChange={mockOnChange}
+        value={'CAT'}
+      />
+    );
 
     expect(getByText('SELECTED-ICON')).toBeInTheDocument();
+  });
+
+  it('Should render label text passed in HTML format', () => {
+    const { getByText } = render(
+      <Radio
+        options={{
+          CAT: {
+            title: <p>Cat</p>,
+            description: 'Cat description',
+          },
+        }}
+        onChange={mockOnChange}
+      />
+    );
+
+    expect(getByText('Cat')).toBeInTheDocument();
   });
 });

--- a/src/lib/components/input/radio/index.tsx
+++ b/src/lib/components/input/radio/index.tsx
@@ -1,16 +1,16 @@
-import classNames from "classnames";
-import { ReactNode } from "react";
+import classNames from 'classnames';
+import { ReactNode } from 'react';
 
 import styles from './styles.module.scss';
 export interface RadioWithDescription {
-  title: string;
+  title: ReactNode;
   description?: string;
   icon?: (selected: boolean) => ReactNode;
   hideBox?: boolean;
 }
 
 export interface RadioProps<ValueType extends string> {
-  options: Record<ValueType, string | RadioWithDescription>;
+  options: Record<ValueType, ReactNode | RadioWithDescription>;
   value?: ValueType;
   onChange: (value: ValueType) => void;
   wide?: boolean;
@@ -30,38 +30,46 @@ export const Radio = <ValueType extends string>({
   wide = false,
   inlineLayout = false,
   classNames: classNamesObj,
-  bordered = true
+  bordered = true,
 }: RadioProps<ValueType>) => {
   const entries = Object.entries(options) as [
     ValueType,
-    string | RadioWithDescription
+    ReactNode | RadioWithDescription
   ][];
-
 
   return (
     <div
-      className={classNames(classNamesObj?.container, styles.container, 'd-flex gap8', {
-        [styles.wide]: wide,
-        [styles.narrow]: !wide,
-        'fd-row': inlineLayout,
-        'f-wrap': inlineLayout,
-        'fd-column': !inlineLayout,
-      })}
+      className={classNames(
+        classNamesObj?.container,
+        styles.container,
+        'd-flex gap8',
+        {
+          [styles.wide]: wide,
+          [styles.narrow]: !wide,
+          'fd-row': inlineLayout,
+          'f-wrap': inlineLayout,
+          'fd-column': !inlineLayout,
+        }
+      )}
     >
       {entries.map(([currentValue, label]) => {
         const checked = value === currentValue;
         const customIcon = (label as RadioWithDescription)?.icon;
         const hideIcon = (label as RadioWithDescription)?.hideBox;
 
+        const isRadioLabelObject = (
+          label: ReactNode | RadioWithDescription
+        ): label is RadioWithDescription => {
+          return (label as RadioWithDescription).title !== undefined;
+        };
+
         return (
           <div className={classNamesObj?.option} key={currentValue}>
             <input
-              className={classNames(
-                "p-radio", {
-                  'p-radio--no-icon': customIcon || hideIcon,
-                  'p-radio--centered': !label,
-                }
-              )}
+              className={classNames('p-radio', {
+                'p-radio--no-icon': customIcon || hideIcon,
+                'p-radio--centered': !label,
+              })}
               id={currentValue}
               type="radio"
               value={currentValue}
@@ -72,29 +80,25 @@ export const Radio = <ValueType extends string>({
 
             <label
               htmlFor={currentValue}
-              className={classNames(
-                classNamesObj?.label,
-                'p-label',
-                {
-                  'jc-center': customIcon,
-                  'fd-column': customIcon,
-                  'p-label--bordered': bordered
-                }
-              )}
+              className={classNames(classNamesObj?.label, 'p-label', {
+                'jc-center': customIcon,
+                'fd-column': customIcon,
+                'p-label--bordered': bordered,
+              })}
               data-cy={`radio-${currentValue}`}
               data-testid={`radio-${currentValue}`}
             >
-              {customIcon && (
-                <div className="mt8">{customIcon?.(checked)}</div>
-              )}
+              {customIcon && <div className="mt8">{customIcon?.(checked)}</div>}
 
-              {typeof label === 'string' ? label : (
+              {isRadioLabelObject(label) ? (
                 <div>
                   <p className="p-p">{label.title}</p>
                   <span className="d-block p-p p-p--small tc-grey-600">
                     {label.description}
                   </span>
                 </div>
+              ) : (
+                label
               )}
             </label>
           </div>


### PR DESCRIPTION
### What this PR does

- Updates the type of the `options` prop used by the Radio and Checkbox component to render the input label, so that it doesn't only accept strings but the broader `ReactNode`
- Adds a test per component to check the label is rendered when we pass it in HTML format

### Why is this needed?

Solves:
[STO-6165](https://linear.app/feather-insurance/issue/STO-6165/update-title-type-for-ds-radio-and-checkbox-input-components)

### How to test?

Run storybook and go through the radio and checkbox component stories to check they still render correctly.

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge
