### PR TITLE
refactor(input): [SIDE-134] Implement label inside input

### DIFF
--- a/src/lib/components/input/iban/index.tsx
+++ b/src/lib/components/input/iban/index.tsx
@@ -12,7 +12,7 @@ const IbanInput = ({
 } & Omit<InputProps, 'onChange' | 'value' | 'ref'>) => (
   <Input
     value={formatIban(value)}
-    onChange={(e) => onChange(formatIban(e.target.value))}
+    onChange={(e) => onChange?.(formatIban(e.target.value))}
     {...props}
   />
 );

--- a/src/lib/components/input/index.tsx
+++ b/src/lib/components/input/index.tsx
@@ -7,11 +7,12 @@ import styles from './style.module.scss';
 // Something weird is going on with enterKeyHint that makes it a required field under certain circumstances. The & Omit<…> and & Pick<…> is a hacky way to go around that.
 export type InputProps =  Omit<JSX.IntrinsicElements['input'], 'enterKeyHint'> &
  Partial<Pick<JSX.IntrinsicElements['input'], 'enterKeyHint'>> & {
-  error?: string;
+  error?: string | boolean;
   prefix?: string;
   label?: string;
   id?: string;
   hideLabel?: boolean;
+  labelInsideInput?: boolean;
 };
 
 export const Input = React.forwardRef(
@@ -25,14 +26,16 @@ export const Input = React.forwardRef(
       error,
       disabled,
       hideLabel = false,
+      labelInsideInput = false,
       ...props
     }: InputProps,
     ref?: React.ForwardedRef<HTMLInputElement>
   ) => {
     const [uniqueId] = useState(id ?? generateId());
+
     return (
       <div className={`${styles.container} ${className ?? ''}`}>
-        {label && (
+        {label && !labelInsideInput && (
           <label
             htmlFor={uniqueId}
             className={classnames('p-p', styles.label, {
@@ -51,12 +54,15 @@ export const Input = React.forwardRef(
             ref={ref}
             className={classnames(
               error ? 'p-input--error' : 'p-input',
-              !label && placeholder && placeholder.length > 0
+              (!label || labelInsideInput) && placeholder && placeholder.length > 0
                 ? styles.input
                 : styles['input--no-placeholder'],
-              { [styles['input--with-prefix']]: prefix }
+              {
+                [styles['input--with-prefix']]: prefix, 
+                [styles['input--with-inside-label']]: labelInsideInput
+              }
             )}
-            placeholder={label ? placeholder : ' '}
+            placeholder={label || labelInsideInput ? placeholder : ' '}
             disabled={disabled}
             {...props}
           />
@@ -71,7 +77,7 @@ export const Input = React.forwardRef(
               {prefix}
             </span>
           )}
-          {!label && (
+          {(!label || labelInsideInput) && (
             <label
               htmlFor={uniqueId}
               className={classnames(
@@ -80,7 +86,7 @@ export const Input = React.forwardRef(
                 { [styles['placeholder--with-error']]: error }
               )}
             >
-              {placeholder}
+              {labelInsideInput ? label : placeholder}
             </label>
           )}
         </div>

--- a/src/lib/components/input/input.stories.tsx
+++ b/src/lib/components/input/input.stories.tsx
@@ -19,6 +19,7 @@ export const InputStory = ({
   value,
   label,
   hideLabel,
+  labelInsideInput,
   prefix,
   error
 }: InputProps) => {
@@ -37,6 +38,7 @@ export const InputStory = ({
       placeholder={placeholder}
       label={label}
       hideLabel={hideLabel}
+      labelInsideInput={labelInsideInput}
       prefix={prefix}
       error={error}
     />

--- a/src/lib/components/input/stories/config.ts
+++ b/src/lib/components/input/stories/config.ts
@@ -20,7 +20,12 @@ const sharedConfig = {
     control: { type: 'text' }
   },
   hideLabel: {
-    description: 'Whether or not a label should be hidden.. This is needed for accessibility purposes and a label should always be provided',
+    description: 'Whether or not a label should be hidden. This is needed for accessibility purposes and a label should always be provided',
+    defaultValue: false,
+    control: { type: 'boolean' }
+  },
+  labelInsideInput: {
+    description: 'Whether or not a label should be visually displayed inside the input borders.',
     defaultValue: false,
     control: { type: 'boolean' }
   },

--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -24,7 +24,8 @@
 }
 
 .input:not(:placeholder-shown) ~ .placeholder,
-.input:focus ~ .placeholder {
+.input:focus ~ .placeholder,
+.input--with-inside-label ~ .placeholder {
   top: 7px;
   left: 16px;
 
@@ -55,6 +56,12 @@
 .input:not(:placeholder-shown) ~ .prefix,
 .input:focus ~ .prefix {
   top: 28px;
+}
+
+.input--with-inside-label ~ .prefix,
+.input--with-inside-label:focus ~ .prefix,
+.input--with-inside-label:not(:placeholder-shown) ~ .prefix {
+  top: 29px;
 }
 
 .input {


### PR DESCRIPTION
### What this PR does
This PR implements the `labelInsideInput` prop that allows the following input styles:

<img width="494" alt="Screenshot 2024-05-16 at 08 48 31" src="https://github.com/getPopsure/dirty-swan/assets/4015038/08324c89-5da6-4051-abd2-e67fd4b4f9d9">

![Screenshot 2024-05-16 at 08 36 53](https://github.com/getPopsure/dirty-swan/assets/4015038/63a68676-6a0a-44ca-bf74-5ebe55e3b415)

Solves:
SIDE-134

### How to test?
Visit [Input story](http://localhost:9009/?path=/docs/jsx-inputs-input--input-story) and toggle `labelInsideInput` prop to true.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
