### PR TITLE
fix(TabInfoButton): [EMU-7334] Increase contrast

### DIFF
--- a/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
@@ -1,3 +1,4 @@
+import Info from '../../../icon/icons/Info';
 import styles from './style.module.scss';
 
 const TableInfoButton = ({
@@ -7,39 +8,13 @@ const TableInfoButton = ({
   onClick: () => void;
   className?: string;
 }) => (
-  <span
-    role="button"
+  <button
     className={`p-btn--secondary ${styles.button} ${className}`}
+    type="button"
     onClick={onClick}
-    onKeyDown={(e) => {
-      e.stopPropagation();
-
-      if (e.key === 'Enter' || e.key === " ") {
-        onClick();
-      }
-    }}
-    tabIndex={0}
   >
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M10 2.66667C5.94991 2.66667 2.66667 5.94991 2.66667 10C2.66667 14.0501 5.94991 17.3333 10 17.3333C14.0501 17.3333 17.3333 14.0501 17.3333 10C17.3333 5.94991 14.0501 2.66667 10 2.66667ZM0.666667 10C0.666667 4.84534 4.84534 0.666667 10 0.666667C15.1547 0.666667 19.3333 4.84534 19.3333 10C19.3333 15.1547 15.1547 19.3333 10 19.3333C4.84534 19.3333 0.666667 15.1547 0.666667 10Z"
-      />
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M10 9C10.5523 9 11 9.44772 11 10V13.3333C11 13.8856 10.5523 14.3333 10 14.3333C9.44772 14.3333 9 13.8856 9 13.3333V10C9 9.44772 9.44772 9 10 9Z"
-      />
-      <path d="M10.8333 6.66667C10.8333 7.1269 10.4602 7.5 10 7.5C9.53976 7.5 9.16667 7.1269 9.16667 6.66667C9.16667 6.20643 9.53976 5.83333 10 5.83333C10.4602 5.83333 10.8333 6.20643 10.8333 6.66667Z" />
-    </svg>
-  </span>
+    <Info size={20} />
+  </button>
 );
 
 export default TableInfoButton;

--- a/src/lib/components/comparisonTable/components/TableInfoButton/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/style.module.scss
@@ -25,7 +25,7 @@
   }
 
   svg {
-    fill: $ds-primary-100;
+    fill: $ds-grey-400;
     transition: all 0.3s ease;
   }
 

--- a/src/lib/components/comparisonTable/components/TableInfoButton/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/style.module.scss
@@ -20,12 +20,16 @@
     background-color: $ds-primary-50;
 
     svg {
-      fill: $ds-primary-300;
+      path {
+        fill: $ds-primary-300;
+      }
     }
   }
 
   svg {
-    fill: $ds-grey-400;
+    path {
+      fill: $ds-grey-400;
+    }
     transition: all 0.3s ease;
   }
 


### PR DESCRIPTION
### What this PR does

This PR increases the contrast ratio between TabInfoButton and background as user testing showed that it's really hard to see.

#### Before

<img width="45" alt="image" src="https://github.com/getPopsure/dirty-swan/assets/13664983/a7a9c746-4c1b-464e-9e88-68761a7eb35e">

#### After

<img width="36" alt="image" src="https://github.com/getPopsure/dirty-swan/assets/13664983/6c8c0a6b-7c4c-4b82-9467-9bae03b5b8db">


### Why is this needed?

Solves:
EMU-7334

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [xw] Edge
