### PR TITLE
feat(CoverageTable): [EPIC-137] Improve CoverageTable

### DIFF
--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
@@ -2,11 +2,8 @@
 
 .container {
   width: var(--growContent, min-content);
-  margin: 0 auto;
-}
-
-.container + .container {
-  margin-top: 8px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .chevron {

--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
@@ -2,6 +2,7 @@
 
 .container {
   width: var(--growContent, min-content);
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }

--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
@@ -47,7 +47,7 @@ export const AccordionItem = ({
   };
 
   return (
-    <div className={`d-flex fd-column ${className} ${styles.container}`}>
+    <section className={`d-flex fd-column ${styles.container} ${className}`}>
       <button
         className={`d-flex ai-center jc-between ${styles.headerButton} ${headerClassName}`}
         onClick={handleClick}
@@ -69,6 +69,6 @@ export const AccordionItem = ({
       <AnimateHeight duration={300} height={isOpen ? 'auto' : 0.1}>
         {children}
       </AnimateHeight>
-    </div>
+    </section>
   );
 };

--- a/src/lib/components/comparisonTable/components/Row/index.tsx
+++ b/src/lib/components/comparisonTable/components/Row/index.tsx
@@ -2,33 +2,36 @@ import React from 'react';
 
 import type { Cell } from '../../index';
 import styles from './style.module.scss';
+import classNames from 'classnames';
 
 interface RowProps<T> {
   cell: Cell<T>;
   data: Array<T>;
   isRowHeader?: boolean;
   rowId: string;
+  cellClassName?: string;
 }
 
 const Row = <T extends { id: number }>(props: RowProps<T>) => {
-  const { cell, data, isRowHeader, rowId } = props;
+  const { cell, data, isRowHeader, rowId, cellClassName } = props;
 
   return (
     <div
       key={rowId}
-      className={`
-        d-flex
-        w-100
-        ${isRowHeader ? styles.header : ''}
-      `}
+      className={classNames('d-flex w-100', {
+        [styles.header]: isRowHeader,
+      })}
     >
       <h4
-        className={`
-          ${styles.cell}
-          ${styles.sticky}
-          ${isRowHeader ? `p-h2 p--serif ${styles.title}` : ''}
-          ${typeof cell.key === 'undefined' ? styles.addon : ''}
-        `}
+        className={classNames(
+          styles.cell,
+          styles.sticky,
+          {
+            [`p-h2 p--serif ${styles.title}`]: isRowHeader,
+            [styles.addon]: typeof cell.key === 'undefined',
+          },
+          cellClassName
+        )}
       >
         {cell.label}
       </h4>
@@ -44,7 +47,7 @@ const Row = <T extends { id: number }>(props: RowProps<T>) => {
 
           return (
             <div
-              className={`ta-center ${styles.cell}`}
+              className={classNames('ta-center', styles.cell, cellClassName)}
               key={`${rowId}-${item.id}`}
             >
               {

--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -31,10 +31,10 @@ $cell-min-width: var(--cellWidth, 211px); // 195 + 16px
 
   line-height: 24px;
 
-  padding: 16px 0;
+  padding: 16px 8px;
 
   &:first-child {
-    padding: 16px 0 16px 16px;
+    padding: 16px 8px 16px 16px;
   }
 
   color: $ds-grey-900;
@@ -60,10 +60,10 @@ $cell-min-width: var(--cellWidth, 211px); // 195 + 16px
     flex: 1 0 $cell-min-width;
     width: $cell-min-width;
     &:first-child {
-      padding: 24px 0 24px 24px;
+      padding: 24px 8px 24px 24px;
     }
 
-    padding: 24px 0;
+    padding: 24px 8px;
   }
 }
 

--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -1,7 +1,7 @@
 @use "../../../../scss/public/colors" as *;
 @use "../../../../scss/public/grid" as *;
 
-$cell-min-width: var(--cellWidth, 256px);
+$cell-min-width: var(--cellWidth, 211px); // 195 + 16px
 
 .header {
   position: relative;
@@ -31,7 +31,11 @@ $cell-min-width: var(--cellWidth, 256px);
 
   line-height: 24px;
 
-  padding: 16px;
+  padding: 16px 0;
+
+  &:first-child {
+    padding: 16px 0 16px 16px;
+  }
 
   color: $ds-grey-900;
 
@@ -55,19 +59,23 @@ $cell-min-width: var(--cellWidth, 256px);
   @include p-size-tablet {
     flex: 1 0 $cell-min-width;
     width: $cell-min-width;
-    padding: 24px;
+    &:first-child {
+      padding: 24px 0 24px 24px;
+    }
+
+    padding: 24px 0;
 
     &:last-child {
-      padding: 24px 8px 24px 24px;
+      padding: 24px 24px 24px 0;
     }
   }
 }
 
 h4.cell {
-  // Set the max width of the first column to the supplied firstColumnWidth (or 288px if not specified) but only
+  // Set the max width of the first column to the supplied firstColumnWidth (or 212px if not specified) but only
   // if this value does not exceed half of the table's width.
   // This is to ensure that the first column is at most as wide as half the table, which will be the case on mobile where only the first column and one other are shown.
-  max-width: min(var(--firstColumnWidth, 288px), calc(var(--tableWidth) / 2));
+  max-width: min(var(--firstColumnWidth, 212px), calc(var(--tableWidth) / 2));
 }
 
 .title {

--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -64,10 +64,6 @@ $cell-min-width: var(--cellWidth, 211px); // 195 + 16px
     }
 
     padding: 24px 0;
-
-    &:last-child {
-      padding: 24px 24px 24px 0;
-    }
   }
 }
 
@@ -124,7 +120,7 @@ h4.cell {
 h4.addon {
   border-right: none;
   max-width: calc(100vw - 64px);
-  width: 100vw;
+  width: 100&;
 
   @include p-size-desktop {
     max-width: 976px;

--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -33,7 +33,7 @@ $cell-min-width: var(--cellWidth, 256px);
 
   padding: 16px;
 
-  color: $ds-grey-700;
+  color: $ds-grey-900;
 
   width: 50vw;
   max-width: calc(var(--tableWidth) / 2);

--- a/src/lib/components/comparisonTable/components/TableArrows/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableArrows/index.tsx
@@ -27,6 +27,7 @@ const TableArrows = (props: TableArrowsProps) => {
             [styles.active]: active.left,
           }
         )}
+        disabled={!active.left}
       >
         <ArrowIcon />
       </button>
@@ -40,6 +41,7 @@ const TableArrows = (props: TableArrowsProps) => {
             [styles.active]: active.right,
           }
         )}
+        disabled={!active.right}
       >
         <ArrowIcon />
       </button>

--- a/src/lib/components/comparisonTable/components/TableArrows/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableArrows/style.module.scss
@@ -42,6 +42,12 @@
     background-color: $ds-grey-200;
     cursor: not-allowed;
   }
+  &:disabled {
+    opacity: 1;
+    &:hover {
+      background-color: $ds-grey-200;
+    }
+  }
 }
 
 .active {

--- a/src/lib/components/comparisonTable/components/TableButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableButton/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import styles from './style.module.scss';
+import TableInfoButton from '../TableInfoButton';
 
 interface Props {
   children: ReactNode;
@@ -12,15 +13,14 @@ const TableButton: React.FC<Props> = ({
   onClick,
   className = '',
 }) => (
-  <button
-    className={`${styles.button} ${className}`}
-    data-testid="ds-table-button"
-    onClick={onClick}
-  >
-    <span>
-      {children}
-    </span>
-  </button>
+  <div className={styles.wrapper}>
+    {children}
+    <TableInfoButton
+      className={`${styles.infoButton} ${className}`}
+      data-testid="ds-table-button"
+      onClick={onClick}
+    />
+  </div>
 );
 
 export default TableButton;

--- a/src/lib/components/comparisonTable/components/TableButton/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableButton/style.module.scss
@@ -1,26 +1,9 @@
-@use "../../../../scss/public/colors" as *;
+.wrapper {
+  position: relative;
+}
 
-.button {
-  background-color: transparent;
-  color: $ds-grey-700;
-  cursor: pointer;
-  margin: 2px 0;
-  padding: 2px;
-  transition: color 0.3s ease;
-
-  span {
-    border-bottom: 2px dashed $ds-grey-600;
-    display: inline;
-    transition: border-color 0.3s ease;
-  }
-
-  &:hover,
-  &:focus {
-    color: $ds-primary-500;
-    outline-color: $ds-primary-500;
-    
-    span {
-      border-color: $ds-primary-500;
-    }
-  }
+.infoButton {
+  position: absolute;
+  right: -32px;
+  top: 0;
 }

--- a/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableInfoButton/index.tsx
@@ -11,6 +11,7 @@ const TableInfoButton = ({
   <button
     className={`p-btn--secondary ${styles.button} ${className}`}
     type="button"
+    data-testid="ds-table-button"
     onClick={onClick}
   >
     <Info size={20} />

--- a/src/lib/components/comparisonTable/components/TableRowHeader/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableRowHeader/index.tsx
@@ -1,5 +1,6 @@
-import TableButton from '../TableButton';
+import classNames from 'classnames';
 import styles from './style.module.scss';
+import TableInfoButton from '../TableInfoButton';
 
 interface TableRowHeaderProps {
   label: string;
@@ -8,18 +9,24 @@ interface TableRowHeaderProps {
   onClickInfo?: () => void;
 }
 
-const TableRowHeader = ({ icon, label, subtitle, onClickInfo }: TableRowHeaderProps) => (
+const TableRowHeader = ({
+  icon,
+  label,
+  subtitle,
+  onClickInfo,
+}: TableRowHeaderProps) => (
   <div className="d-flex">
     {icon && <span className={`mr8 ${styles.icon}`}>{icon}</span>}
     <div>
       <p className="p-p d-inline">
-        {!onClickInfo ? (
-          <span>{label}</span>
-        ) : (
-          <TableButton className="mr8 ta-left" onClick={onClickInfo}>
-            {label}
-          </TableButton>
-        )}
+        <span
+          className={classNames({
+            mr8: onClickInfo,
+          })}
+        >
+          {label}
+        </span>
+        {onClickInfo && <TableInfoButton onClick={onClickInfo} />}
       </p>
       {subtitle && <p className="p-p--small tc-grey-500">{subtitle}</p>}
     </div>

--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -4,7 +4,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowValues } from '../components/TableArrows';
 import generateId from '../../../util/generateId';
 
-export const useComparisonTable = () => {
+export const useComparisonTable = ({
+  onSelectionChanged,
+}: {
+  onSelectionChanged?: (selectedIndex: number) => void;
+}) => {
   const [showMore, setShowMore] = useState<boolean>(false);
   const [headerWidth, setHeaderWidth] = useState(1400);
   const [headerId, setHeaderId] = useState('');
@@ -137,6 +141,11 @@ export const useComparisonTable = () => {
   useEffect(() => {
     setHeaderId(generateId());
   }, []);
+
+  useEffect(() => {
+    onSelectionChanged?.(selectedTabIndex);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTabIndex]);
 
   return {
     headerWidth,

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -27,18 +27,20 @@ The Comparison Table component provides an easy way to compare vast amounts of i
 
 ## Arguments
 
-| attribute             | unit                | description                                                | default value | required |
-| --------------------- | ------------------- | ---------------------------------------------------------- | ------------- | -------- |
-| headers               | [Header[]](#header) | The structure of the table                                 | n/a           | true     |
-| data                  | array               | The title text that needs to be displayed                  | n/a           | true     |
-| hideDetails           | boolean             | Hide table groups that do not have the `default` attribute | false         | false    |
-| hideScrollBars        | boolean             | Hide scroll bars                                           | false         | false    |
-| hideScrollBarsMobile  | boolean             | Hide scroll bars on mobile only                            | false         | false    |
-| collapsibleSections   | boolean             | Make table groups with a label collapsible                 | false         | false    |
-| cellWidth             | number              | Width of a table content cell                              | 256px         | false    |
-| firstColumnWidth      | number              | Width of the first column of the table                     | 288px         | false    |
-| stickyHeaderTopOffset | number              | Y-offset of the sticky header row                          | 0px           | false    |
-| growContent           | boolean             | Makes the content area grow to fill the available space    | false         | false    |
+| attribute             | unit                | description                                                | default value  | required |
+| --------------------- | ------------------- | ---------------------------------------------------------- | -------------- | -------- |
+| headers               | [Header[]](#header) | The structure of the table                                 | n/a            | true     |
+| data                  | array               | The title text that needs to be displayed                  | n/a            | true     |
+| hideDetails           | boolean             | Hide table groups that do not have the `default` attribute | false          | false    |
+| hideDetailsCaption    | string              | Caption of the button to hide the details                  | 'Hide details' | false    |
+| showDetailsCaption    | string              | Caption of the button to show the details                  | 'Show details' | false    |
+| hideScrollBars        | boolean             | Hide scroll bars                                           | false          | false    |
+| hideScrollBarsMobile  | boolean             | Hide scroll bars on mobile only                            | false          | false    |
+| collapsibleSections   | boolean             | Make table groups with a label collapsible                 | false          | false    |
+| cellWidth             | number              | Width of a table content cell                              | 256px          | false    |
+| firstColumnWidth      | number              | Width of the first column of the table                     | 288px          | false    |
+| stickyHeaderTopOffset | number              | Y-offset of the sticky header row                          | 0px            | false    |
+| growContent           | boolean             | Makes the content area grow to fill the available space    | false          | false    |
 
 ## Types
 

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -37,8 +37,8 @@ The Comparison Table component provides an easy way to compare vast amounts of i
 | hideScrollBars        | boolean                                   | Hide scroll bars                                                    | false          | false    |
 | hideScrollBarsMobile  | boolean                                   | Hide scroll bars on mobile only                                     | false          | false    |
 | collapsibleSections   | boolean                                   | Make table groups with a label collapsible                          | false          | false    |
-| cellWidth             | number                                    | Width of a table content cell                                       | 256px          | false    |
-| firstColumnWidth      | number                                    | Width of the first column of the table                              | 288px          | false    |
+| cellWidth             | number                                    | Width of a table content cell                                       | 211px          | false    |
+| firstColumnWidth      | number                                    | Width of the first column of the table                              | 212px          | false    |
 | stickyHeaderTopOffset | number                                    | Y-offset of the sticky header row                                   | 0px            | false    |
 | growContent           | boolean                                   | Makes the content area grow to fill the available space             | false          | false    |
 | onSelectionChanged    | (number) => void                          | Callback to be called when the selected tab index changes on mobile | n/a            | false    |

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -33,6 +33,7 @@ The Comparison Table component provides an easy way to compare vast amounts of i
 | data                  | array               | The title text that needs to be displayed                  | n/a           | true     |
 | hideDetails           | boolean             | Hide table groups that do not have the `default` attribute | false         | false    |
 | hideScrollBars        | boolean             | Hide scroll bars                                           | false         | false    |
+| hideScrollBarsMobile  | boolean             | Hide scroll bars on mobile only                            | false         | false    |
 | collapsibleSections   | boolean             | Make table groups with a label collapsible                 | false         | false    |
 | cellWidth             | number              | Width of a table content cell                              | 256px         | false    |
 | firstColumnWidth      | number              | Width of the first column of the table                     | 288px         | false    |
@@ -76,9 +77,7 @@ export const ComparisonTableWithData = () => {
           key: 'name',
           label: 'Films',
           render: (value) => (
-            <TableButton onClick={() => {}}>
-              {value}
-            </TableButton>
+            <TableButton onClick={() => {}}>{value}</TableButton>
           ),
         },
         {
@@ -91,15 +90,18 @@ export const ComparisonTableWithData = () => {
           key: 'imdb',
           label: 'IMDB rating',
           render: (value) => (
-            <TableButton onClick={() => {}}>
-              {value}
-            </TableButton>
+            <TableButton onClick={() => {}}>{value}</TableButton>
           ),
         },
         {
           id: 3,
           key: 'rating',
-          label: <TableRowHeader label="Our rating of movies found online on IMDB lists" onClickInfo={() => {}} />,
+          label: (
+            <TableRowHeader
+              label="Our rating of movies found online on IMDB lists"
+              onClickInfo={() => {}}
+            />
+          ),
           render: (value) => (
             <TableButton onClick={() => {}}>
               <TableRating type="star" rating={value} />
@@ -322,9 +324,7 @@ export const ComparisonTableWithData = () => {
           key: 'name',
           label: 'Films',
           render: (value) => (
-            <TableButton onClick={() => {}}>
-              {value}
-            </TableButton>
+            <TableButton onClick={() => {}}>{value}</TableButton>
           ),
         },
         {
@@ -337,15 +337,18 @@ export const ComparisonTableWithData = () => {
           key: 'imdb',
           label: 'IMDB rating',
           render: (value) => (
-            <TableButton onClick={() => {}}>
-              {value}
-            </TableButton>
+            <TableButton onClick={() => {}}>{value}</TableButton>
           ),
         },
         {
           id: 3,
           key: 'rating',
-          label: <TableRowHeader label="Our rating of movies found online on IMDB lists" onClickInfo={() => {}} />,
+          label: (
+            <TableRowHeader
+              label="Our rating of movies found online on IMDB lists"
+              onClickInfo={() => {}}
+            />
+          ),
           render: (value) => (
             <TableButton onClick={() => {}}>
               <TableRating type="star" rating={value} />

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -70,12 +70,17 @@ export interface Header<T> {
 
 ### ClassNameOverrides
 
+Note that if the component uses custom css such as media queries etc. for certain properties, the override must also use
+custom css (and not just Dirty Swan classes) or else it won't to able override the existing rules.
+
 ```typescript
 export interface ClassNameOverrides {
   header?: string;
   container?: string;
   cell?: string;
   headerCell?: string;
+  collapsibleSection?: string;
+  section?: string;
 }
 ```
 

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -27,21 +27,22 @@ The Comparison Table component provides an easy way to compare vast amounts of i
 
 ## Arguments
 
-| attribute             | unit                | description                                                         | default value  | required |
-| --------------------- | ------------------- | ------------------------------------------------------------------- | -------------- | -------- |
-| headers               | [Header[]](#header) | The structure of the table                                          | n/a            | true     |
-| data                  | array               | The title text that needs to be displayed                           | n/a            | true     |
-| hideDetails           | boolean             | Hide table groups that do not have the `default` attribute          | false          | false    |
-| hideDetailsCaption    | string              | Caption of the button to hide the details                           | 'Hide details' | false    |
-| showDetailsCaption    | string              | Caption of the button to show the details                           | 'Show details' | false    |
-| hideScrollBars        | boolean             | Hide scroll bars                                                    | false          | false    |
-| hideScrollBarsMobile  | boolean             | Hide scroll bars on mobile only                                     | false          | false    |
-| collapsibleSections   | boolean             | Make table groups with a label collapsible                          | false          | false    |
-| cellWidth             | number              | Width of a table content cell                                       | 256px          | false    |
-| firstColumnWidth      | number              | Width of the first column of the table                              | 288px          | false    |
-| stickyHeaderTopOffset | number              | Y-offset of the sticky header row                                   | 0px            | false    |
-| growContent           | boolean             | Makes the content area grow to fill the available space             | false          | false    |
-| onSelectionChanged    | (number) => void    | Callback to be called when the selected tab index changes on mobile | n/a            | false    |
+| attribute             | unit                                      | description                                                         | default value  | required |
+| --------------------- | ----------------------------------------- | ------------------------------------------------------------------- | -------------- | -------- |
+| headers               | [Header[]](#header)                       | The structure of the table                                          | n/a            | true     |
+| data                  | array                                     | The title text that needs to be displayed                           | n/a            | true     |
+| hideDetails           | boolean                                   | Hide table groups that do not have the `default` attribute          | false          | false    |
+| hideDetailsCaption    | string                                    | Caption of the button to hide the details                           | 'Hide details' | false    |
+| showDetailsCaption    | string                                    | Caption of the button to show the details                           | 'Show details' | false    |
+| hideScrollBars        | boolean                                   | Hide scroll bars                                                    | false          | false    |
+| hideScrollBarsMobile  | boolean                                   | Hide scroll bars on mobile only                                     | false          | false    |
+| collapsibleSections   | boolean                                   | Make table groups with a label collapsible                          | false          | false    |
+| cellWidth             | number                                    | Width of a table content cell                                       | 256px          | false    |
+| firstColumnWidth      | number                                    | Width of the first column of the table                              | 288px          | false    |
+| stickyHeaderTopOffset | number                                    | Y-offset of the sticky header row                                   | 0px            | false    |
+| growContent           | boolean                                   | Makes the content area grow to fill the available space             | false          | false    |
+| onSelectionChanged    | (number) => void                          | Callback to be called when the selected tab index changes on mobile | n/a            | false    |
+| classNameOverrides    | [ClassNameOverrides](#classnameoverrides) | "className" props to be passed down to various internal components  | n/a            | false    |
 
 ## Types
 
@@ -64,6 +65,17 @@ export interface Header<T> {
   label?: React.ReactNode;
   cells: Array<Cell<T>>;
   default?: boolean;
+}
+```
+
+### ClassNameOverrides
+
+```typescript
+export interface ClassNameOverrides {
+  header?: string;
+  container?: string;
+  cell?: string;
+  headerCell?: string;
 }
 ```
 

--- a/src/lib/components/comparisonTable/index.stories.mdx
+++ b/src/lib/components/comparisonTable/index.stories.mdx
@@ -27,20 +27,21 @@ The Comparison Table component provides an easy way to compare vast amounts of i
 
 ## Arguments
 
-| attribute             | unit                | description                                                | default value  | required |
-| --------------------- | ------------------- | ---------------------------------------------------------- | -------------- | -------- |
-| headers               | [Header[]](#header) | The structure of the table                                 | n/a            | true     |
-| data                  | array               | The title text that needs to be displayed                  | n/a            | true     |
-| hideDetails           | boolean             | Hide table groups that do not have the `default` attribute | false          | false    |
-| hideDetailsCaption    | string              | Caption of the button to hide the details                  | 'Hide details' | false    |
-| showDetailsCaption    | string              | Caption of the button to show the details                  | 'Show details' | false    |
-| hideScrollBars        | boolean             | Hide scroll bars                                           | false          | false    |
-| hideScrollBarsMobile  | boolean             | Hide scroll bars on mobile only                            | false          | false    |
-| collapsibleSections   | boolean             | Make table groups with a label collapsible                 | false          | false    |
-| cellWidth             | number              | Width of a table content cell                              | 256px          | false    |
-| firstColumnWidth      | number              | Width of the first column of the table                     | 288px          | false    |
-| stickyHeaderTopOffset | number              | Y-offset of the sticky header row                          | 0px            | false    |
-| growContent           | boolean             | Makes the content area grow to fill the available space    | false          | false    |
+| attribute             | unit                | description                                                         | default value  | required |
+| --------------------- | ------------------- | ------------------------------------------------------------------- | -------------- | -------- |
+| headers               | [Header[]](#header) | The structure of the table                                          | n/a            | true     |
+| data                  | array               | The title text that needs to be displayed                           | n/a            | true     |
+| hideDetails           | boolean             | Hide table groups that do not have the `default` attribute          | false          | false    |
+| hideDetailsCaption    | string              | Caption of the button to hide the details                           | 'Hide details' | false    |
+| showDetailsCaption    | string              | Caption of the button to show the details                           | 'Show details' | false    |
+| hideScrollBars        | boolean             | Hide scroll bars                                                    | false          | false    |
+| hideScrollBarsMobile  | boolean             | Hide scroll bars on mobile only                                     | false          | false    |
+| collapsibleSections   | boolean             | Make table groups with a label collapsible                          | false          | false    |
+| cellWidth             | number              | Width of a table content cell                                       | 256px          | false    |
+| firstColumnWidth      | number              | Width of the first column of the table                              | 288px          | false    |
+| stickyHeaderTopOffset | number              | Y-offset of the sticky header row                                   | 0px            | false    |
+| growContent           | boolean             | Makes the content area grow to fill the available space             | false          | false    |
+| onSelectionChanged    | (number) => void    | Callback to be called when the selected tab index changes on mobile | n/a            | false    |
 
 ## Types
 

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -48,6 +48,7 @@ export interface ComparisonTableProps<T> {
   data: Array<T>;
   hideDetails?: boolean;
   hideScrollBars?: boolean;
+  hideScrollBarsMobile?: boolean;
   collapsibleSections?: boolean;
   cellWidth?: number;
   firstColumnWidth?: number;
@@ -68,6 +69,7 @@ const ComparisonTable = <T extends { id: number }>(
     hideDetails,
     styles,
     hideScrollBars,
+    hideScrollBarsMobile,
     collapsibleSections,
     cellWidth,
     firstColumnWidth,
@@ -109,6 +111,7 @@ const ComparisonTable = <T extends { id: number }>(
               id={headerId}
               className={classNames(baseStyles.container, {
                 [baseStyles.noScrollBars]: hideScrollBars,
+                [baseStyles.noScrollBarsMobile]: hideScrollBarsMobile,
               })}
             >
               <div className={classNames(baseStyles['overflow-container'])}>

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -56,11 +56,15 @@ export interface ComparisonTableProps<T> {
   firstColumnWidth?: number;
   stickyHeaderTopOffset?: number;
   growContent?: boolean;
-  styles?: {
-    header?: string;
-    container?: string;
-  };
+  classNameOverrides?: ClassNameOverrides;
   onSelectionChanged?: (selectedIndex: number) => void;
+}
+
+export interface ClassNameOverrides {
+  header?: string;
+  container?: string;
+  cell?: string;
+  headerCell?: string;
 }
 
 const ComparisonTable = <T extends { id: number }>(
@@ -72,7 +76,7 @@ const ComparisonTable = <T extends { id: number }>(
     hideDetails,
     hideDetailsCaption = 'Hide details',
     showDetailsCaption = 'Show details',
-    styles,
+    classNameOverrides,
     hideScrollBars,
     hideScrollBarsMobile,
     collapsibleSections,
@@ -111,7 +115,9 @@ const ComparisonTable = <T extends { id: number }>(
   return (
     <ScrollSync onSync={scrollContainerCallbackRef}>
       <div style={cssVariablesStyle}>
-        <div className={classNames(baseStyles.header, styles?.header)}>
+        <div
+          className={classNames(baseStyles.header, classNameOverrides?.header)}
+        >
           <ScrollSyncPane>
             <div
               id={headerId}
@@ -135,6 +141,7 @@ const ComparisonTable = <T extends { id: number }>(
                     cell={headers[0].cells[0]}
                     data={data}
                     isRowHeader
+                    cellClassName={classNameOverrides?.headerCell}
                   />
                 </div>
               </div>
@@ -157,7 +164,13 @@ const ComparisonTable = <T extends { id: number }>(
                   if (index === 0 && headerGroupIndex === 0) return null;
 
                   return (
-                    <Row<T> key={rowId} rowId={rowId} cell={cell} data={data} />
+                    <Row<T>
+                      key={rowId}
+                      rowId={rowId}
+                      cell={cell}
+                      data={data}
+                      cellClassName={classNameOverrides?.cell}
+                    />
                   );
                 });
 
@@ -178,7 +191,7 @@ const ComparisonTable = <T extends { id: number }>(
                           <div
                             className={classNames(
                               baseStyles.container,
-                              styles?.container,
+                              classNameOverrides?.container,
                               {
                                 [baseStyles.noScrollBars]: hideScrollBars,
                               }
@@ -202,7 +215,7 @@ const ComparisonTable = <T extends { id: number }>(
                           <div
                             className={classNames(
                               baseStyles.container,
-                              styles?.container,
+                              classNameOverrides?.container,
                               {
                                 [baseStyles.noScrollBars]: hideScrollBars,
                               }

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -47,6 +47,8 @@ export interface ComparisonTableProps<T> {
   headers: Array<TableHeader<T>>;
   data: Array<T>;
   hideDetails?: boolean;
+  hideDetailsCaption?: string;
+  showDetailsCaption?: string;
   hideScrollBars?: boolean;
   hideScrollBarsMobile?: boolean;
   collapsibleSections?: boolean;
@@ -67,6 +69,8 @@ const ComparisonTable = <T extends { id: number }>(
     headers,
     data,
     hideDetails,
+    hideDetailsCaption = 'Hide details',
+    showDetailsCaption = 'Show details',
     styles,
     hideScrollBars,
     hideScrollBarsMobile,
@@ -246,7 +250,7 @@ const ComparisonTable = <T extends { id: number }>(
                   onClick={toggleMoreRows}
                   type="button"
                 >
-                  {showMore ? 'Hide details' : 'Show details'}
+                  {showMore ? hideDetailsCaption : showDetailsCaption}
                   <Chevron
                     className={showMore ? '' : baseStyles['icon-inverted']}
                   />

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -116,18 +116,18 @@ const ComparisonTable = <T extends { id: number }>(
 
   return (
     <ScrollSync onSync={scrollContainerCallbackRef}>
-      <div style={cssVariablesStyle}>
+      <div
+        style={cssVariablesStyle}
+        className={classNames({
+          [baseStyles.noScrollBars]: hideScrollBars,
+          [baseStyles.noScrollBarsMobile]: hideScrollBarsMobile,
+        })}
+      >
         <div
           className={classNames(baseStyles.header, classNameOverrides?.header)}
         >
           <ScrollSyncPane>
-            <div
-              id={headerId}
-              className={classNames(baseStyles.container, {
-                [baseStyles.noScrollBars]: hideScrollBars,
-                [baseStyles.noScrollBarsMobile]: hideScrollBarsMobile,
-              })}
-            >
+            <div id={headerId} className={classNames(baseStyles.container)}>
               <div className={classNames(baseStyles['overflow-container'])}>
                 <div className={baseStyles['group-container']}>
                   <TableArrows

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -65,6 +65,8 @@ export interface ClassNameOverrides {
   container?: string;
   cell?: string;
   headerCell?: string;
+  collapsibleSection?: string;
+  section?: string;
 }
 
 const ComparisonTable = <T extends { id: number }>(
@@ -180,7 +182,10 @@ const ComparisonTable = <T extends { id: number }>(
                   <Fragment key={idString}>
                     {headerGroup.label && collapsibleSections ? (
                       <AccordionItem
-                        className="mt8"
+                        className={classNames(
+                          'mt8',
+                          classNameOverrides?.collapsibleSection
+                        )}
                         label={headerGroup.label}
                         headerClassName="p24 br8"
                         isOpen={selectedSection === idString}
@@ -210,7 +215,13 @@ const ComparisonTable = <T extends { id: number }>(
                         </ScrollSyncPane>
                       </AccordionItem>
                     ) : (
-                      <div key={idString}>
+                      <section
+                        key={idString}
+                        className={classNames(
+                          baseStyles.section,
+                          classNameOverrides?.section
+                        )}
+                      >
                         <ScrollSyncPane>
                           <div
                             className={classNames(
@@ -246,7 +257,7 @@ const ComparisonTable = <T extends { id: number }>(
                             </div>
                           </div>
                         </ScrollSyncPane>
-                      </div>
+                      </section>
                     )}
                   </Fragment>
                 );

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -60,6 +60,7 @@ export interface ComparisonTableProps<T> {
     header?: string;
     container?: string;
   };
+  onSelectionChanged?: (selectedIndex: number) => void;
 }
 
 const ComparisonTable = <T extends { id: number }>(
@@ -79,6 +80,7 @@ const ComparisonTable = <T extends { id: number }>(
     firstColumnWidth,
     stickyHeaderTopOffset,
     growContent,
+    onSelectionChanged,
   } = props;
 
   const {
@@ -92,7 +94,7 @@ const ComparisonTable = <T extends { id: number }>(
     toggleMoreRows,
     showMore,
     headerId,
-  } = useComparisonTable();
+  } = useComparisonTable({ onSelectionChanged });
 
   const cssVariablesStyle = {
     '--tableWidth': `${headerWidth}px`,

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -183,7 +183,7 @@ const ComparisonTable = <T extends { id: number }>(
                     {headerGroup.label && collapsibleSections ? (
                       <AccordionItem
                         className={classNames(
-                          'mt8',
+                          'mt16',
                           classNameOverrides?.collapsibleSection
                         )}
                         label={headerGroup.label}
@@ -196,6 +196,7 @@ const ComparisonTable = <T extends { id: number }>(
                           <div
                             className={classNames(
                               baseStyles.container,
+                              'pb16',
                               classNameOverrides?.container,
                               {
                                 [baseStyles.noScrollBars]: hideScrollBars,
@@ -226,6 +227,7 @@ const ComparisonTable = <T extends { id: number }>(
                           <div
                             className={classNames(
                               baseStyles.container,
+                              'pb16',
                               classNameOverrides?.container,
                               {
                                 [baseStyles.noScrollBars]: hideScrollBars,

--- a/src/lib/components/comparisonTable/style.module.scss
+++ b/src/lib/components/comparisonTable/style.module.scss
@@ -42,7 +42,7 @@
   }
 }
 
-.section {
+.section + .section {
   margin-top: 48px;
 
   @include p-size-tablet {

--- a/src/lib/components/comparisonTable/style.module.scss
+++ b/src/lib/components/comparisonTable/style.module.scss
@@ -26,6 +26,22 @@
   scroll-snap-type: unset;
 }
 
+.noScrollBarsMobile {
+  @include p-size-tablet {
+    // Disable the scrollbar in all browsers
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    &::-webkit-scrollbar {
+      /* WebKit */
+      width: 0;
+      height: 0;
+    }
+
+    // Disable snapping since it's not needed without scrollbars
+    scroll-snap-type: unset;
+  }
+}
+
 .overflow-container {
   width: max-content;
   min-width: 100%;

--- a/src/lib/components/comparisonTable/style.module.scss
+++ b/src/lib/components/comparisonTable/style.module.scss
@@ -42,6 +42,14 @@
   }
 }
 
+.section {
+  margin-top: 48px;
+
+  @include p-size-tablet {
+    margin-top: 72px;
+  }
+}
+
 .overflow-container {
   width: max-content;
   min-width: 100%;
@@ -60,15 +68,9 @@
   background-color: $ds-grey-100;
   border-radius: 8px;
 
-  margin-top: 48px;
-
   & > h4 {
     padding: 24px;
     display: inline-block;
-  }
-
-  @include p-size-tablet {
-    margin-top: 72px;
   }
 }
 

--- a/src/lib/components/comparisonTable/style.module.scss
+++ b/src/lib/components/comparisonTable/style.module.scss
@@ -21,24 +21,21 @@
     width: 0;
     height: 0;
   }
-
-  // Disable snapping since it's not needed without scrollbars
-  scroll-snap-type: unset;
 }
 
 .noScrollBarsMobile {
-  @include p-size-tablet {
-    // Disable the scrollbar in all browsers
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* Internet Explorer 10+ */
-    &::-webkit-scrollbar {
-      /* WebKit */
-      width: 0;
-      height: 0;
+  @include p-size-mobile {
+    * {
+      // Disable the scrollbar in all browsers
+      scrollbar-width: none; /* Firefox */
+      -ms-overflow-style: none; /* Internet Explorer 10+ */
+      -webkit-scrollbar {
+        /* WebKit */
+        width: 0;
+        height: 0;
+        display: none;
+      }
     }
-
-    // Disable snapping since it's not needed without scrollbars
-    scroll-snap-type: unset;
   }
 }
 


### PR DESCRIPTION
### What this PR does

This PR improves the CoverageTable implementation by doing the following:
* Add `hideScrollBarsMobile` prop
* Fix scrollbar hiding killing the mobile view buttons
* Add props to change detail button captions
* Truly disable `TableArrows` buttons to avoid some edge cases
* Expose `onSelectionChanged` callback
* Replace underline links with (i) buttons
* Expose `classNameOverrides` and made "sections" into real `section`s
* Increase cell text contrast
* Fixed an issue where uncollapsed sections would overflow on the right
* Adjust padding and cell default sizes
* Fix addon card size

### Why is this needed?

To have a more streamlined CoverageTable which still offers flexibility.

Solves:
EPIC-137

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
