### PR TITLE
fix(button): Fix btn-secondary/textColor loading not showing correctly

### DIFF
--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { ReactElement, ReactNode } from 'react';
-import styles from './style.module.scss';
 
 type ButtonVariant =
   | 'filledColor'
@@ -51,12 +50,13 @@ const Button = React.forwardRef((
         buttonTypeClassNameMap[variant], 
         className, {
           'p-btn--loading': loading,
+          'tc-transparent': loading,
           'p-btn--icon-only': hideLabel,
         })}
       data-testid="button"
       {...props}
     >
-      {leftIcon || rightIcon ? (
+      {!loading && (leftIcon || rightIcon) ? (
         <div className="d-flex jc-center ai-center">
           {leftIcon && (
             <span

--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -271,6 +271,7 @@
       animation: spinner-rotate 0.9s infinite;
     }
 
+    &.p-btn--secondary,
     &.p-btn--secondary-grey,
     &.p-btn--secondary-white {
       &::before {


### PR DESCRIPTION
### What this PR does
This PR fixes btn-secondary/textColor not loading loading correctly.

**After (before it was just showing a white screen)**
<img width="302" alt="Screenshot 2024-04-10 at 12 18 21" src="https://github.com/getPopsure/dirty-swan/assets/4015038/bf20b495-57f2-41f0-b7b7-83a5bed42da7">


### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
