### PR TITLE
feat(accordion): Add Accordion component

### DIFF
--- a/src/lib/components/accordion/index.stories.tsx
+++ b/src/lib/components/accordion/index.stories.tsx
@@ -1,0 +1,85 @@
+import { Accordion, AccordionProps } from '.';
+import { ArthritisIcon, CpuIcon, WindIcon, ZapIcon } from '../icon';
+
+const story = {
+  title: 'JSX/Accordion',
+  component: Accordion,
+  argTypes: {
+    classNames: {
+      description: 'Class names for the Accordion component and its children elements',
+    },
+    variant: {
+      description: 'Variant that defines the style of the Accordion',
+    },
+    multiple: {
+      description: 'Allow multiple items to be open at the same time',
+    },
+    items: {
+      description: 'Accordion items to be displayed. Each item should have an id, question, and answer. Optionally, an icon can be added to the item. \n\nThe answer property accepts markdown.',
+    },
+    onClick: {
+      description: 'Function that runs on click of the Accordion item',
+      action: true,
+      table: {
+        category: 'Callbacks',
+      },
+    },
+  },
+  args: {
+    items: [
+      {
+        id: '1',
+        question: 'What is the meaning of life?',
+        answer: '42',
+        icon: <CpuIcon size={24} />
+      },
+      {
+        id: '2',
+        question: 'How old is the universe?',
+        answer: '13.8 **billion** years',
+        icon: <ZapIcon size={24} />,
+      },
+      {
+        id: '3',
+        question: 'What is the capital of France?',
+        answer: 'Paris',
+        icon: <WindIcon size={24} />,
+      },
+      {
+        id: '4',
+        question: 'Who painted the Mona Lisa?',
+        answer: 'Leonardo da Vinci',
+        icon: <ArthritisIcon size={24} />,
+      },
+    ],
+    variant: 'default',
+    multiple: false,
+    classNames: {
+      questionWrapper: '',
+      buttonWrapper: '',
+      wrapper: '',
+      icon: '',
+      question: '',
+      answer: '',
+      markdown: ''
+    },
+  }
+};
+ 
+export const AccordionStory = ({
+  items,
+  multiple,
+  onClick,
+  variant
+}: AccordionProps) => (
+  <Accordion
+    items={items}
+    multiple={multiple}
+    variant={variant}
+    onClick={onClick}
+  />
+);
+
+AccordionStory.storyName = "Accordion";
+ 
+export default story;

--- a/src/lib/components/accordion/index.stories.tsx
+++ b/src/lib/components/accordion/index.stories.tsx
@@ -36,7 +36,7 @@ const story = {
       {
         id: '2',
         question: 'How old is the universe?',
-        answer: '13.8 **billion** years',
+        answer: '13.8 billion years',
         icon: <ZapIcon size={24} />,
       },
       {
@@ -48,7 +48,7 @@ const story = {
       {
         id: '4',
         question: 'Who painted the Mona Lisa?',
-        answer: 'Leonardo da Vinci',
+        answer: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         icon: <ArthritisIcon size={24} />,
       },
     ],

--- a/src/lib/components/accordion/index.tsx
+++ b/src/lib/components/accordion/index.tsx
@@ -5,13 +5,12 @@ import AnimateHeight from 'react-animate-height';
 import styles from './style.module.scss';
 import { ChevronDownIcon } from '../icon';
 import { Card } from '../cards/card';
-import { Markdown } from '../markdown';
 
 export interface AccordionItem {
   id: string;
   question: string;
   icon?: ReactNode;
-  answer: string;
+  answer: ReactNode;
 }
 
 export interface AccordionProps {
@@ -63,7 +62,6 @@ const Accordion = ({
     <div
       className={
         classnamesUtil(
-          styles.wrapper,
           {
             'br8': !isDefaultVariant,
             [styles.wrapperBordered]: !isDefaultVariant,
@@ -92,21 +90,25 @@ const Accordion = ({
               classNames={{
                 icon: classnamesUtil(
                   classNames?.icon,
-                  'tc-grey-700'
+                  styles.icon,
+                  'tc-grey-700',
                 ),
                 buttonWrapper: classnamesUtil(
                   classNames?.buttonWrapper,
-                  styles.buttonWrapper,
-                  { 'py8': isDefaultVariant, },
+                  styles.buttonWrapper, {
+                    [styles.buttonWrapperDefault]: isDefaultVariant
+                  },
                 ),
                 wrapper: classnamesUtil(
                   classNames?.wrapper,
-                  'bg-transparent br0',
+                  'bg-transparent br0 px8 py8',
                   { 'pl0': isDefaultVariant },
                 ),
                 title: classnamesUtil(
                   classNames?.question,
-                  'tc-grey-700 fw-bold'
+                  styles.question,
+                  'fw-bold', 
+                  { [styles.questionOpen]: isOpen }
                 ),
                 ...classNames,
               }}
@@ -118,7 +120,6 @@ const Accordion = ({
                   className={classnamesUtil(styles.chevron, {
                     [styles.chevronOpen]: isOpen
                   })}
-                  color="grey-700"
                   size={20}
                   noMargin
                 />
@@ -132,15 +133,11 @@ const Accordion = ({
               <div 
                 className={classnamesUtil(
                   classNames?.answer,
-                  'tc-grey-600 p16 pl0', 
+                  'tc-grey-600 pr16 pb16', 
                   { 'pl16': !isDefaultVariant },
                 )}
               >
-                  {typeof answer === 'string' ? (
-                    <Markdown className={classNames.markdown}>{answer}</Markdown>
-                  ) : (
-                    answer
-                  )}
+                  {answer}
               </div>
             </AnimateHeight>
           </div>

--- a/src/lib/components/accordion/index.tsx
+++ b/src/lib/components/accordion/index.tsx
@@ -1,0 +1,153 @@
+import classnamesUtil from 'classnames';
+import { ReactNode, useCallback, useState } from 'react';
+import AnimateHeight from 'react-animate-height';
+
+import styles from './style.module.scss';
+import { ChevronDownIcon } from '../icon';
+import { Card } from '../cards/card';
+import { Markdown } from '../markdown';
+
+export interface AccordionItem {
+  id: string;
+  question: string;
+  icon?: ReactNode;
+  answer: string;
+}
+
+export interface AccordionProps {
+  items: AccordionItem[];
+  classNames?: {
+    questionWrapper?: string;
+    buttonWrapper?: string;
+    wrapper?: string;
+    question?: string;
+    answer?: string;
+    icon?: string;
+    markdown?: string;
+  };
+  multiple?: boolean;
+  onClick?: (item: AccordionItem) => void;
+  variant?: 'default' | 'bordered';
+};
+
+const Accordion = ({
+  items = [],
+  classNames = {},
+  variant = 'default',
+  multiple = false,
+  onClick,
+}: AccordionProps) => {
+  const [selectedQuestionId, setSelectedQuestionId] = useState<(string[])>([]);
+  const isDefaultVariant = variant === 'default';
+
+  const handleClick = useCallback((questionData:  AccordionItem) => {
+    const { id } = questionData;
+    if (selectedQuestionId.includes(id)) {
+      if (!multiple) {
+        setSelectedQuestionId([]);
+        return
+      }
+
+      setSelectedQuestionId((selectedItems) => 
+        selectedItems.filter((selectedId) => selectedId !== id)
+      );
+    } else {
+      onClick?.(questionData);
+      setSelectedQuestionId((selectedIds) => [
+        id, ...multiple ? selectedIds : [],
+      ]);
+    }
+  }, [multiple, onClick, selectedQuestionId]);
+
+  return (
+    <div
+      className={
+        classnamesUtil(
+          styles.wrapper,
+          {
+            'br8': !isDefaultVariant,
+            [styles.wrapperBordered]: !isDefaultVariant,
+          }
+        )
+      }
+    >
+      {items.map((questionData) => {
+        const { question, answer, id, icon } = questionData;
+        const isOpen = selectedQuestionId.includes(id);
+
+        return (
+          <div
+            key={id}
+            className={classnamesUtil(
+              classNames?.questionWrapper,
+              styles.container,
+              { [styles.containerBordered]: !isDefaultVariant }
+            )}
+          >
+            <Card
+              title={question}
+              titleVariant="small"
+              density='compact'
+              icon={icon}
+              classNames={{
+                icon: classnamesUtil(
+                  classNames?.icon,
+                  'tc-grey-700'
+                ),
+                buttonWrapper: classnamesUtil(
+                  classNames?.buttonWrapper,
+                  styles.buttonWrapper,
+                  { 'py8': isDefaultVariant, },
+                ),
+                wrapper: classnamesUtil(
+                  classNames?.wrapper,
+                  'bg-transparent br0',
+                  { 'pl0': isDefaultVariant },
+                ),
+                title: classnamesUtil(
+                  classNames?.question,
+                  'tc-grey-700 fw-bold'
+                ),
+                ...classNames,
+              }}
+              dropShadow={false}
+              onClick={() => handleClick(questionData)}
+              aria-expanded={isOpen}
+              actionIcon={
+                <ChevronDownIcon
+                  className={classnamesUtil(styles.chevron, {
+                    [styles.chevronOpen]: isOpen
+                  })}
+                  color="grey-700"
+                  size={20}
+                  noMargin
+                />
+              }
+            />
+
+            <AnimateHeight
+              duration={300}
+              height={isOpen ? 'auto' : 0}
+            >
+              <div 
+                className={classnamesUtil(
+                  classNames?.answer,
+                  'tc-grey-600 p16 pl0', 
+                  { 'pl16': !isDefaultVariant },
+                )}
+              >
+                  {typeof answer === 'string' ? (
+                    <Markdown className={classNames.markdown}>{answer}</Markdown>
+                  ) : (
+                    answer
+                  )}
+              </div>
+            </AnimateHeight>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export { Accordion };

--- a/src/lib/components/accordion/style.module.scss
+++ b/src/lib/components/accordion/style.module.scss
@@ -1,0 +1,39 @@
+@use "../../scss/public/colors" as *;
+
+.wrapper {
+  overflow: hidden;
+}
+
+.wrapperBordered {
+  border: 1px solid $ds-grey-300;
+}
+
+.container {
+  border-bottom: 1px solid $ds-grey-300;
+
+  &Bordered:last-of-type {
+    border-bottom: 0;
+  }
+}
+
+.buttonWrapper {
+  border-radius: 0!important;
+
+  &:hover {
+    background: $ds-primary-50;
+    outline: 0 solid transparent!important;
+  }
+
+  &:focus-visible {
+    background: $ds-primary-50;
+    outline: 2px solid $ds-primary-500!important;
+  }
+}
+
+.chevron {
+  transition: transform 0.3s ease-in-out;
+
+  &Open {
+    transform: rotate(180deg);
+  }
+}

--- a/src/lib/components/accordion/style.module.scss
+++ b/src/lib/components/accordion/style.module.scss
@@ -1,9 +1,5 @@
 @use "../../scss/public/colors" as *;
 
-.wrapper {
-  overflow: hidden;
-}
-
 .wrapperBordered {
   border: 1px solid $ds-grey-300;
 }
@@ -16,24 +12,51 @@
   }
 }
 
-.buttonWrapper {
-  border-radius: 0!important;
-
-  &:hover {
-    background: $ds-primary-50;
-    outline: 0 solid transparent!important;
-  }
-
-  &:focus-visible {
-    background: $ds-primary-50;
-    outline: 2px solid $ds-primary-500!important;
-  }
+.question {
+  color: $ds-grey-700;
 }
 
 .chevron {
+  color: $ds-grey-700;
   transition: transform 0.3s ease-in-out;
 
   &Open {
     transform: rotate(180deg);
+  }
+}
+
+.buttonWrapper {
+  background-color: transparent!important;
+  color: $ds-primary-500;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  outline-offset: -4px;
+
+  &Default {
+    margin-top: 12px;
+    margin-bottom: 12px;
+    outline-offset: -2px;
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: $ds-primary-50;
+
+    .icon {
+      color: $ds-primary-500!important;
+    }
+
+    .question,
+    .chevron{
+      color: $ds-primary-500;
+    }
+  }
+
+  &:hover {
+    outline: 0 solid transparent!important;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $ds-primary-500!important;
   }
 }

--- a/src/lib/components/cards/card/index.tsx
+++ b/src/lib/components/cards/card/index.tsx
@@ -67,7 +67,7 @@ const Card = <E extends ElementType = CardDefaultAsType>({
     <Tag
       className={classNamesUtil(
         classNames?.buttonWrapper,
-        ' d-flex w100 br8 ai-stretch',
+        'd-flex w100 ai-stretch',
         {
           'c-pointer': propsWithActionIcon,
           [styles.button]: propsWithActionIcon
@@ -81,7 +81,7 @@ const Card = <E extends ElementType = CardDefaultAsType>({
     >
       <div
         className={classNamesUtil(
-          'd-flex fd-column br8 bg-white w100 ta-left',
+          'd-flex fd-column jc-center w100 ta-left',
           { 'bs-sm': dropShadow },
           {
             compact: 'p16',
@@ -93,6 +93,7 @@ const Card = <E extends ElementType = CardDefaultAsType>({
             center: 'jc-center',
             bottom: 'jc-end',
           }[verticalAlignment as VerticalAlignmentType],
+          styles?.wrapper,
           classNames?.wrapper
         )}
       >
@@ -118,13 +119,13 @@ const Card = <E extends ElementType = CardDefaultAsType>({
           <div className="d-flex jc-between w100">
             <div className="d-flex jc-center gap8 fd-column tc-grey-900 w100">
               {label && (
-                <h3 className={classNamesUtil('p-p--small', classNames?.label)}>
+                <h4 className={classNamesUtil('p-p--small', classNames?.label)}>
                   {label}
-                </h3>
+                </h4>
               )}
 
               {title && (
-                <h2
+                <h3
                   className={classNamesUtil(
                     classNames?.title,
                     {
@@ -135,7 +136,7 @@ const Card = <E extends ElementType = CardDefaultAsType>({
                   )}
                 >
                   {title}
-                </h2>
+                </h3>
               )}
 
               {description && (

--- a/src/lib/components/cards/card/style.module.scss
+++ b/src/lib/components/cards/card/style.module.scss
@@ -6,6 +6,7 @@
   outline: 1px solid transparent;
   transition: all 0.2s ease-in-out;
   text-decoration: none;
+  border-radius: 8px;
 
   &:hover {
     outline: 1px solid $ds-primary-500;
@@ -16,6 +17,10 @@
     outline: 2px solid $ds-primary-500;
     color: $ds-primary-500;
   }
+}
+
+.wrapper {
+  background-color: $ds-white;
 }
 
 .icon {


### PR DESCRIPTION
### What this PR does
This PR adds the `Accordion` component and does minimal changes to `Card` component for improved rewriting of styles.

### How to test?
Run storybook book and visit [Accordion story page](http://localhost:9009/?path=/docs/jsx-accordion--accordion-story).

**Preview:**
https://github.com/getPopsure/dirty-swan/assets/4015038/7d5a210f-e6f4-41f0-93eb-a95f91b362bb

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
