### PR TITLE
feat(modal): Add footer prop to Modal components

### DIFF
--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -6,6 +6,7 @@ import styles from './style.module.scss';
 import { XIcon } from '../../icon/icons';
 import useOnClose from '../hooks/useOnClose';
 import classNames from 'classnames';
+import { ModalFooter } from '../components/ModalFooter';
 
 export const BottomModal = ({
   title,
@@ -14,8 +15,10 @@ export const BottomModal = ({
   onClose,
   className = '',
   dismissible = true,
+  footer,
 }: Props) => {
   const [containerXOffset, setContainerXOffset] = useState(0);
+  const [footerHeight, setFooterHeight] = useState(80);
   const {
     isClosing,
     handleContainerClick,
@@ -39,45 +42,66 @@ export const BottomModal = ({
   }
 
   return (
-    <div
-      className={isClosing ? styles['overlay--close'] : styles.overlay}
-      onClick={handleOnOverlayClick}
-    >
+    <>
       <div
-        className={styles.wrapper}
-        ref={containerRef}
-        onClick={handleContainerClick}
-        style={{ top: `${containerXOffset}px` }}
+        className={isClosing ? styles.overlayClose : styles.overlay}
+        onClick={handleOnOverlayClick}
       >
         <div
-          className={`${
-            isClosing ? styles['container--close'] : styles.container
-          } ${className}`}
+          className={styles.wrapper}
+          ref={containerRef}
+          onClick={handleContainerClick}
+          style={{ top: `${containerXOffset}px` }}
         >
           <div
-            className={classNames(styles.header, {
-              'jc-between': !!title,
-              'jc-end': !title,
-            })}
-          >
-            <div className={`p-h4 ${styles.title}`}>{title}</div>
-            {dismissible && (
-              <button
-                type="button"
-                className={styles.close}
-                onClick={handleOnClose}
-              >
-                <XIcon
-                  size={24}
-                  color={'grey-700'}
-                  className={`${styles.closeIcon}`}
-                />
-              </button>
+            className={classNames(
+              styles.container,
+              styles.appear,
+              className, {
+                [styles.appearClose]: isClosing, 
+              }
             )}
+            style={{ paddingBottom: footer ? footerHeight : 0 }}
+          >
+            <div
+              className={classNames(styles.header, {
+                'jc-between': !!title,
+                'jc-end': !title,
+              })}
+            >
+              <div className={`p-h4 ${styles.title}`}>{title}</div>
+              {dismissible && (
+                <button
+                  type="button"
+                  className={styles.close}
+                  onClick={handleOnClose}
+                >
+                  <XIcon
+                    size={24}
+                    color={'grey-700'}
+                    className={`${styles.closeIcon}`}
+                  />
+                </button>
+              )}
+            </div>
+            <div className={footer ? '' : styles.content}>{children}</div>
           </div>
-          <div className={styles.content}>{children}</div>
         </div>
       </div>
-    </div>
+
+      {footer && (
+        <ModalFooter
+          className={classNames(
+            styles.appear, {
+              [styles.appearClose]: isClosing, 
+            }
+          )}
+          fixed
+          onHeightChange={setFooterHeight}
+        >
+          {footer?.(handleOnClose)}
+        </ModalFooter>
+      )}
+    </>
   );
 };

--- a/src/lib/components/modal/bottomModal/style.module.scss
+++ b/src/lib/components/modal/bottomModal/style.module.scss
@@ -65,7 +65,7 @@
 
   animation: fade-in 0.3s both;
 
-  &--close {
+  &Close {
     @extend .overlay;
     animation-delay: 0.1s;
     animation: fade-out 0.3s both;
@@ -86,14 +86,15 @@
   border-top-right-radius: 8px;
 
   width: 100%;
+}
 
+.appear {
   animation-name: appear-in;
   animation-duration: 0.4s;
   animation-fill-mode: both;
-  animation-timing-function: ease-out;
+  animation-timing-function: ease-in;
 
-  &--close {
-    @extend .container;
+  &Close {
     animation-name: disappear-out;
     animation-duration: 0.4s;
     animation-delay: 0s;

--- a/src/lib/components/modal/components/ModalFooter.tsx
+++ b/src/lib/components/modal/components/ModalFooter.tsx
@@ -1,0 +1,59 @@
+import { ReactNode, useEffect, useRef, useState } from "react";
+import styles from './style.module.scss';
+import classNames from "classnames";
+
+interface ModalFooterProps {
+  children: ReactNode;
+  className?: string;
+  fixed?: boolean;
+  onHeightChange?: (height: number) => void;
+}
+
+const ModalFooter = ({
+  children,
+  className,
+  fixed,
+  onHeightChange,
+}: ModalFooterProps) => {
+  const [height, setHeight] = useState(80);
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current || !fixed) {
+        return;
+    }
+
+    const currentRef = ref.current;
+    const observer = new ResizeObserver((entries) => {
+        const { height } = entries[0].contentRect;
+        setHeight(height);
+    });
+
+    observer.observe(currentRef);
+
+    return () => observer.unobserve(currentRef);
+  }, [fixed]);
+
+  useEffect(() => {
+    onHeightChange?.(height);
+  }, [height, onHeightChange]);
+
+  return (
+    <div
+      ref={ref}
+      className={classNames(
+        className,
+        'bg-white',
+        styles.wrapper,
+        { [styles.wrapperFixed]: fixed }
+      )}
+    >
+      <div className="px24 py16">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export { ModalFooter };

--- a/src/lib/components/modal/components/style.module.scss
+++ b/src/lib/components/modal/components/style.module.scss
@@ -1,0 +1,14 @@
+@use "../../../scss/public/colors" as *;
+
+.wrapper {
+  border-top: 1px solid $ds-grey-300;
+  width: 100%;
+
+  &Fixed {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 101;
+  }
+}

--- a/src/lib/components/modal/index.stories.tsx
+++ b/src/lib/components/modal/index.stories.tsx
@@ -2,6 +2,8 @@
 import { useState } from 'react';
 import { BottomModal, BottomOrRegularModal, Props, RegularModal } from '.';
 import { Markdown } from '../markdown';
+import { ModalFooter } from './components/ModalFooter';
+import { Button } from '../button';
 
 const story = {
   title: 'JSX/Modals',
@@ -245,6 +247,49 @@ export const NonDismissibleModal = ({
           >
             Continue
           </button>
+        </div>
+      </BottomOrRegularModal>
+    </>
+  );
+}
+
+export const ModalWithFooter = ({
+  children,
+  isOpen,
+  onClose,
+  title,
+}: Props) => {
+  const [display, setDisplay] = useState(isOpen);
+  const handleOnClose = () => {
+    onClose();
+    setDisplay(false);
+  };
+
+  return (
+    <>
+      <button
+        className="p-btn--primary wmn2 mt24"
+        onClick={() => setDisplay(true)}
+      >
+        Click to open modal
+      </button>
+
+      <BottomOrRegularModal
+        title={title}
+        isOpen={display}
+        onClose={handleOnClose}
+        footer={(onClose) => 
+          <Button className='w100' onClick={onClose}>
+            Continue
+          </Button>
+        }
+      >
+        <div style={{ padding: '0 24px 24px 24px' }}>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            <div style={{ height: '440px' }} />
+            {children}
+          </div>
         </div>
       </BottomOrRegularModal>
     </>

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -9,6 +9,7 @@ export interface Props {
   onClose: () => void;
   className?: string;
   dismissible?: boolean;
+  footer?: (onClose: () => void) => React.ReactNode;
 }
 
 export { BottomModal, RegularModal, BottomOrRegularModal };

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Props } from '..';
 import useOnClose from '../hooks/useOnClose';
@@ -6,6 +6,7 @@ import useOnClose from '../hooks/useOnClose';
 import styles from './style.module.scss';
 import { XIcon } from '../../icon/icons';
 import classNames from 'classnames';
+import { ModalFooter } from '../components/ModalFooter';
 
 export const RegularModal = ({
   title,
@@ -14,6 +15,7 @@ export const RegularModal = ({
   onClose,
   className = '',
   dismissible = true,
+  footer,
 }: Props) => {
   const {
     isClosing,
@@ -36,7 +38,10 @@ export const RegularModal = ({
           isClosing ? styles['container--close'] : styles.container
         } ${className}`}
       >
-        <div className={styles.body} onClick={handleContainerClick}>
+        <div
+          className={styles.body}
+          onClick={handleContainerClick}
+        >
           <div
             className={classNames(styles.header, {
               'jc-between': !!title,
@@ -58,7 +63,14 @@ export const RegularModal = ({
               </button>
             )}
           </div>
+
           {children}
+
+          {footer && (
+            <ModalFooter>
+              {footer?.(handleOnClose)}
+            </ModalFooter>
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/components/modal/regularModal/style.module.scss
+++ b/src/lib/components/modal/regularModal/style.module.scss
@@ -98,6 +98,8 @@
   background-color: white;
   border-radius: 8px;
   margin: 80px auto;
+  position: relative;
+  overflow: hidden;
 }
 
 .header {


### PR DESCRIPTION
### What this PR does
This PR adds the footer prop to the Modal components.

### Why is this needed?
We want to have a footer component that renders fixed at the bottom on `BottomModal` and in flow in `RegularModal`.

### How to test?
Run storybook, go to [Modal stories](http://localhost:9009/?path=/docs/jsx-modals--modal-with-footer) and try the last story that has a footer. On mobile it shows Bottom modal and on desktop/tablet it shows the RegularModal.

**Preview:**
<img width="456" alt="Screenshot 2024-06-18 at 11 56 22" src="https://github.com/getPopsure/dirty-swan/assets/4015038/ce2eb0ca-8a85-48f1-82d7-23c349c91cb7">
<img width="771" alt="Screenshot 2024-06-18 at 11 56 04" src="https://github.com/getPopsure/dirty-swan/assets/4015038/6e824085-b8af-43f9-a9a9-91c82f7fb339">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
