### PR TITLE
fix(CoverageTable): [EPIC-137] Fix details toggle messing up refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-dropzone": "^14.2.2",
     "react-hot-toast": "^2.4.1",
     "react-markdown": "^8.0.3",
-    "react-scroll-sync": "^0.11.0",
+    "react-scroll-sync": "^0.11.2",
     "remark-directive": "^2.0.1",
     "sass": "^1.35.1",
     "signature_pad": "^3.0.0-beta.3"
@@ -98,7 +98,7 @@
     "@types/react-autosuggest": "^10.1.4",
     "@types/react-day-picker": "^5.3.0",
     "@types/react-dom": "^17.0.8",
-    "@types/react-scroll-sync": "^0.8.2",
+    "@types/react-scroll-sync": "^0.9.0",
     "@types/sass": "^1.16.0",
     "babel-core": "^6.26.3",
     "babel-runtime": "^6.26.0",

--- a/src/lib/components/comparisonTable/components/TableArrows/index.tsx
+++ b/src/lib/components/comparisonTable/components/TableArrows/index.tsx
@@ -25,9 +25,9 @@ const TableArrows = (props: TableArrowsProps) => {
           styles.arrow,
           {
             [styles.active]: active.left,
+            [styles.noPointerEvents]: !active.left,
           }
         )}
-        disabled={!active.left}
       >
         <ArrowIcon />
       </button>
@@ -39,9 +39,9 @@ const TableArrows = (props: TableArrowsProps) => {
           styles.arrow,
           {
             [styles.active]: active.right,
+            [styles.noPointerEvents]: !active.right,
           }
         )}
-        disabled={!active.right}
       >
         <ArrowIcon />
       </button>

--- a/src/lib/components/comparisonTable/components/TableArrows/style.module.scss
+++ b/src/lib/components/comparisonTable/components/TableArrows/style.module.scss
@@ -42,12 +42,6 @@
     background-color: $ds-grey-200;
     cursor: not-allowed;
   }
-  &:disabled {
-    opacity: 1;
-    &:hover {
-      background-color: $ds-grey-200;
-    }
-  }
 }
 
 .active {
@@ -58,4 +52,8 @@
     background-color: $ds-grey-200;
     cursor: pointer;
   }
+}
+
+.noPointerEvents {
+  pointer-events: none;
 }

--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -2,7 +2,6 @@ import debounce from 'lodash.debounce';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ArrowValues } from '../components/TableArrows';
-import generateId from '../../../util/generateId';
 
 export const useComparisonTable = ({
   onSelectionChanged,
@@ -11,7 +10,6 @@ export const useComparisonTable = ({
 }) => {
   const [showMore, setShowMore] = useState<boolean>(false);
   const [headerWidth, setHeaderWidth] = useState(1400);
-  const [headerId, setHeaderId] = useState('');
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [selectedSection, setSelectedSection] = useState('');
 
@@ -127,29 +125,12 @@ export const useComparisonTable = ({
   };
 
   useEffect(() => {
-    if (headerRef.current) {
-      return;
-    }
-
-    const headerById = document.getElementById(headerId);
-
-    if (headerById) {
-      scrollContainerCallbackRef(headerById);
-    }
-  }, [headerId, scrollContainerCallbackRef]);
-
-  useEffect(() => {
-    setHeaderId(generateId());
-  }, []);
-
-  useEffect(() => {
     onSelectionChanged?.(selectedTabIndex);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTabIndex]);
 
   return {
     headerWidth,
-    headerId,
     contentContainerRef,
     selectedSection,
     setSelectedSection,

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -100,7 +100,6 @@ const ComparisonTable = <T extends { id: number }>(
     handleArrowsClick,
     toggleMoreRows,
     showMore,
-    headerId,
   } = useComparisonTable({ onSelectionChanged });
 
   const cssVariablesStyle = {
@@ -116,7 +115,7 @@ const ComparisonTable = <T extends { id: number }>(
   } as React.CSSProperties;
 
   return (
-    <ScrollSync onSync={scrollContainerCallbackRef}>
+    <ScrollSync>
       <div
         style={cssVariablesStyle}
         className={classNames({
@@ -127,8 +126,8 @@ const ComparisonTable = <T extends { id: number }>(
         <div
           className={classNames(baseStyles.header, classNameOverrides?.header)}
         >
-          <ScrollSyncPane>
-            <div id={headerId} className={classNames(baseStyles.container)}>
+          <ScrollSyncPane innerRef={scrollContainerCallbackRef}>
+            <div className={classNames(baseStyles.container)}>
               <div className={classNames(baseStyles['overflow-container'])}>
                 <div className={baseStyles['group-container']}>
                   <TableArrows

--- a/yarn.lock
+++ b/yarn.lock
@@ -3649,10 +3649,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-scroll-sync@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.npmjs.org/@types/react-scroll-sync/-/react-scroll-sync-0.8.2.tgz"
-  integrity sha512-u/LM/8NDxEYaR1OogAjjVTUjUJg0MiierTEeFEIs7BwJBvl4IhTCZOyDCs/On/bzSeH/AOgszyeAa8kIJgIt9Q==
+"@types/react-scroll-sync@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@types/react-scroll-sync/-/react-scroll-sync-0.9.0.tgz#f9c556cc1441b28344f6b820cac34099cab74f2b"
+  integrity sha512-DFJzqtF0lMUNxsKZ9aoFS+LGieGLXWQVWvCMTZWKm/qcGz+GCNTqwdHsnyWW3yy/aNSUxlXCAWdHaemGaES6lQ==
   dependencies:
     "@types/react" "*"
 
@@ -13956,10 +13956,10 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react-scroll-sync@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/react-scroll-sync/-/react-scroll-sync-0.11.0.tgz#eaeb55240d7cb07ab6ccab2fb483f46f2832b8c1"
-  integrity sha512-COfA885/2NAQPxusIU6sukKiSFXgAd9+OWD7iBWA4NF5Y1Np8poBKLwgZ3y4iywo5/+ch0PLGz887myIbm+fPw==
+react-scroll-sync@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/react-scroll-sync/-/react-scroll-sync-0.11.2.tgz#fe8a3a09eab5a44323bdf0f63283c1dd0cd99b45"
+  integrity sha512-n7m+bbRTSWuczhKQf6Evvl7PFGkTt4RfP4bhyUtUyv6znovpybhAScQDdrFr9Jh280nG39x9AWMY8j477PHL1A==
   dependencies:
     prop-types "^15.5.7"
 


### PR DESCRIPTION
### What this PR does

This PR fixes an issue when toggling details on then off, where the scrollContainerRef would get lost.

This is accomplished by 2 things:
1. Using the new prop "InnerRef" that [can finally be used to get the ref to the child component again](https://github.com/okonet/react-scroll-sync/pull/90) inside a `ScrollSyncPane`. This way a consistent ref is retained.
2. Removing the "disabled" state from TableArrows as it was somehow messing with the refs for some unknown reason.

Before:

https://github.com/getPopsure/dirty-swan/assets/13664983/eedcc601-1a37-4141-8185-908210c4fddc

After:

https://github.com/getPopsure/dirty-swan/assets/13664983/2689eb5e-8d0a-4e89-9b92-fe57a47981eb

### How to test?

On a mobile view, navigate to the very last item, then toggle details on, then off. Try to navigate the items again. It should work again,


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
