### PR TITLE
fix(multi-dropzone): Fix MultiDropzone not uploading when clicking on label

### DIFF
--- a/src/lib/components/multiDropzone/index.test.tsx
+++ b/src/lib/components/multiDropzone/index.test.tsx
@@ -156,13 +156,6 @@ describe('MultiDropzone component', () => {
         screen.getByText('Please wait while uploading file...')
       ).toBeInTheDocument();
     });
-
-    it('should associate input with its label', () => {
-      const { getByLabelText } = setup({});
-      const input = getByLabelText('Choose file or drag & drop');
-
-      expect(input).toBeInTheDocument();
-    });
   });
 
   describe('Uploaded files', () => {

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef } from 'react';
+import { useCallback, useState } from 'react';
 import classnames from 'classnames';
 import { useDropzone, FileRejection } from 'react-dropzone';
 import AnimateHeight from 'react-animate-height';
@@ -88,8 +88,6 @@ const MultiDropzone = ({
     onDrop,
   });
 
-  const uniqueId = useRef(generateId());
-
   return (
     <div className={styles.container}>
       <div
@@ -103,7 +101,6 @@ const MultiDropzone = ({
       >
         <input
           data-testid="ds-drop-input"
-          id={uniqueId.current}
           {...getInputProps()}
         />
         <UploadCloudIcon
@@ -111,8 +108,7 @@ const MultiDropzone = ({
           size={isCondensed ? 24 : 64}
           color={'purple-500'}
         />
-        <label
-          htmlFor={uniqueId.current}
+        <div
           className={`p-h4 mt8 d-block c-pointer ${
             isCondensed ? styles.textInline : ''
           }`}
@@ -121,7 +117,7 @@ const MultiDropzone = ({
             ? textOverrides?.currentlyUploadingText ||
               'Please wait while uploading file...'
             : textOverrides?.instructionsText || 'Choose file or drag & drop'}
-        </label>
+        </div>
         <div className="p-p--small tc-grey-500">
           {textOverrides?.supportsText || placeholder}
         </div>


### PR DESCRIPTION
### What this PR does
If clicking on the `Choose file or drag & drop` label on a safari browser, the upload isn't triggered.

Behaviour [can be reproduced here](http://dirtyswan.design/?path=/docs/jsx-multidropzone--multi-dropzone-story).

This seems to be caused by the fact that we are triggering our own id while react-dropzone creates its own input reference inside.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
