### PR TITLE
feat(toast): Add toast component/util

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-autosuggest": "^10.1.0",
     "react-day-picker": "^7.4.10",
     "react-dropzone": "^14.2.2",
+    "react-hot-toast": "^2.4.1",
     "react-markdown": "^8.0.3",
     "react-scroll-sync": "^0.11.0",
     "remark-directive": "^2.0.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,9 @@ export {
   Badge,
   images,
   Spinner,
-  Toggle
+  Toggle,
+  Toaster,
+  toast,
 } from './lib';
 
 export * from './lib/components/icon';

--- a/src/lib/components/toast/index.stories.tsx
+++ b/src/lib/components/toast/index.stories.tsx
@@ -1,0 +1,124 @@
+import classNames from 'classnames';
+import { Toast, ToastProps, ToastType, Toaster, toast } from '.';
+import Button from '../button';
+import styles from './style.module.scss';
+
+const toastTypes: ToastType[] = ['success', 'warning', 'error', 'information'];
+
+const story = {
+  title: 'JSX/Toast',
+  component: Toast,
+  argTypes: {
+    title: {
+      description: 'Title of the toast.',
+    },
+    description: {
+      description: 'Additional description content to be displayed inside the toast.',
+    },
+    type: {
+      description: 'Type of toast to display. This changes the styles/colors of the toast.',
+    },
+    action: {
+      description: 'Object containing a possible action button inside the toast.',
+    },
+    duration: {
+      description: 'Duration in ms that the toast should be displayed.',
+      table: {
+        defaultValue: { summary: 3000 },
+      }
+    },
+    onDismiss: {
+      table: {
+        disable: true,
+      },
+    }
+  },
+  args: {
+    title: 'We couldn’t open the chat',
+    description: 'Description description description description description description description',
+    action: {
+      title: 'Send an email',
+      onClick: () => {}
+    },
+    type: 'success',
+    duration: 3000,
+  },
+};
+
+const FakeInlineToast = ({ 
+  title, 
+  description, 
+  action, 
+  type
+}: Omit<ToastProps, 'onDismiss'>) => (
+  <div className='mb32'>
+    <div className={classNames(styles.toast, 'br8 bs-lg d-inline-flex')}>
+      <Toast 
+        title={title}
+        onDismiss={() => {}}
+        description={description}
+        action={action}
+        type={type}
+      />
+    </div>
+  </div>
+);
+
+export const ToastStory = ({ title, description, action, type, duration }: ToastProps) => {
+  const showToast = () => toast(
+    title, 
+    {
+      description,
+      duration,
+      type,
+      action
+    }
+  );
+
+  return (
+    <>
+      <div className='mb16'>
+        <div>
+          Show a toast using the following code:
+        </div>
+        <pre className='bg-grey-300 br4 d-inline-flex p8 mt8'>
+          {"() => toast(title, { description, type, action })"}
+        </pre>
+      </div>
+      <Toaster />
+
+      <Button
+        buttonTitle='Click here to trigger toast'
+        onClick={showToast}
+      />
+    </>
+  );
+};
+
+ToastStory.storyName = "Toast";
+
+export const ToastTypes = (props: ToastProps) => {
+  return (
+    <>
+      {toastTypes.map((toastType) => (
+        <div key={toastType} className='d-flex fd-column'>
+          <h3 className='p-h3 mb16'>{toastType}</h3>
+          <FakeInlineToast {...props} type={toastType} />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export const ToastContent = ({ title, description, action }: ToastProps) => {
+  return (
+    <div className='d-flex fd-column'>
+      <FakeInlineToast title={title} />
+      <FakeInlineToast title={title} description={description} />
+      <FakeInlineToast title={title} description={description} action={action} />
+      <FakeInlineToast title={title} action={action} />
+    </div>
+  );
+};
+
+export default story;

--- a/src/lib/components/toast/index.test.tsx
+++ b/src/lib/components/toast/index.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '../../util/testUtils';
+
+import { Toast } from '.';
+
+const onDismiss = jest.fn();
+const onActionClick = jest.fn();
+
+describe('Toast component', () => {
+  it('Should render title', async () => {
+    render(
+      <Toast title={'Title'} onDismiss={() => {}} />
+    )
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+  });
+
+  it('Should not render description', async () => {
+    render(
+      <Toast title={'Title'} onDismiss={() => {}} />
+    )
+
+    expect(screen.queryByText('Description')).not.toBeInTheDocument();
+  });
+
+  it('Should render description', async () => {
+    render(
+      <Toast title={'Title'} description={"Description"} onDismiss={() => {}} />
+    )
+
+    expect(screen.getByText('Description')).toBeInTheDocument();
+  });
+
+  it('Should not render action', async () => {
+    render(
+      <Toast title={'Title'} onDismiss={() => {}} />
+    )
+
+    expect(screen.queryByText('Action')).not.toBeInTheDocument();
+  });
+
+  it('Should render action', async () => {
+    render(
+      <Toast title={'Title'} action={{ title: 'Action', onClick: () => {}}} onDismiss={() => {}} />
+    )
+
+    expect(screen.getByText('Action')).toBeInTheDocument();
+  });
+
+  it('Should trigger action', async () => {
+    const { user } = render(
+      <Toast title={'Title'} action={{ title: 'Action', onClick: onActionClick}} onDismiss={() => {}} />
+    )
+
+    await user.click(screen.getByText('Action'))
+
+    expect(onActionClick).toHaveBeenCalled();
+  });
+
+  it('Should trigger dismiss', async () => {
+    const { user } = render(
+      <Toast title={'Title'} onDismiss={onDismiss} />
+    )
+
+    await user.click(screen.getByTestId('toast-close-button'))
+
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/toast/index.tsx
+++ b/src/lib/components/toast/index.tsx
@@ -1,0 +1,94 @@
+import { ReactNode } from 'react';
+import classNames from 'classnames';
+
+import styles from './style.module.scss';
+import { Toaster as HotToaster, toast as hotToast } from 'react-hot-toast';
+import { XIcon } from '../icon';
+
+export type ToastType = 'warning' | 'error' | 'success' | 'information';
+
+export interface ToastOptions {
+  type?: ToastType;
+  description?: ReactNode;
+  duration?: number;
+  action?: {
+    title: string;
+    onClick: () => void;
+  }
+};
+
+export interface ToastProps extends ToastOptions { 
+  onDismiss: () => void,
+  title: string 
+};
+
+const Toaster = () => (
+  <HotToaster 
+    toastOptions={{
+      className: classNames(styles.toast, 'bs-lg'),
+    }}
+  />
+);
+
+const Toast = ({
+  action,
+  description,
+  onDismiss,
+  title,
+  type = "success"
+}: ToastProps) => (
+  <div className='d-flex jc-between w100'>
+    <div
+      className={classNames(
+        styles.toastSidebar, 
+        styles[`toastSidebar--${type}`]
+      )}
+    />
+    <div className='mr16'>
+      <h4 className='p-h4'>{title}</h4>
+      
+      {description && (
+        <p className='p-p p-p--small mt8 tc-grey-600'>{description}</p>
+      )}
+
+      {action && (
+        <button
+          className={classNames(
+            styles.actionButton,
+            styles[`actionButton--${type}`],
+            'mt8 c-pointer'
+          )}
+          onClick={() => {
+            action.onClick();
+            onDismiss();
+          }}
+          type="button"
+        >
+          {action.title}
+        </button>
+      )}
+    </div>
+
+    <div className='d-flex ai-center'>
+      <button
+        className={classNames(styles.closeButton, 'c-pointer')}
+        onClick={onDismiss}
+        data-testid="toast-close-button"
+      >
+        <XIcon /> 
+      </button>
+    </div>
+  </div>
+);
+
+const toast = (title: string, { duration = 3000, ...toastOptions }: ToastOptions) => (
+  hotToast((t) => (
+    <Toast
+      title={title} 
+      onDismiss={() => hotToast.dismiss(t.id)} 
+      {...toastOptions}
+    />
+  ), { duration })
+);
+
+export { Toaster, Toast, toast };

--- a/src/lib/components/toast/style.module.scss
+++ b/src/lib/components/toast/style.module.scss
@@ -1,0 +1,85 @@
+@use '../../scss/public/colors' as *;
+
+.toastWrapper {
+  margin: 0;
+  padding: 0;
+}
+
+.toast {
+  position: relative;
+  margin: 0;
+  width: 392px;
+  overflow: hidden;
+  padding: 20px 16px 20px 20px;
+}
+
+.toastSidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 8px;
+
+  &--information {
+    background-color: $ds-blue-500;
+  }
+
+  &--error {
+    background-color: $ds-red-500;
+  }
+
+  &--warning {
+    background-color: $ds-yellow-500;
+  }
+
+  &--success {
+    background-color: $ds-green-500;
+  }
+}
+
+.closeButton {
+  background-color: transparent;
+  color: $ds-grey-400;
+  min-width: 24px;
+
+  &:hover {
+    color: $ds-grey-600;
+  }
+}
+
+.actionButton {
+  background-color: transparent;
+
+  &--warning {
+    color: $ds-yellow-700;
+
+    &:hover {
+      color: $ds-yellow-900;
+    }
+  }
+
+  &--error {
+    color: $ds-red-500;
+
+    &:hover {
+      color: $ds-red-700;
+    }
+  }
+
+  &--success {
+    color: $ds-green-700;
+
+    &:hover {
+      color: $ds-green-900;
+    }
+  }
+
+  &--information {
+    color: $ds-blue-500;
+
+    &:hover {
+      color: $ds-blue-700;
+    }
+  }
+
+}

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -47,6 +47,7 @@ import { Link } from './components/link';
 import { images } from './util/images';
 import { Spinner } from './components/spinner';
 import { Toggle } from './components/input/toggle';
+import { Toaster, toast } from './components/toast';
 
 export * from './components/icon';
 
@@ -87,6 +88,8 @@ export {
   images,
   Spinner,
   Toggle,
+  Toaster,
+  toast
 };
 
 export type {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8534,6 +8534,11 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+goober@^2.1.10:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.13.tgz#e3c06d5578486212a76c9eba860cbc3232ff6d7c"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -13822,6 +13827,13 @@ react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-inspector@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
### What this PR does
This PR adds the Toaster component and toast util. Under the hood is using react-hot-toast that will replace in-app usages of `react-toastify`. The main reason for changing libraries is because this one is more than half of the size providing the same features we need.

### How to test?
Visit [Toast story](http://localhost:9009/?path=/docs/jsx-toast--toast-story)
[Figma link](https://www.figma.com/file/MKs4cbojdVOBKUxv7okb93/Dirty-Swan-Design-System?node-id=3%3A461&mode=dev)

**Screenshots:**
<img width="438" alt="Screenshot 2023-10-19 at 13 30 08" src="https://github.com/getPopsure/dirty-swan/assets/4015038/5aee4ba0-62f1-4baf-96f8-1bd4a2af75e5">
<img width="431" alt="Screenshot 2023-10-19 at 13 30 12" src="https://github.com/getPopsure/dirty-swan/assets/4015038/8c32da30-3ecd-478a-b017-a160e44b6fed">
tal

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
