### PR TITLE
fix(radio): Add prop to allow inline icon option to custom icon

### DIFF
--- a/src/lib/components/input/radio/index.stories.tsx
+++ b/src/lib/components/input/radio/index.stories.tsx
@@ -207,6 +207,39 @@ export const RadioWithCustomLabel = ({ onChange, wide, classNames, inlineLayout 
   );
 }
 
+export const RadioWithCustomLabelInline = ({ onChange, wide, classNames, inlineLayout }: RadioProps<string>) => {
+  const [checkedValues, setCheckedValues] = useState<string>();
+
+  const handleOnChange = (newValue: string) => {
+    setCheckedValues(newValue);
+    onChange(newValue);
+  }
+
+  return (
+    <Radio 
+      options={{
+        BIGDOG: {
+          icon: () => <img src={images.bigDog} alt='' />,
+          title: 'Dog',
+        },
+        FISH:{
+          icon: () => <img src={images.brokenAquarium} alt='' />,
+          title: 'Fish',
+        },
+        OTHER:{
+          icon: () => <img src={images.brokenGlass} alt='' />,
+          title: 'Other',
+        }
+      }} 
+      onChange={handleOnChange}
+      inlineIcon
+      value={checkedValues}
+      classNames={{ option: "w30" }}
+      inlineLayout
+    />
+  );
+}
+
 RadioStory.storyName = 'Radio';
 
 export const RadioIconOnly = ({ onChange }: RadioProps<string>) => {

--- a/src/lib/components/input/radio/index.tsx
+++ b/src/lib/components/input/radio/index.tsx
@@ -15,6 +15,7 @@ export interface RadioProps<ValueType extends string> {
   onChange: (value: ValueType) => void;
   wide?: boolean;
   inlineLayout?: boolean;
+  inlineIcon?: boolean;
   classNames?: {
     container?: string;
     label?: string;
@@ -29,6 +30,7 @@ export const Radio = <ValueType extends string>({
   onChange,
   wide = false,
   inlineLayout = false,
+  inlineIcon = false,
   classNames: classNamesObj,
   bordered = true,
 }: RadioProps<ValueType>) => {
@@ -81,14 +83,23 @@ export const Radio = <ValueType extends string>({
             <label
               htmlFor={currentValue}
               className={classNames(classNamesObj?.label, 'p-label', {
-                'jc-center': customIcon,
-                'fd-column': customIcon,
+                'jc-center': customIcon && !inlineIcon,
+                'fd-column': customIcon && !inlineIcon,
                 'p-label--bordered': bordered,
               })}
               data-cy={`radio-${currentValue}`}
               data-testid={`radio-${currentValue}`}
             >
-              {customIcon && <div className="mt8">{customIcon?.(checked)}</div>}
+              {customIcon && (
+                <div 
+                  className={classNames(
+                    "d-inline-flex ai-center jc-center", 
+                    inlineIcon ? "mr8" : "mt8"
+                  )}
+                >
+                  {customIcon?.(checked)}
+                </div>
+              )}
 
               {isRadioLabelObject(label) ? (
                 <div>


### PR DESCRIPTION
### What this PR does
Add prop to allow inline icon option to custom icon:
![Screenshot 2023-10-20 at 13 24 55](https://github.com/getPopsure/dirty-swan/assets/4015038/29adf1a8-00f3-4908-8a6b-43fb26c8c8e2)
![Screenshot 2023-10-20 at 13 24 51](https://github.com/getPopsure/dirty-swan/assets/4015038/8cecf543-3604-4c64-8091-a5d01eac51fb)


### How to test?
Run storybook and go to [Radio stories](http://localhost:9009/?path=/docs/jsx-inputs-radio--radio-story).

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
