### PR TITLE
fix(toggle): Add disabled state to Toggle component

### DIFF
--- a/src/lib/components/input/toggle/index.stories.tsx
+++ b/src/lib/components/input/toggle/index.stories.tsx
@@ -42,6 +42,10 @@ const story = {
       description: 'Property that defines if options should show inline instead of block. Check inline checkbox options story for examples.',
       defaultValue: false
     },
+    disabled: {
+      description: 'Shows toggle on a disabled state.',
+      defaultValue: false
+    },
     className: {
       description: 'ClassNames for custom styling',
       defaultValue: {
@@ -59,6 +63,7 @@ export const ToggleStory = ({
   bordered,
   classNames,
   inlineLayout,
+  disabled,
 }: ToggleProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
@@ -75,6 +80,7 @@ export const ToggleStory = ({
       bordered={bordered}
       classNames={classNames}
       inlineLayout={inlineLayout}
+      disabled={disabled}
     />
   );
 }

--- a/src/lib/components/input/toggle/index.tsx
+++ b/src/lib/components/input/toggle/index.tsx
@@ -12,7 +12,8 @@ export interface ToggleProps<ValueType extends string> {
   value?: ValueType[];
   onChange: (value: ValueType[]) => void;
   inlineLayout?: boolean;
-  bordered?: Boolean,
+  disabled?: boolean;
+  bordered?: boolean,
   classNames?: {
     container?: string;
     label?: string;
@@ -27,6 +28,7 @@ export const Toggle = <ValueType extends string>({
   inlineLayout = false,
   bordered = true,
   classNames: classNamesObj,
+  disabled,
 }: ToggleProps<ValueType> & {  }) => {
   const hasNoneValue = Object.keys(options).includes('NONE');
 
@@ -104,6 +106,7 @@ export const Toggle = <ValueType extends string>({
                   onChange={() => handleOnChange(currentValue)}
                   type="checkbox" 
                   value={currentValue}
+                  disabled={disabled}
                 />
                 <span className={styles.toggle} />
               </span>


### PR DESCRIPTION
### What this PR does

This PR adds the disabled state to Toggle component.

### How to test?
Run storybook and[ check Toggle component story.](http://localhost:9009/?path=/docs/jsx-inputs-checkbox--checkbox-story)


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
