### PR TITLE
refactor(date-selector): DateSelector component updates

### DIFF
--- a/src/lib/components/dateSelector/components/Calendar.tsx
+++ b/src/lib/components/dateSelector/components/Calendar.tsx
@@ -74,6 +74,7 @@ export const Calendar = ({
         hideLabel
         variant='textColor'
         leftIcon={<CalendarIcon />}
+        type="button"
       >
         Select date
       </Button>
@@ -86,6 +87,10 @@ export const Calendar = ({
           toMonth={dateCalendarToMonth}
           selectedDays={selectedDateInDateType}
           onDayClick={(date: Date) => {
+            if (!dayjs(date).isValid()) {
+              return;
+            }
+
             if (
               dayjs(date).isAfter(dateCalendarFromMonth) ||
               dayjs(date).isBefore(dateCalendarToMonth)

--- a/src/lib/components/dateSelector/index.test.tsx
+++ b/src/lib/components/dateSelector/index.test.tsx
@@ -16,97 +16,97 @@ const setup = (date?: string, onChange: (date: string) => void = () => {}) => {
 describe('DateSelector component', () => {
   it('should show the value inside the inputs', () => {
     const date = '2024-01-01';
-    const { getByTestId } = setup(date);
+    const { getByLabelText } = setup(date);
 
-    expect(getByTestId('date-selector-day')).toHaveValue('1');
-    expect(getByTestId('date-selector-month')).toHaveValue('1');
-    expect(getByTestId('date-selector-year')).toHaveValue('2024');
+    expect(getByLabelText('Day')).toHaveValue('1');
+    expect(getByLabelText('Month')).toHaveValue('1');
+    expect(getByLabelText('Year')).toHaveValue('2024');
   });
 
   it('should call onChange with the value changed', async () => {
     const callback = jest.fn();
-    const { getByTestId, user } = setup(undefined, callback);
+    const { getByLabelText, user } = setup(undefined, callback);
 
-    await user.type(getByTestId('date-selector-day'), '5');
-    await user.type(getByTestId('date-selector-month'), '7');
-    await user.type(getByTestId('date-selector-year'), '2023');
+    await user.type(getByLabelText('Day'), '5');
+    await user.type(getByLabelText('Month'), '7');
+    await user.type(getByLabelText('Year'), '2023');
 
-    expect(getByTestId('date-selector-day')).toHaveValue('5');
-    expect(getByTestId('date-selector-month')).toHaveValue('7');
-    expect(getByTestId('date-selector-year')).toHaveValue('2023');
+    expect(getByLabelText('Day')).toHaveValue('5');
+    expect(getByLabelText('Month')).toHaveValue('7');
+    expect(getByLabelText('Year')).toHaveValue('2023');
     expect(callback).toHaveBeenCalledWith('2023-07-05');
   });
 
   it('should call onChange with the value changed with initial value', async () => {
     const callback = jest.fn();
     const date = '2024-01-01';
-    const { getByTestId, user } = setup(date, callback);
+    const { getByLabelText, user } = setup(date, callback);
 
-    await user.type(getByTestId('date-selector-day'), '{backspace}3');
-    await user.type(getByTestId('date-selector-month'), '{backspace}7');
-    await user.type(getByTestId('date-selector-year'), '{backspace}3');
+    await user.type(getByLabelText('Day'), '{backspace}3');
+    await user.type(getByLabelText('Month'), '{backspace}7');
+    await user.type(getByLabelText('Year'), '{backspace}3');
 
-    expect(getByTestId('date-selector-day')).toHaveValue('3');
-    expect(getByTestId('date-selector-month')).toHaveValue('7');
-    expect(getByTestId('date-selector-year')).toHaveValue('2023');
+    expect(getByLabelText('Day')).toHaveValue('3');
+    expect(getByLabelText('Month')).toHaveValue('7');
+    expect(getByLabelText('Year')).toHaveValue('2023');
     expect(callback).toHaveBeenCalledWith('2023-07-03');
   });
 
   it('should call onChange empty when invalid date', async () => {
     const callback = jest.fn();
-    const { getByTestId, user } = setup(undefined, callback);
+    const { getByLabelText, user } = setup(undefined, callback);
 
-    await user.type(getByTestId('date-selector-day'), '5');
+    await user.type(getByLabelText('Day'), '5');
 
-    expect(getByTestId('date-selector-day')).toHaveValue('5');
+    expect(getByLabelText('Day')).toHaveValue('5');
     expect(callback).toHaveBeenCalledWith('');
   });
 
   it('should call onChange empty when year out of boundaries', async () => {
     const callback = jest.fn();
     const date = '2024-01-01';
-    const { getByTestId, user } = setup(date, callback);
+    const { getByLabelText, user } = setup(date, callback);
 
-    await user.type(getByTestId('date-selector-year'), '{backspace}{backspace}30');
+    await user.type(getByLabelText('Year'), '{backspace}{backspace}30');
 
-    expect(getByTestId('date-selector-year')).toHaveValue('2030');
+    expect(getByLabelText('Year')).toHaveValue('2030');
     expect(callback).toHaveBeenCalledWith('');
   });
 
   it('should call onChange when year in boundaries after being out of boundaries', async () => {
     const callback = jest.fn();
     const date = '2030-01-01';
-    const { getByTestId, user } = setup(date, callback);
+    const { getByLabelText, user } = setup(date, callback);
 
-    await user.type(getByTestId('date-selector-year'), '{backspace}{backspace}23');
+    await user.type(getByLabelText('Year'), '{backspace}{backspace}23');
 
-    expect(getByTestId('date-selector-year')).toHaveValue('2023');
+    expect(getByLabelText('Year')).toHaveValue('2023');
     expect(callback).toHaveBeenCalledWith('2023-01-01');
   });
 
   it('should call onChange with the value changed', async () => {
     const callback = jest.fn();
     const date = '2024-01-01';
-    const { getByTestId, user } = setup(date, callback);
+    const { getByLabelText, user } = setup(date, callback);
 
-    await user.type(getByTestId('date-selector-day'), '{backspace}3');
-    await user.type(getByTestId('date-selector-month'), '{backspace}7');
-    await user.type(getByTestId('date-selector-year'), '{backspace}3');
+    await user.type(getByLabelText('Day'), '{backspace}3');
+    await user.type(getByLabelText('Month'), '{backspace}7');
+    await user.type(getByLabelText('Year'), '{backspace}3');
 
-    expect(getByTestId('date-selector-day')).toHaveValue('3');
-    expect(getByTestId('date-selector-month')).toHaveValue('7');
+    expect(getByLabelText('Day')).toHaveValue('3');
+    expect(getByLabelText('Month')).toHaveValue('7');
     expect(callback).toHaveBeenCalledWith('2023-07-03');
   });
 
   it('should navigate inputs from day to month when day is over 3', async () => {
     const callback = jest.fn();
     const date = '2024-01-01';
-    const { getByTestId, user } = setup(date, callback);
+    const { getByLabelText, user } = setup(date, callback);
 
-    await user.type(getByTestId('date-selector-day'), '{backspace}45');
+    await user.type(getByLabelText('Day'), '{backspace}45');
 
-    expect(getByTestId('date-selector-day')).toHaveValue('4');
-    expect(getByTestId('date-selector-month')).toHaveValue('5');
+    expect(getByLabelText('Day')).toHaveValue('4');
+    expect(getByLabelText('Month')).toHaveValue('5');
     expect(callback).toHaveBeenCalledWith('2024-05-04');
   });
 
@@ -115,7 +115,7 @@ describe('DateSelector component', () => {
       const callback = jest.fn();
       const date = '2024-01-01';
       const expectedDate = '2024-01-17';
-      const { getByTestId, getByLabelText, user } = setup(date, callback);
+      const { getByLabelText, getByTestId, user } = setup(date, callback);
       const button = getByTestId('calendar-button');
 
       await user.click(button);
@@ -132,7 +132,7 @@ describe('DateSelector component', () => {
     it('should close the calendar when clicking outside', async () => {
       const callback = jest.fn();
       const date = '2024-01-01';
-      const { getByTestId, getByLabelText, user } = setup(date, callback);
+      const { getByLabelText, getByTestId, user } = setup(date, callback);
       const button = getByTestId('calendar-button');
 
       await user.click(button);

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -9,13 +9,20 @@ import {
 } from '../../util/calendarDate';
 
 import styles from './style.module.scss';
-import { Input } from '../input';
+import { Input, InputProps } from '../input';
 import classNames from 'classnames';
 import { Calendar } from './components/Calendar';
 
 dayjs.extend(localeData);
 const COLLECTABLE_DATE_FORMAT = 'YYYY-MM-DD';
 type FormatPlaceholder = 'dayFormat' | 'monthFormat' | 'yearFormat';
+
+interface DateSelectorInputProps extends InputProps {
+  'data-cy': string;
+  'data-testid': string;
+  ref: (el: HTMLInputElement) => void;
+}
+
 export interface DateSelectorProps {
   value?: string;
   onChange: (date: string) => void;
@@ -32,6 +39,7 @@ export interface DateSelectorProps {
     error?: string;
   };
   firstDayOfWeek?: number;
+  inputProps?: (key: keyof CalendarDate) => Partial<DateSelectorInputProps>;
 }
 
 const defaultPlaceholders: DateSelectorProps["placeholders"] = {
@@ -83,6 +91,7 @@ export const DateSelector = ({
   displayCalendar,
   dayjsLocale,
   firstDayOfWeek = 0,
+  inputProps,
 }: DateSelectorProps) => {
   const placeholders = {
     ...defaultPlaceholders,
@@ -191,13 +200,13 @@ export const DateSelector = ({
     }
   }
 
-  const getInputProps = (key: keyof CalendarDate, index: number) => ({
+  const getInputProps = (key: keyof CalendarDate, index: number): DateSelectorInputProps => ({
     'data-cy': `date-selector-${key}`,
     'data-testid': `date-selector-${key}`,
     className: styles[`${key}Input`],
     id: key,
     name: key,
-    maxLength: 2,
+    maxLength: key === 'year' ? 4 : 2,
     required: true,
     label: placeholders?.[key],
     placeholder: placeholders?.[`${key}Format` as FormatPlaceholder] ?? "",
@@ -205,10 +214,12 @@ export const DateSelector = ({
     value: internalValue[key] ?? '',
     error: (hasError && [key, 'all'].includes(hasError)) && isDirty,
     type: "text", 
-    ref: (el: HTMLInputElement) => { itemsRef.current[index] = el },
+    inputMode: "numeric",
+    ref: (el: HTMLInputElement) => { itemsRef.current[index] = el }, 
     onKeyUp: (event: KeyboardEvent<HTMLInputElement>) => handleOnKeyUp(event, index),
     onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => handleOnKeyDown(event, index),
     onChange: ({ target }: ChangeEvent<HTMLInputElement>) => handleOnChange(key, target.value),
+    ...inputProps?.(key) || {},
   });
 
   return (
@@ -216,22 +227,12 @@ export const DateSelector = ({
       <div className="d-flex ai-center">
         <div className={classNames(styles.container, "d-flex gap8")}>
           <div className={"d-flex gap8 jc-between"}>
-            <Input
-              {...getInputProps('day', 0)}
-              inputMode='numeric'
-            />
+            <Input {...getInputProps('day', 0)} />
 
-            <Input
-              {...getInputProps('month', 1)}
-              inputMode='numeric'
-            />
+            <Input {...getInputProps('month', 1)} />
           </div>
 
-          <Input
-            {...getInputProps('year', 2)}
-            inputMode='numeric'
-            maxLength={4}
-          />
+          <Input {...getInputProps('year', 2)} />
         </div>
 
         <Calendar


### PR DESCRIPTION
### What this PR does
DateSelector component updates:
- Moves tests to use `getByLabelText` instead of `getByTestId` (but still keeps `data-testid` as it can be useful for app testing)
- Adds additional validation to calendar component on clicking
- Allows configuring input props


### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
