### PR TITLE
fix(currency-input): Fix currency input type to not allow null

### DIFF
--- a/src/lib/components/input/currency/index.tsx
+++ b/src/lib/components/input/currency/index.tsx
@@ -4,9 +4,9 @@ import { formatInput, reverseFormatInput } from './format';
 import { Input, InputProps } from '..';
 
 export type CurrencyInputProps = {
-  value?: number | null | undefined;
+  value?: number;
   placeholder?: string;
-  onChange?: (value: number | null) => void;
+  onChange?: (value: number) => void;
 } & Omit<InputProps, 'onChange' | 'value' | 'ref'>
 
 const CurrencyInput = ({
@@ -38,7 +38,7 @@ const CurrencyInput = ({
 
   useEffect(() => {
     if (shadowValue === '' && value) {
-      onChange?.(null)
+      onChange?.(0);
     } else if (shadowValue) {
       onChange?.(reverseFormatInput(shadowValue));
     }

--- a/src/lib/components/input/currency/input.stories.tsx
+++ b/src/lib/components/input/currency/input.stories.tsx
@@ -22,9 +22,9 @@ export const CurrencyInputStory = ({
   prefix,
   error
 }: CurrencyInputProps) => {
-  const [newValue, setValue] = useState<number | null>(Number);
+  const [newValue, setValue] = useState<number>(Number);
 
-  const handleOnChange = (value: number | null) => {
+  const handleOnChange = (value: number) => {
     setValue(value)
     onChange?.(value);
   }


### PR DESCRIPTION
### What this PR does
Update Currency input to always return a number, even if empty.

### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
STO-XXX
EMU-XXX
RVN-XXX

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
