### PR TITLE
chore: Add missing ds-grey-400 on documentation

### DIFF
--- a/src/lib/scss/public/demo.tsx
+++ b/src/lib/scss/public/demo.tsx
@@ -159,6 +159,11 @@ const colors = [
   {
     name: 'Grey 300',
     code: 'grey-300',
+    hex: '#ededf2',
+  },
+  {
+    name: 'Grey 400',
+    code: 'grey-400',
     hex: '#d2d2d8',
   },
   {


### PR DESCRIPTION
### What this PR does

Adding missing `grey-400` value on http://dirtyswan.design/?path=/story/css-variables-colors--page

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
