### PR TITLE
fix(card): [EMU-7042] Add falsy value option for actionIcon and fix actionable card sizes

### DIFF
--- a/src/lib/components/card/index.tsx
+++ b/src/lib/components/card/index.tsx
@@ -41,87 +41,91 @@ const CardContent = ({
   actionIcon,
   title,
   titleVariant = 'large',
-}: CardProps) => (
-  <section
-    className={classNamesUtil(
-      'd-flex fd-column jc-center br8 bg-white w100 ta-left',
-      { 'bs-sm': dropShadow },
-      {
-        compact: 'p16',
-        balanced: 'p24',
-        spacious: 'p32',
-      }[density],
-      classNames?.wrapper
-    )}
-  >
-    <div className="d-flex w100">
-      {icon && (
-        <div
-          className={classNamesUtil(
-            `d-flex ai-center tc-primary-500`,
-            styles.icon,
-            styles[`icon${density}`],
-            classNames?.icon
-          )}
-        >
-          {icon}
-        </div>
+}: CardProps) => {
+  const hideActionIcon = typeof actionIcon !== 'undefined' && !actionIcon;
+
+  return (
+    <section
+      className={classNamesUtil(
+        'd-flex fd-column jc-center br8 bg-white w100 ta-left',
+        { 'bs-sm': dropShadow },
+        {
+          compact: 'p16',
+          balanced: 'p24',
+          spacious: 'p32',
+        }[density],
+        classNames?.wrapper
       )}
+    >
+      <div className="d-flex w100">
+        {icon && (
+          <div
+            className={classNamesUtil(
+              `d-flex ai-center tc-primary-500`,
+              styles.icon,
+              styles[`icon${density}`],
+              classNames?.icon
+            )}
+          >
+            {icon}
+          </div>
+        )}
 
-      <div className="d-flex jc-between w100">
-        <div className="d-flex jc-center gap8 fd-column tc-grey-900 w100">
-          {label && (
-            <h3 className={classNamesUtil('p-p--small', classNames?.label)}>
-              {label}
-            </h3>
-          )}
+        <div className="d-flex jc-between w100">
+          <div className="d-flex jc-center gap8 fd-column tc-grey-900 w100">
+            {label && (
+              <h3 className={classNamesUtil('p-p--small', classNames?.label)}>
+                {label}
+              </h3>
+            )}
 
-          {title && (
-            <h2
-              className={classNamesUtil(
-                classNames?.title,
-                {
-                  large: 'p-h3',
-                  medium: 'p-h4',
-                  small: 'p-p',
-                }[titleVariant]
-              )}
-            >
-              {title}
-            </h2>
-          )}
+            {title && (
+              <h2
+                className={classNamesUtil(
+                  classNames?.title,
+                  {
+                    large: 'p-h3',
+                    medium: 'p-h4',
+                    small: 'p-p',
+                  }[titleVariant]
+                )}
+              >
+                {title}
+              </h2>
+            )}
 
-          {description && (
+            {description && (
+              <div
+                className={classNamesUtil(
+                  'tc-grey-600',
+                  classNames?.description,
+                  descriptionVariant === 'small' ? 'p-p--small' : 'p-p'
+                )}
+              >
+                {description}
+              </div>
+            )}
+          </div>
+
+          {onClick && !hideActionIcon && (
             <div
               className={classNamesUtil(
-                'tc-grey-600',
-                classNames?.description,
-                descriptionVariant === 'small' ? 'p-p--small' : 'p-p'
+                styles.actionIcon,
+                classNames?.actionIcon,
+                styles[`actionIcon${density}`],
+                'd-flex ai-center'
               )}
             >
-              {description}
+              {actionIcon || <ChevronRightIcon size={24} />}
             </div>
           )}
         </div>
-
-        {onClick && (
-          <div
-            className={classNamesUtil(
-              styles.actionIcon,
-              classNames?.actionIcon,
-              styles[`actionIcon${density}`],
-              'd-flex ai-center'
-            )}
-          >
-            {actionIcon || <ChevronRightIcon size={24} />}
-          </div>
-        )}
       </div>
-    </div>
 
-    {children && <div className={classNames?.children}>{children}</div>}
-  </section>
-);
+      {children && <div className={classNames?.children}>{children}</div>}
+    </section>
+  );
+};
 
 const Card = (props: CardProps) => {
   const { onClick } = props;
@@ -130,7 +134,7 @@ const Card = (props: CardProps) => {
     return (
       <button
         className={classNamesUtil(
-          'c-pointer d-flex w100 br8',
+          'c-pointer d-flex w100 br8 ai-stretch',
           styles.button,
           props.classNames?.buttonWrapper
         )}

--- a/src/lib/components/card/style.module.scss
+++ b/src/lib/components/card/style.module.scss
@@ -2,13 +2,17 @@
 
 .button {
   background-color: transparent;
-  border: 1px solid transparent;
   color: $ds-grey-900;
-  outline-color: $ds-primary-500;
+  outline: 1px solid transparent;
   transition: all 0.2s ease-in-out;
 
   &:hover {
-    border-color: $ds-primary-500;
+    outline: 1px solid $ds-primary-500;
+    color: $ds-primary-500;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $ds-primary-500;
     color: $ds-primary-500;
   }
 }


### PR DESCRIPTION
### What this PR does
This PR fixes:
- card action action which now allows to use falsy values to not render it (e.g. `<Card actionIcon={null} />`)
- fixes card sizes that were differently if it was an action card, with and without action icon.

Solves:
EMU-7042

**Before:**
<img width="1485" alt="Screenshot 2024-01-12 at 11 51 19" src="https://github.com/getPopsure/dirty-swan/assets/4015038/f9f45ccc-2a48-4799-9f5d-6376453c5aec">

**After:**
<img width="1512" alt="Screenshot 2024-01-12 at 11 47 17" src="https://github.com/getPopsure/dirty-swan/assets/4015038/7a283736-c7c0-49e5-8e2d-6538f0298936">


### How to test?
Run storybook and check the [Card stories](http://localhost:9009/?path=/docs/jsx-card--card-story).

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
