### PR TITLE
refactor(info-card): Replace children wrapper p with div

### DIFF
--- a/src/lib/components/cards/infoCard/index.tsx
+++ b/src/lib/components/cards/infoCard/index.tsx
@@ -43,7 +43,7 @@ export const InfoCard = ({
         />
       )}
       <div className="p-h4 ta-center mt64">{title}</div>
-      <p className="p-p mt16 tc-grey-600">{children}</p>
+      <div className="p-p mt16 tc-grey-600">{children}</div>
     </div>
   </div>
 );


### PR DESCRIPTION
### What this PR does
This PR replaces the children wrapper p with a div to avoid the nesting elements error.

### How to test?
Run storybook and check `InfoCard` story. There should be no visible changes.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
