### PR TITLE
refactor(date-selector): Improve validation handling

### DIFF
--- a/src/lib/components/dateSelector/index.test.tsx
+++ b/src/lib/components/dateSelector/index.test.tsx
@@ -52,14 +52,44 @@ describe('DateSelector component', () => {
     expect(callback).toHaveBeenCalledWith('2023-07-03');
   });
 
-  it('should call onChange empty when invalid date', async () => {
+  it('should not call onChange when there is an invalid date that has not been completely filled', async () => {
     const callback = jest.fn();
     const { getByLabelText, user } = setup(undefined, callback);
 
     await user.type(getByLabelText('Day'), '5');
 
     expect(getByLabelText('Day')).toHaveValue('5');
-    expect(callback).toHaveBeenCalledWith('');
+    expect(callback).not.toHaveBeenCalled();
+
+    await user.type(getByLabelText('Month'), '4');
+
+    expect(getByLabelText('Month')).toHaveValue('4');
+    expect(callback).not.toHaveBeenCalled();
+
+    await user.type(getByLabelText('Year'), '2020');
+
+    expect(getByLabelText('Year')).toHaveValue('2020');
+    expect(callback).toHaveBeenCalledWith("2020-04-05");
+  });
+
+  it('should show error boundaries error for min date onChange empty when year out of boundaries', async () => {
+    const callback = jest.fn();
+    const date = '2010-01-01';
+    const { getByTestId } = setup(date, callback);
+
+    expect(getByTestId('date-error-message')).toBeVisible();
+    expect(getByTestId('date-error-message')).toHaveTextContent('Please choose a date after 2019');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should show error boundaries error for ,ax date onChange empty when year out of boundaries', async () => {
+    const callback = jest.fn();
+    const date = '2100-01-01';
+    const { getByTestId } = setup(date, callback);
+
+    expect(getByTestId('date-error-message')).toBeVisible();
+    expect(getByTestId('date-error-message')).toHaveTextContent('Please choose a date before 2026');
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it('should call onChange empty when year out of boundaries', async () => {


### PR DESCRIPTION
### What this PR does
Only validates/shows error message after a date has been completed once:
<img width="380" alt="Screenshot 2024-06-11 at 15 07 54" src="https://github.com/getPopsure/dirty-swan/assets/4015038/8e728139-6ebd-4c51-9ef1-8ac7cb638587">

Adds specific error messages for year boundaries errors:
<img width="403" alt="Screenshot 2024-06-11 at 15 07 37" src="https://github.com/getPopsure/dirty-swan/assets/4015038/383befc9-2dc5-4e29-a7ad-bca8e6a464e8">

<img width="330" alt="Screenshot 2024-06-11 at 15 07 43" src="https://github.com/getPopsure/dirty-swan/assets/4015038/29821a52-0260-452f-b659-990702a52356">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
