### PR TITLE
refactor(toaster): Add toaster classnames

### DIFF
--- a/src/lib/components/toast/index.stories.tsx
+++ b/src/lib/components/toast/index.stories.tsx
@@ -1,7 +1,7 @@
-import classNames from 'classnames';
-import { Toast, ToastProps, ToastType, Toaster, toast } from '.';
+import { ToasterProps, Toast, ToastProps, ToastType, Toaster, toast } from '.';
 import { Button } from '../button';
 import styles from './style.module.scss';
+import classNames from 'classnames';
 
 const toastTypes: ToastType[] = ['success', 'warning', 'error', 'information'];
 
@@ -31,7 +31,13 @@ const story = {
       table: {
         disable: true,
       },
-    }
+    },
+    classNames: {
+      description: 'Allows customization of toast and toast wrapper (named as Toaster)',
+      table: {
+        category: 'Toaster props',
+      },
+    },
   },
   args: {
     title: 'We couldn’t open the chat',
@@ -42,6 +48,10 @@ const story = {
     },
     type: 'success',
     duration: 3000,
+    classNames: {
+      toast: "",
+      wrapper: ""
+    }
   },
 };
 
@@ -49,7 +59,7 @@ const FakeInlineToast = ({
   title, 
   description, 
   action, 
-  type
+  type,
 }: Omit<ToastProps, 'onDismiss'>) => (
   <div className='mb32'>
     <div
@@ -69,7 +79,14 @@ const FakeInlineToast = ({
   </div>
 );
 
-export const ToastStory = ({ title, description, action, type, duration }: ToastProps) => {
+export const ToastStory = ({ 
+  title, 
+  description, 
+  action, 
+  type, 
+  duration, 
+  classNames: toasterClassNames 
+}: ToastProps & ToasterProps) => {
   const showToast = () => toast(
     title, 
     {
@@ -90,7 +107,7 @@ export const ToastStory = ({ title, description, action, type, duration }: Toast
           {"() => toast(title, { description, type, action })"}
         </pre>
       </div>
-      <Toaster />
+      <Toaster classNames={toasterClassNames} />
 
       <Button onClick={showToast}>Click here to trigger toast</Button>
     </>

--- a/src/lib/components/toast/index.tsx
+++ b/src/lib/components/toast/index.tsx
@@ -5,6 +5,13 @@ import styles from './style.module.scss';
 import { Toaster as HotToaster, toast as hotToast } from 'react-hot-toast';
 import { XIcon } from '../icon';
 
+export interface ToasterProps {
+  classNames?: {
+    wrapper?: string;
+    toast?: string;
+  };
+}
+
 export type ToastType = 'warning' | 'error' | 'success' | 'information';
 
 export interface ToastOptions {
@@ -22,10 +29,11 @@ export interface ToastProps extends ToastOptions {
   title: string 
 };
 
-const Toaster = () => (
+const Toaster = ({ classNames: toasterClassNames }: ToasterProps) => (
   <HotToaster 
+  containerClassName={toasterClassNames?.wrapper}
     toastOptions={{
-      className: classNames(styles.toast, 'bs-lg'),
+      className: classNames(styles.toast, 'bs-lg', toasterClassNames?.toast),
     }}
   />
 );


### PR DESCRIPTION
### What this PR does
This PR adds classnames prop to Toaster component which allows for a generic customisation of both toast and toast wrapper.

### Why is this needed?
In some cases, consumers of the design system might want to pull the toast down or update some of the generic styles.

Solves:
EMU-7256

### How to test?
Run storybook and add classnames to see the differences:
<img width="400" alt="Screenshot 2024-03-25 at 15 22 13" src="https://github.com/getPopsure/dirty-swan/assets/4015038/a74c58e7-1a8c-49bf-a365-b6583d4dee41">
<img width="200" alt="Screenshot 2024-03-25 at 15 22 10" src="https://github.com/getPopsure/dirty-swan/assets/4015038/02837520-aa28-42f4-9c1e-0279ae62fe0a">


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
