### PR TITLE
fix(comparison-table): Fix comparison table not growing

### DIFF
--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -1,5 +1,5 @@
 import debounce from 'lodash.debounce';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { ArrowValues } from '../components/TableArrows';
 import generateId from '../../../util/generateId';
@@ -49,6 +49,18 @@ export const useComparisonTable = () => {
       }
       observerRef.current?.disconnect();
     };
+  }, []);
+
+  useLayoutEffect(() => {
+    const resetHeaderWidth = () => {
+      if (headerRef.current) {
+        setHeaderWidth(headerRef.current.clientWidth);
+      }
+    }
+
+    window.addEventListener('resize', resetHeaderWidth);
+
+    return () => window.removeEventListener('resize', resetHeaderWidth);
   }, []);
 
   const handleTableScroll = () => {


### PR DESCRIPTION
### What this PR does
This PR fixes the comparison table not re-growing in some edge cases (sudden resizes like visual regression tests).

**Before:**
https://github.com/getPopsure/dirty-swan/assets/4015038/b5b7e050-899b-46f0-8842-0b77c6d6a9ee


**After:**
https://github.com/getPopsure/dirty-swan/assets/4015038/0b83c546-9bc3-4575-ae81-27a6b14727d1


### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
