### PR TITLE
refactor(IbanInput): Make IbanInput onChange prop optional

### DIFF
--- a/src/lib/components/input/iban/index.tsx
+++ b/src/lib/components/input/iban/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import type { SyntheticEvent } from 'react';
 import { Input, InputProps } from '..';
 
 import { formatIban } from './formatIban';
@@ -8,13 +10,20 @@ const IbanInput = ({
   ...props
 }: {
   value?: string;
-  onChange: (value: string) => void;
-} & Omit<InputProps, 'onChange' | 'value' | 'ref'>) => (
-  <Input
-    value={formatIban(value)}
-    onChange={(e) => onChange(formatIban(e.target.value))}
+  onChange?: (value: string) => void;
+} & Omit<InputProps, 'onChange' | 'value' | 'ref'>) => {
+  const [iban, setIban] = useState<string | undefined>(value);
+
+  const handleChange = (e: SyntheticEvent<HTMLInputElement>) => {
+    setIban(e.currentTarget.value);
+    onChange?.(formatIban(e.currentTarget.value));
+  }
+  return <Input
+    name='iban'
+    value={formatIban(iban)}
+    onChange={handleChange}
     {...props}
   />
-);
+};
 
 export default IbanInput;


### PR DESCRIPTION
### What this PR does

Make onChange prop for IbanInput optional

### Why is this needed?


Solves:
EMU-6707

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
