### PR TITLE
fix(card): Allow always setting action icon

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,6 +55,8 @@ export type {
   TableHeader,
   UploadedFile,
   UploadStatus,
+  CardProps,
+  IconWrapperProps
 } from './lib';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/lib/components/card/index.stories.tsx
+++ b/src/lib/components/card/index.stories.tsx
@@ -40,7 +40,11 @@ const story = {
       description: 'Wether to display card with drop shadow styles or not.',
     },
     actionIcon: {
+      control: { type: 'text' },
       description: 'ReactNode to be rendered on the right side of the card when there is an onClick action. By default it renders the ChevronRightIcon.',
+    },
+    showActionIcon: {
+      description: 'Property that always displays action icon even if no onClick is set.',
     },
   },
   args: {
@@ -66,6 +70,7 @@ const story = {
 
 export const CardStory = ({ 
   actionIcon,
+  showActionIcon,
   children,
   classNames,
   density,
@@ -91,6 +96,7 @@ export const CardStory = ({
       titleVariant={titleVariant}
       onClick={onClick}
       actionIcon={actionIcon}
+      showActionIcon={showActionIcon}
     >
       {children}
     </Card>

--- a/src/lib/components/card/index.tsx
+++ b/src/lib/components/card/index.tsx
@@ -26,6 +26,7 @@ export interface CardProps {
   label?: ReactNode;
   onClick?: () => void;
   actionIcon?: ReactNode;
+  showActionIcon?: boolean;
 }
 
 const CardContent = ({
@@ -41,6 +42,7 @@ const CardContent = ({
   actionIcon,
   title,
   titleVariant = 'large',
+  showActionIcon
 }: CardProps) => {
   const hideActionIcon = typeof actionIcon !== 'undefined' && !actionIcon;
 
@@ -107,7 +109,7 @@ const CardContent = ({
             )}
           </div>
 
-          {onClick && !hideActionIcon && (
+          {(showActionIcon || (onClick && !hideActionIcon)) && (
             <div
               className={classNamesUtil(
                 styles.actionIcon,

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -27,6 +27,7 @@ import {
   CardWithTopIcon,
   InfoCard,
   CardButton,
+  CardProps,
 } from './components/cards';
 import { Card  } from './components/card';
 import { Button } from './components/button';
@@ -49,6 +50,7 @@ import { illustrations, images, IllustrationKeys } from './util/images';
 import { Spinner } from './components/spinner';
 import { Toggle } from './components/input/toggle';
 import { Toaster, toast } from './components/toast';
+import { IconWrapperProps } from './components/icon/IconWrapper';
 
 export * from './components/icon';
 
@@ -103,6 +105,8 @@ export type {
   TableHeader,
   UploadedFile,
   UploadStatus,
+  CardProps,
+  IconWrapperProps
 };
 
 export type { DownloadStatus } from './models/download';


### PR DESCRIPTION
### What this PR does
This PR:
- Exports missing `CardsProps` and `IconWrapperProps`,
- Adds `showActionAction` prop to allow always showing actionIcon, useful for cases where properties other than onClick should show the icon:
<img width="388" alt="Screenshot 2024-04-03 at 10 20 40" src="https://github.com/getPopsure/dirty-swan/assets/4015038/cffc32d0-a87c-4df3-8e0a-910a4526283d">


### How to test?
On storybook, turn `showActionIcon` to true.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
