### PR TITLE
feat(radio-component): [STO-6632] add support for disabling radio input

### DIFF
--- a/src/lib/components/input/radio/index.stories.tsx
+++ b/src/lib/components/input/radio/index.stories.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from 'react';
 import { Radio, RadioProps } from '.';
 import { images } from '../../../util/images';
@@ -8,21 +7,22 @@ const story = {
   component: Radio,
   argTypes: {
     options: {
-      description: 'Object that contains the possible options for rendering in the input.',
+      description:
+        'Object that contains the possible options for rendering in the input.',
       defaultValue: {
-        CAT:{
+        CAT: {
           title: 'Cat',
-          description: 'At least 1'
+          description: 'At least 1',
         },
-        DOG:{
+        DOG: {
           title: 'Dog',
-          description: 'At least 2'
+          description: 'At least 2',
         },
-        NONE:{
+        NONE: {
           title: 'None',
-          description: 'No pets'
-        }
-      }
+          description: 'No pets',
+        },
+      },
     },
     value: {
       description: 'Current checked values.',
@@ -31,122 +31,137 @@ const story = {
       description: 'Function called everytime a value changes.',
       action: true,
       table: {
-        category: "Callbacks",
+        category: 'Callbacks',
       },
     },
     wide: {
-      description: 'Property that defines if options should fill 100% of available horizontal space',
-      defaultValue: false
+      description:
+        'Property that defines if options should fill 100% of available horizontal space',
+      defaultValue: false,
     },
     inlineLayout: {
-      description: 'Property that defines if options should show inline instead of block. Check inline radio options story for examples.',
-      defaultValue: false
+      description:
+        'Property that defines if options should show inline instead of block. Check inline radio options story for examples.',
+      defaultValue: false,
     },
     classNames: {
       description: 'ClassNames for custom styling',
       defaultValue: {
         container: '',
         label: '',
-        option: ''
-      }
+        option: '',
+      },
     },
     bordered: {
       description: 'Property that defines if option should show with border',
-      defaultValue: true
+      defaultValue: true,
     },
-  }
+    disabled: {
+      description:
+        'Property that defines if the input and corresponding label are disabled and not clickable',
+      defaultValue: false,
+    },
+  },
 };
 
-export const RadioStory = ({ 
+export const RadioStory = ({
   onChange,
   options,
   wide,
   classNames,
   inlineLayout,
   bordered,
+  disabled,
 }: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
+    <Radio
       wide={wide}
-      options={options} 
+      options={options}
       onChange={handleOnChange}
       value={checkedValues}
       classNames={classNames}
       inlineLayout={inlineLayout}
       bordered={bordered}
+      disabled={disabled}
     />
   );
-}
+};
 
-export const RadioWithCustomWrapperStyles = ({ onChange }: RadioProps<string>) => {
+export const RadioWithCustomWrapperStyles = ({
+  onChange,
+}: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
+    <Radio
       onChange={handleOnChange}
       value={checkedValues}
       options={{
         CAT1: 'Cat',
         DOG1: 'Dog',
-      }} 
-      classNames={{ container: "p32 bg-primary-300 br24 bs-lg" }}
+      }}
+      classNames={{ container: 'p32 bg-primary-300 br24 bs-lg' }}
     />
   );
-}
+};
 
-export const RadioWithCustomOptionStyles = ({ onChange }: RadioProps<string>) => {
+export const RadioWithCustomOptionStyles = ({
+  onChange,
+}: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
+    <Radio
       onChange={handleOnChange}
       value={checkedValues}
       options={{
         CAT2: 'Cat',
         DOG2: 'Dog',
-      }} 
-      classNames={{ option: "mb32 p24 bg-green-100 br12 bs-lg" }}
+      }}
+      classNames={{ option: 'mb32 p24 bg-green-100 br12 bs-lg' }}
     />
   );
-}
+};
 
-export const RadioWithCustomLabelStyles = ({ onChange }: RadioProps<string>) => {
+export const RadioWithCustomLabelStyles = ({
+  onChange,
+}: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
-  const handleOnChange = (newValue: string  ) => {
+  const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
+    <Radio
       onChange={handleOnChange}
       value={checkedValues}
       options={{
         CAT3: 'Cat',
         DOG3: 'Dog',
-      }} 
-      classNames={{ label: "bg-grey-900 tc-white" }}
+      }}
+      classNames={{ label: 'bg-grey-900 tc-white' }}
     />
   );
-}
+};
 
 export const RadioWithInlineLayout = ({ onChange }: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
@@ -154,10 +169,10 @@ export const RadioWithInlineLayout = ({ onChange }: RadioProps<string>) => {
   const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
+    <Radio
       onChange={handleOnChange}
       value={checkedValues}
       options={{
@@ -167,78 +182,88 @@ export const RadioWithInlineLayout = ({ onChange }: RadioProps<string>) => {
         RABBIT: 'Rabbit',
         RAT: 'Rat',
         ANOTHER: 'Other',
-      }} 
-      classNames={{ option: "w30" }}
+      }}
+      classNames={{ option: 'w30' }}
       inlineLayout
       wide
     />
   );
-}
+};
 
-export const RadioWithCustomLabel = ({ onChange, wide, classNames, inlineLayout }: RadioProps<string>) => {
+export const RadioWithCustomLabel = ({
+  onChange,
+  wide,
+  classNames,
+  inlineLayout,
+}: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
+    <Radio
       options={{
         BIGDOG: {
-          icon: () => <img src={images.bigDog} alt='' />,
+          icon: () => <img src={images.bigDog} alt="" />,
           title: 'Dog',
         },
-        FISH:{
-          icon: () => <img src={images.brokenAquarium} alt='' />,
+        FISH: {
+          icon: () => <img src={images.brokenAquarium} alt="" />,
           title: 'Fish',
         },
-        OTHER:{
-          icon: () => <img src={images.brokenGlass} alt='' />,
+        OTHER: {
+          icon: () => <img src={images.brokenGlass} alt="" />,
           title: 'Other',
-        }
-      }} 
+        },
+      }}
       onChange={handleOnChange}
       value={checkedValues}
-      classNames={{ option: "w30" }}
+      classNames={{ option: 'w30' }}
       inlineLayout
     />
   );
-}
+};
 
-export const RadioWithCustomLabelInline = ({ onChange, wide, classNames, inlineLayout }: RadioProps<string>) => {
+export const RadioWithCustomLabelInline = ({
+  onChange,
+  wide,
+  classNames,
+  inlineLayout,
+}: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
   const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
+    <Radio
       options={{
         BIGDOG: {
-          icon: () => <img src={images.bigDog} alt='' />,
+          icon: () => <img src={images.bigDog} alt="" />,
           title: 'Dog',
         },
-        FISH:{
-          icon: () => <img src={images.brokenAquarium} alt='' />,
+        FISH: {
+          icon: () => <img src={images.brokenAquarium} alt="" />,
           title: 'Fish',
         },
-        OTHER:{
-          icon: () => <img src={images.brokenGlass} alt='' />,
+        OTHER: {
+          icon: () => <img src={images.brokenGlass} alt="" />,
           title: 'Other',
-        }
-      }} 
+        },
+      }}
       onChange={handleOnChange}
       inlineIcon
       value={checkedValues}
-      classNames={{ option: "w30" }}
+      classNames={{ option: 'w30' }}
       inlineLayout
     />
   );
-}
+};
 
 RadioStory.storyName = 'Radio';
 
@@ -248,18 +273,18 @@ export const RadioIconOnly = ({ onChange }: RadioProps<string>) => {
   const handleOnChange = (newValue: string) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Radio 
-      options={{ NOTHING: '' }} 
+    <Radio
+      options={{ NOTHING: '' }}
       onChange={handleOnChange}
       classNames={{ label: 'jc-start' }}
       value={checkedValues}
       bordered={false}
     />
   );
-}
+};
 
 RadioStory.storyName = 'Radio';
 

--- a/src/lib/components/input/radio/index.test.tsx
+++ b/src/lib/components/input/radio/index.test.tsx
@@ -107,4 +107,23 @@ describe('Radio component', () => {
 
     expect(getByText('Cat')).toBeInTheDocument();
   });
+
+  it('Should disable the input', async () => {
+    const { getByTestId } = render(
+      <Radio
+        options={{
+          CAT: {
+            title: 'Cat',
+            description: 'Cat description',
+          },
+        }}
+        onChange={mockOnChange}
+        disabled
+      />
+    );
+
+    const radioInput = getByTestId('radio-input-CAT');
+
+    expect(radioInput).toBeDisabled();
+  });
 });

--- a/src/lib/components/input/radio/index.tsx
+++ b/src/lib/components/input/radio/index.tsx
@@ -22,6 +22,7 @@ export interface RadioProps<ValueType extends string> {
     option?: string;
   };
   bordered?: boolean;
+  disabled?: boolean;
 }
 
 export const Radio = <ValueType extends string>({
@@ -33,6 +34,7 @@ export const Radio = <ValueType extends string>({
   inlineIcon = false,
   classNames: classNamesObj,
   bordered = true,
+  disabled = false,
 }: RadioProps<ValueType>) => {
   const entries = Object.entries(options) as [
     ValueType,
@@ -78,6 +80,7 @@ export const Radio = <ValueType extends string>({
               onChange={() => onChange(currentValue)}
               checked={checked}
               data-testid={`radio-input-${currentValue}`}
+              disabled={disabled}
             />
 
             <label
@@ -91,10 +94,10 @@ export const Radio = <ValueType extends string>({
               data-testid={`radio-${currentValue}`}
             >
               {customIcon && (
-                <div 
+                <div
                   className={classNames(
-                    "d-inline-flex ai-center jc-center", 
-                    inlineIcon ? "mr8" : "mt8"
+                    'd-inline-flex ai-center jc-center',
+                    inlineIcon ? 'mr8' : 'mt8'
                   )}
                 >
                   {customIcon?.(checked)}

--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -96,12 +96,23 @@
 }
 
 .p-radio--no-icon + label::before {
-  display: none!important;
+  display: none !important;
 }
 .p-radio:checked {
   & + label::before {
     border-color: $ds-primary-500;
     background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 20 20" stroke="white" stroke-width="4" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="50%" fill="#{util.url-encoded-color($ds-primary-500)}"/></svg>');
+  }
+}
+
+.p-radio:disabled {
+  + .p-label {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  + .p-label--bordered:hover {
+    border-color: $ds-grey-400;
   }
 }
 


### PR DESCRIPTION
### What this PR does

Allows making the DS radio input and corresponding label not clickable by leveraging the native `disabled` attribute.

https://github.com/getPopsure/dirty-swan/assets/113006001/f13b3f00-8c68-435e-bb91-86dd9c562d8e

### Why is this needed?

The new Dental quote screen needs to be updated to improve the discoverability of tooth replacement coverage. For that, we need to be able to disable the radio inputs based on the selected plan - this option is currently not available in DS. 

-> [Design on Figma](https://www.figma.com/file/RTKZdSPByXcWDCioyo6BeE/Sign-Ups?type=design&node-id=35714-24696&mode=design&t=OthcHT3ZTe9NYS2V-4)
-> [Ticket](https://linear.app/feather-insurance/issue/STO-6621/improve-discoverability-of-tooth-replacement-coverage)

Solves:
[STO-6632](https://linear.app/feather-insurance/issue/STO-6632/update-the-ds-component)

### How to test?

- Run `yarn storybook`
- Toggle to `true` the `disabled` prop in [the Radio component section](http://localhost:9009/?path=/docs/jsx-inputs-radio--radio-story) 

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
