### PR TITLE
fix(images): Fix images types and add missing card exports

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ export {
   CardWithTopIcon,
   InfoCard,
   CardButton,
+  Card,
   Button,
   AutoSuggestMultiSelect,
   Chip,

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -28,6 +28,7 @@ import {
   InfoCard,
   CardButton,
 } from './components/cards';
+import { Card  } from './components/card';
 import { Button } from './components/button';
 import { AutoSuggestMultiSelect } from './components/input/autoSuggestMultiSelect';
 import Chip from './components/chip';
@@ -66,6 +67,7 @@ export {
   CardWithLeftIcon,
   CardWithTopIcon,
   InfoCard,
+  Card,
   CardButton,
   Button,
   CurrencyInput,

--- a/src/lib/util/images/index.ts
+++ b/src/lib/util/images/index.ts
@@ -22,7 +22,7 @@ const images = {
   books: `${basePath}/books.svg`,
   finalExpenses: `${basePath}/finalExpenses.svg`,
   mortgage: `${basePath}/mortgage.svg`,
-} as const;
+};
 
 const illustrations = {
   aids: `${basePathIllustrations}/aids.svg`,
@@ -155,7 +155,7 @@ const illustrations = {
   water: `${basePathIllustrations}/water.svg`,
   wavingHand: `${basePathIllustrations}/waving-hand.svg`,
   worldwide: `${basePathIllustrations}/worldwide.svg`,
-} as const;
+};
 
 type IllustrationKeys = keyof typeof illustrations;
 


### PR DESCRIPTION
### What this PR does
This PR removes `as const` from image assets as they are breaking private-signup. This still allows autocompletion from types and we can still use `IllustrationKeys` types.

This PR also adds missing cards exports.
### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
