### PR TITLE
refactor(toast): Update toast styles

### DIFF
--- a/src/lib/components/toast/index.stories.tsx
+++ b/src/lib/components/toast/index.stories.tsx
@@ -35,7 +35,7 @@ const story = {
   },
   args: {
     title: 'We couldn’t open the chat',
-    description: 'Description description description description description description description',
+    description: "We couldn't open the chat description. We couldn't open the chat description.",
     action: {
       title: 'Send an email',
       onClick: () => {}
@@ -52,7 +52,12 @@ const FakeInlineToast = ({
   type
 }: Omit<ToastProps, 'onDismiss'>) => (
   <div className='mb32'>
-    <div className={classNames(styles.toast, 'br8 bs-lg d-inline-flex')}>
+    <div
+      className={classNames(styles.toast, 'br8 bs-lg d-inline-flex')}
+      style={{
+        padding: "12px 20px"
+      }}
+    >
       <Toast 
         title={title}
         onDismiss={() => {}}

--- a/src/lib/components/toast/index.tsx
+++ b/src/lib/components/toast/index.tsx
@@ -37,14 +37,18 @@ const Toast = ({
   title,
   type = "success"
 }: ToastProps) => (
-  <div className='d-flex jc-between w100'>
+  <div 
+    className={classNames(
+      styles.toastContent,
+      'd-flex jc-between w100'
+  )}>
     <div
       className={classNames(
         styles.toastSidebar, 
         styles[`toastSidebar--${type}`]
       )}
     />
-    <div className='mr16'>
+    <div className='d-flex fd-column jc-center ta-left mr8'>
       <h4 className='p-h4'>{title}</h4>
       
       {description && (
@@ -56,7 +60,7 @@ const Toast = ({
           className={classNames(
             styles.actionButton,
             styles[`actionButton--${type}`],
-            'mt8 c-pointer'
+            'mt8 c-pointer ta-left'
           )}
           onClick={() => {
             action.onClick();
@@ -75,7 +79,7 @@ const Toast = ({
         onClick={onDismiss}
         data-testid="toast-close-button"
       >
-        <XIcon /> 
+        <XIcon size={24} /> 
       </button>
     </div>
   </div>

--- a/src/lib/components/toast/style.module.scss
+++ b/src/lib/components/toast/style.module.scss
@@ -8,9 +8,13 @@
 .toast {
   position: relative;
   margin: 0;
+  padding: 0;
   width: 392px;
   overflow: hidden;
-  padding: 20px 16px 20px 20px;
+}
+
+.toastContent {
+  padding: 4px 0 4px 8px;
 }
 
 .toastSidebar {
@@ -67,18 +71,18 @@
   }
 
   &--success {
-    color: $ds-green-700;
+    color: $ds-spearmint-700;
 
     &:hover {
-      color: $ds-green-900;
+      color: $ds-spearmint-900;
     }
   }
 
   &--information {
-    color: $ds-blue-500;
+    color: $ds-blue-700;
 
     &:hover {
-      color: $ds-blue-700;
+      color: $ds-blue-900;
     }
   }
 


### PR DESCRIPTION
### What this PR does
This PR updates some of the toast styles after syncing with the design team.

**Before:**
<img width="456" alt="Screenshot 2023-10-25 at 15 41 22" src="https://github.com/getPopsure/dirty-swan/assets/4015038/1d3ef026-9423-4395-ab41-9e78ccc471f2">

**After:**
<img width="444" alt="Screenshot 2023-10-25 at 15 41 12" src="https://github.com/getPopsure/dirty-swan/assets/4015038/cb652798-d102-4a0d-b91a-6b992d00ca40">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
