### PR TITLE
refactor(card): Add verticalAlignment prop to Card component

### DIFF
--- a/src/lib/components/cards/card/index.stories.tsx
+++ b/src/lib/components/cards/card/index.stories.tsx
@@ -50,6 +50,10 @@ const story = {
     showActionIcon: {
       description: 'Property that always displays action icon even if no onClick is set.',
     },
+    verticalAlignment: {
+      description: 'Vertical alignment of the card content',
+      control: { type: 'select' },
+    },
   },
   args: {
     density: 'balanced',
@@ -69,6 +73,7 @@ const story = {
       icon: ''
     },
     dropShadow: true,
+    verticalAlignment: 'center',
   }
 };
 
@@ -87,6 +92,7 @@ export const CardStory = ({
   onClick,
   title,
   titleVariant,
+  verticalAlignment,
 }: CardProps) => (
   <div className='d-flex p24 bg-grey-200'>
     <Card
@@ -103,6 +109,7 @@ export const CardStory = ({
       onClick={onClick}
       actionIcon={actionIcon}
       showActionIcon={showActionIcon}
+      verticalAlignment={verticalAlignment}
     >
       {children}
     </Card>

--- a/src/lib/components/cards/card/index.tsx
+++ b/src/lib/components/cards/card/index.tsx
@@ -8,6 +8,7 @@ const cardDefaultAs = 'section' as const
 type CardDefaultAsType = typeof cardDefaultAs;
 type DensityType = 'balanced' | 'compact' | 'spacious';
 type TitleVariantType = 'small' | 'medium' | 'large';
+type VerticalAlignmentType = 'top' | 'center' | 'bottom';
 
 type CardOwnProps<E extends ElementType = CardDefaultAsType> = {
   as?: E;
@@ -33,6 +34,7 @@ type CardOwnProps<E extends ElementType = CardDefaultAsType> = {
   onClick?: () => void;
   actionIcon?: ReactNode;
   showActionIcon?: boolean;
+  verticalAlignment?: VerticalAlignmentType;
 } 
 
 export type CardProps<E extends ElementType = CardDefaultAsType> = CardOwnProps<E> &
@@ -53,6 +55,7 @@ const Card = <E extends ElementType = CardDefaultAsType>({
   title,
   titleVariant = 'large',
   showActionIcon,
+  verticalAlignment = 'center',
   ...rest
 }: CardProps<E>) => {
   const hideActionIcon = typeof actionIcon !== 'undefined' && !actionIcon;
@@ -78,13 +81,18 @@ const Card = <E extends ElementType = CardDefaultAsType>({
     >
       <div
         className={classNamesUtil(
-          'd-flex fd-column jc-center br8 bg-white w100 ta-left',
+          'd-flex fd-column br8 bg-white w100 ta-left',
           { 'bs-sm': dropShadow },
           {
             compact: 'p16',
             balanced: 'p24',
             spacious: 'p32',
           }[density as DensityType],
+          {
+            top: 'jc-start',
+            center: 'jc-center',
+            bottom: 'jc-end',
+          }[verticalAlignment as VerticalAlignmentType],
           classNames?.wrapper
         )}
       >
@@ -92,10 +100,15 @@ const Card = <E extends ElementType = CardDefaultAsType>({
           {icon && (
             <div
               className={classNamesUtil(
-                `d-flex ai-center tc-primary-500`,
+                `d-flex tc-primary-500`,
                 styles.icon,
                 styles[`icon${density}`],
-                classNames?.icon
+                classNames?.icon, 
+                {
+                  top: 'ai-start',
+                  center: 'ai-center',
+                  bottom: 'ai-end',
+                }[verticalAlignment as VerticalAlignmentType],
               )}
             >
               {icon}


### PR DESCRIPTION
### What this PR does
This PR adds the `verticalAlignment` prop to Card component.

**Preview:**
<img width="623" alt="Screenshot 2024-06-19 at 09 55 13" src="https://github.com/getPopsure/dirty-swan/assets/4015038/5399140d-d7ed-40ab-81e0-d970ec9bdde8">
<img width="612" alt="Screenshot 2024-06-19 at 09 55 23" src="https://github.com/getPopsure/dirty-swan/assets/4015038/421febc1-df85-4cf8-afb5-cd71dea4bd35">


Solves:
STO-XXX
EMU-XXX
RVN-XXX

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
