### PR TITLE
feat(card): Add polymorphic as prop support to Card component

### DIFF
--- a/src/lib/components/card/index.stories.tsx
+++ b/src/lib/components/card/index.stories.tsx
@@ -2,12 +2,16 @@ import { Card, CardProps } from '.';
 import { illustrations } from '../../util/images';
 import { Button } from '../button';
 import { Badge } from '../badge';
-import { CheckIcon, MehIcon, PlusCircleIcon, XIcon } from '../icon';
+import { CheckIcon, InfoIcon, MehIcon, PlusCircleIcon, XIcon } from '../icon';
 
 const story = {
   title: 'JSX/Card',
   component: Card,
   argTypes: {
+    as: {
+      control: { type: 'text' },
+      description: 'Allow wrapper element type to be custom defined'
+    },
     density: {
       description: 'Spacing around the card'
     },
@@ -69,6 +73,7 @@ const story = {
 };
 
 export const CardStory = ({ 
+  as,
   actionIcon,
   showActionIcon,
   children,
@@ -85,6 +90,7 @@ export const CardStory = ({
 }: CardProps) => (
   <div className='d-flex p24 bg-grey-200'>
     <Card
+      as={as}
       classNames={classNames}
       description={description}
       descriptionVariant={descriptionVariant}
@@ -105,6 +111,32 @@ export const CardStory = ({
 
 CardStory.storyName = "Card";
 
+export const CardAsOtherComponents = () => (
+  <div className='d-flex fd-column gap16 p24 bg-grey-200'>
+   
+    <h3 className='p-h3'>As an anchor:</h3>
+    <Card
+      as="a"
+      href="https://feather-insurance.com"
+      target="_blank"
+      title="Card with an a tag"
+      density='compact'
+    />
+
+    <h3 className='p-h3'>As a nav:</h3>
+    <Card
+      as="nav"
+      title="Card with a nav tag"
+      density='compact'
+    />
+
+    <p className='p-p p-p--small fw-bold d-flex ai-center gap8 mt32'>
+      <InfoIcon />
+      Inspect elements to see the different HTML tags being rendered.
+    </p>
+  </div>
+);
+
 export const CardDensities = () => (
   <div className='d-flex fd-column gap16 p24 bg-grey-200'>
     <Card
@@ -122,11 +154,7 @@ export const CardDensities = () => (
   </div>
 );
 
-export const CardsWithIcons = ({ 
-  children,
-  icon,
-  title,
-}: CardProps) => (
+export const CardsWithIcons = ({ title }: CardProps) => (
   <div className='d-flex gap16 p24 bg-grey-200'>
     <Card
       icon={
@@ -139,7 +167,7 @@ export const CardsWithIcons = ({
       title={title}
     />
     <Card
-      icon={<MehIcon size={24} />}
+      icon={<MehIcon size={24} noMargin />}
       title={title}
     />
   </div>
@@ -147,7 +175,6 @@ export const CardsWithIcons = ({
 
 export const CardWithOnClickAction = ({ 
   children,
-  icon,
   title,
 }: CardProps) => (
   <div className='d-flex p24 bg-grey-200'>
@@ -190,11 +217,7 @@ export const CardOverridesStyles = ({
   </div>
 );
 
-export const CardsWithinCardsAndComplexLayout = ({ 
-  children,
-  label,
-  title,
-}: CardProps) => (
+export const CardsWithinCardsAndComplexLayout = () => (
   <div className='d-flex p24 bg-grey-200'>
     <Card
       label={(

--- a/src/lib/components/card/index.tsx
+++ b/src/lib/components/card/index.tsx
@@ -1,10 +1,14 @@
-import { ReactNode } from 'react';
+import { ElementType, ReactNode } from 'react';
 import classNamesUtil from 'classnames';
 import { ChevronRightIcon } from '../icon';
 
 import styles from './style.module.scss';
 
-export interface CardProps {
+const CardDefault = 'section' as const
+type CardDefaultAsType = typeof CardDefault;
+
+type CardOwnProps<E extends ElementType = CardDefaultAsType> = {
+  as?: E;
   children?: ReactNode;
   classNames?: {
     buttonWrapper?: string;
@@ -29,7 +33,11 @@ export interface CardProps {
   showActionIcon?: boolean;
 }
 
-const CardContent = ({
+export type CardProps<E extends ElementType = CardDefaultAsType> = CardOwnProps<E> &
+  Omit<React.ComponentProps<E>, keyof CardOwnProps<E>>
+
+const Card = <E extends ElementType = CardDefaultAsType>({
+  as,
   children,
   classNames,
   density = 'balanced',
@@ -42,113 +50,111 @@ const CardContent = ({
   actionIcon,
   title,
   titleVariant = 'large',
-  showActionIcon
-}: CardProps) => {
+  showActionIcon,
+  ...rest
+}: CardProps<E>) => {
   const hideActionIcon = typeof actionIcon !== 'undefined' && !actionIcon;
-
+  const propsWithActionIcon = onClick || rest?.href || rest.to; 
+  const cardDefaultTag = onClick ? 'button' : CardDefault;
+  const Tag = as || cardDefaultTag;
+  
   return (
-    <section
+    <Tag
       className={classNamesUtil(
-        'd-flex fd-column jc-center br8 bg-white w100 ta-left',
-        { 'bs-sm': dropShadow },
+        classNames?.buttonWrapper,
+        ' d-flex w100 br8 ai-stretch',
         {
-          compact: 'p16',
-          balanced: 'p24',
-          spacious: 'p32',
-        }[density],
-        classNames?.wrapper
+          'c-pointer': propsWithActionIcon,
+          [styles.button]: propsWithActionIcon
+        },
       )}
+      {...onClick && { 
+        onClick, 
+        type: "button"
+      }}
+      {...rest}
     >
-      <div className="d-flex w100">
-        {icon && (
-          <div
-            className={classNamesUtil(
-              `d-flex ai-center tc-primary-500`,
-              styles.icon,
-              styles[`icon${density}`],
-              classNames?.icon
-            )}
-          >
-            {icon}
-          </div>
+      <div
+        className={classNamesUtil(
+          'd-flex fd-column jc-center br8 bg-white w100 ta-left',
+          { 'bs-sm': dropShadow },
+          {
+            compact: 'p16',
+            balanced: 'p24',
+            spacious: 'p32',
+          }[density],
+          classNames?.wrapper
         )}
+      >
+        <div className="d-flex w100">
+          {icon && (
+            <div
+              className={classNamesUtil(
+                `d-flex ai-center tc-primary-500`,
+                styles.icon,
+                styles[`icon${density}`],
+                classNames?.icon
+              )}
+            >
+              {icon}
+            </div>
+          )}
 
-        <div className="d-flex jc-between w100">
-          <div className="d-flex jc-center gap8 fd-column tc-grey-900 w100">
-            {label && (
-              <h3 className={classNamesUtil('p-p--small', classNames?.label)}>
-                {label}
-              </h3>
-            )}
+          <div className="d-flex jc-between w100">
+            <div className="d-flex jc-center gap8 fd-column tc-grey-900 w100">
+              {label && (
+                <h3 className={classNamesUtil('p-p--small', classNames?.label)}>
+                  {label}
+                </h3>
+              )}
 
-            {title && (
-              <h2
-                className={classNamesUtil(
-                  classNames?.title,
-                  {
-                    large: 'p-h3',
-                    medium: 'p-h4',
-                    small: 'p-p',
-                  }[titleVariant]
-                )}
-              >
-                {title}
-              </h2>
-            )}
+              {title && (
+                <h2
+                  className={classNamesUtil(
+                    classNames?.title,
+                    {
+                      large: 'p-h3',
+                      medium: 'p-h4',
+                      small: 'p-p',
+                    }[titleVariant]
+                  )}
+                >
+                  {title}
+                </h2>
+              )}
 
-            {description && (
+              {description && (
+                <div
+                  className={classNamesUtil(
+                    'tc-grey-600',
+                    classNames?.description,
+                    descriptionVariant === 'small' ? 'p-p--small' : 'p-p'
+                  )}
+                >
+                  {description}
+                </div>
+              )}
+            </div>
+
+            {(showActionIcon || (propsWithActionIcon && !hideActionIcon)) && (
               <div
                 className={classNamesUtil(
-                  'tc-grey-600',
-                  classNames?.description,
-                  descriptionVariant === 'small' ? 'p-p--small' : 'p-p'
+                  styles.actionIcon,
+                  classNames?.actionIcon,
+                  styles[`actionIcon${density}`],
+                  'd-flex ai-center'
                 )}
               >
-                {description}
+                {actionIcon || <ChevronRightIcon size={24} />}
               </div>
             )}
           </div>
-
-          {(showActionIcon || (onClick && !hideActionIcon)) && (
-            <div
-              className={classNamesUtil(
-                styles.actionIcon,
-                classNames?.actionIcon,
-                styles[`actionIcon${density}`],
-                'd-flex ai-center'
-              )}
-            >
-              {actionIcon || <ChevronRightIcon size={24} />}
-            </div>
-          )}
         </div>
+
+        {children && <div className={classNames?.children}>{children}</div>}
       </div>
-
-      {children && <div className={classNames?.children}>{children}</div>}
-    </section>
+    </Tag>
   );
-};
-
-const Card = (props: CardProps) => {
-  const { onClick } = props;
-
-  if (onClick) {
-    return (
-      <button
-        className={classNamesUtil(
-          'c-pointer d-flex w100 br8 ai-stretch',
-          styles.button,
-          props.classNames?.buttonWrapper
-        )}
-        onClick={onClick}
-        type="button"
-      >
-        <CardContent {...props} />
-      </button>
-    );
-  }
-
-  return <CardContent {...props} />;
 };
 
 export { Card };

--- a/src/lib/components/card/style.module.scss
+++ b/src/lib/components/card/style.module.scss
@@ -5,6 +5,7 @@
   color: $ds-grey-900;
   outline: 1px solid transparent;
   transition: all 0.2s ease-in-out;
+  text-decoration: none;
 
   &:hover {
     outline: 1px solid $ds-primary-500;


### PR DESCRIPTION
### What this PR does
This PR adds the `as` prop to Card component allowing it to be rendered as other components.

This is specially useful if we want to use `a`, `button` or react-router `Link` component props without having to wrap the component in those elements (which allows to make use of hover, focus and related states).

### How to test?
Run storybook and [go to stories card, to the `Card as other components` story](http://localhost:9009/?path=/docs/jsx-card--card-story#card-as-other-components).


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
