### PR TITLE
fix(icon): [EMU-7000] Fix icons shrinking

### DIFF
--- a/src/lib/components/icon/IconWrapper/IconWrapper.tsx
+++ b/src/lib/components/icon/IconWrapper/IconWrapper.tsx
@@ -25,6 +25,7 @@ const IconWrapper = ({
       [styles.wrapper]: !noMargin
     })}
     style={{
+      minWidth: `${size}px`,
       width: `${size}px`,
       height: `${size}px`
     }}


### PR DESCRIPTION
### What this PR does
This PR adds a min-width property to icon wrapper preventing icons from shrinking below their width on some layout definitions. 

### Why is this needed?
When setting icons on layouts (like flex), sometimes content shrinks under the minimum wanted width, one example being the multi drop zone component:

**Before:**
<img width="259" alt="Screenshot 2023-12-13 at 09 39 50" src="https://github.com/getPopsure/dirty-swan/assets/4015038/a6220961-0cac-487c-98b8-2abadd5be1e1">

**After:**
<img width="277" alt="Screenshot 2023-12-13 at 09 39 53" src="https://github.com/getPopsure/dirty-swan/assets/4015038/458bbced-67a8-4bf0-b48f-7412a2e7891d">

Solves:
EMU-7000

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
