### PR TITLE
refactor(modal): Refactor Modal and add modal footer

### DIFF
--- a/src/lib/components/modal/bottomModal/img/close.svg
+++ b/src/lib/components/modal/bottomModal/img/close.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18 6L6 18" stroke="#26262E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-<path d="M6 6L18 18" stroke="#26262E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-</svg>

--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -1,83 +1,23 @@
-import React, { useState, useCallback } from 'react';
-
 import { Props } from '..';
 import styles from './style.module.scss';
-
-import { XIcon } from '../../icon/icons';
-import useOnClose from '../hooks/useOnClose';
 import classNames from 'classnames';
+import { GenericModal } from '../genericModal';
 
-export const BottomModal = ({
-  title,
-  isOpen,
-  children,
-  onClose,
-  className = '',
-  dismissible = true,
-}: Props) => {
-  const [containerXOffset, setContainerXOffset] = useState(0);
-  const {
-    isClosing,
-    handleContainerClick,
-    handleOnClose,
-    handleOnOverlayClick,
-  } = useOnClose(onClose, isOpen, dismissible);
+const BottomModal = ({ className, ...rest }: Props) => (
+  <GenericModal
+    titleSize='small'
+    classNames={{
+      wrapper: classNames('w100', styles.wrapper),
+      container: ({ isClosing }) => classNames(
+        'bg-white d-flex fd-column w100',
+        className,
+        styles.container, {
+          [styles.containerClose]: isClosing, 
+        }
+      ),
+    }}
+    {...rest}
+  />
+);
 
-  const containerRef = useCallback((node: HTMLDivElement) => {
-    if (node !== null) {
-      setContainerXOffset(
-        Math.max(
-          window.innerHeight * 0.1,
-          window.innerHeight - node.getBoundingClientRect().height
-        )
-      );
-    }
-  }, []);
-
-  if (!isOpen) {
-    return <></>;
-  }
-
-  return (
-    <div
-      className={isClosing ? styles['overlay--close'] : styles.overlay}
-      onClick={handleOnOverlayClick}
-    >
-      <div
-        className={styles.wrapper}
-        ref={containerRef}
-        onClick={handleContainerClick}
-        style={{ top: `${containerXOffset}px` }}
-      >
-        <div
-          className={`${
-            isClosing ? styles['container--close'] : styles.container
-          } ${className}`}
-        >
-          <div
-            className={classNames(styles.header, {
-              'jc-between': !!title,
-              'jc-end': !title,
-            })}
-          >
-            <div className={`p-h4 ${styles.title}`}>{title}</div>
-            {dismissible && (
-              <button
-                type="button"
-                className={styles.close}
-                onClick={handleOnClose}
-              >
-                <XIcon
-                  size={24}
-                  color={'grey-700'}
-                  className={`${styles.closeIcon}`}
-                />
-              </button>
-            )}
-          </div>
-          <div className={styles.content}>{children}</div>
-        </div>
-      </div>
-    </div>
-  );
-};
+export { BottomModal };

--- a/src/lib/components/modal/bottomModal/style.module.scss
+++ b/src/lib/components/modal/bottomModal/style.module.scss
@@ -1,22 +1,5 @@
 @use '../../../scss/public/grid' as *;
-
-@keyframes fade-in {
-  0% {
-    background-color: rgba($color: #000000, $alpha: 0);
-  }
-  100% {
-    background-color: rgba($color: #000000, $alpha: 0.3);
-  }
-}
-
-@keyframes fade-out {
-  from {
-    background-color: rgba($color: #000000, $alpha: 0.3);
-  }
-  to {
-    background-color: rgba($color: #000000, $alpha: 0);
-  }
-}
+@use '../../../scss/public/colors' as *;
 
 @keyframes appear-in {
   0% {
@@ -41,78 +24,35 @@
   }
 }
 
-.close {
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
-}
-
-.closeIcon {
-  margin: 0;
-}
-
-.overlay {
-  position: fixed;
-
-  z-index: 100;
-
-  overflow: auto;
-
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-
-  animation: fade-in 0.3s both;
-
-  &--close {
-    @extend .overlay;
-    animation-delay: 0.1s;
-    animation: fade-out 0.3s both;
-  }
-}
-
 .wrapper {
   position: relative;
   top: 0;
-  width: 100%;
   overflow: hidden;
 }
 
 .container {
-  background-color: white;
-
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
 
-  width: 100%;
+  overflow: auto;
+  max-height: 90vh;
+  bottom: 0;
+  position: fixed;
+
+  @include p-size-mobile {
+    padding-bottom: 48px;
+  }
 
   animation-name: appear-in;
   animation-duration: 0.4s;
   animation-fill-mode: both;
-  animation-timing-function: ease-out;
+  animation-timing-function: ease-in;
 
-  &--close {
-    @extend .container;
+  &Close {
     animation-name: disappear-out;
     animation-duration: 0.4s;
     animation-delay: 0s;
     animation-fill-mode: both;
     animation-timing-function: ease-out;
-  }
-}
-
-.header {
-  height: 60px;
-
-  display: flex;
-  align-items: center;
-
-  padding: 0 16px;
-}
-
-.content {
-  @include p-size-mobile {
-    padding-bottom: 48px;
   }
 }

--- a/src/lib/components/modal/genericModal/index.tsx
+++ b/src/lib/components/modal/genericModal/index.tsx
@@ -1,0 +1,130 @@
+import { Props } from '..';
+import useOnClose from '../hooks/useOnClose';
+
+import styles from './style.module.scss';
+import classNamesUtil from 'classnames';
+import { Button } from '../../button';
+import { XIcon } from '../../icon';
+
+interface GenericModalProps extends Props {
+  classNames?: {
+    wrapper?: string | (({ isClosing }: { isClosing: boolean }) => string);
+    container?: string | (({ isClosing }: { isClosing: boolean }) => string);
+    overlay?: string;
+    header?: string;
+    closeButton?: string;
+    title?: string;
+    body?: string;
+    footer?: string;
+  };
+  titleSize?: 'small' | 'default';
+}
+
+export const GenericModal = ({
+  title,
+  isOpen,
+  children,
+  onClose,
+  classNames,
+  dismissible = true,
+  footer,
+  titleSize = 'default',
+}: GenericModalProps) => {
+  const {
+    isClosing,
+    handleContainerClick,
+    handleOnClose,
+    handleOnOverlayClick,
+  } = useOnClose(onClose, isOpen, dismissible);
+
+  return !isOpen ? null : (
+    <div
+      className={classNamesUtil(
+        classNames?.overlay,
+        styles.overlay, {
+          [styles.overlayClose]: isClosing,
+        }
+      )}
+      onClick={handleOnOverlayClick}
+    >
+      <div 
+        className={
+          typeof classNames?.wrapper === 'string' 
+            ? classNames?.wrapper 
+            : classNames?.wrapper?.({ isClosing })
+        }
+      >
+        <div
+          className={
+            typeof classNames?.container === 'string' 
+            ? classNames?.container 
+            : classNames?.container?.({ isClosing })
+          }
+          onClick={handleContainerClick}
+        >
+
+          <div
+            className={classNamesUtil(
+              'bg-white d-flex ai-center w100 px24 pt24 pb16',
+              styles.header, {
+                'jc-between': !!children,
+                'jc-end': !children,
+              }
+            )}
+          >
+            {title && (
+              <div
+                className={classNamesUtil(
+                  styles.title,
+                  titleSize === 'small' ? 'p-h4' : 'p-h2'
+                )}
+              >
+                {title}
+              </div>
+            )}
+          
+            {dismissible && (
+              <Button
+                hideLabel
+                leftIcon={<XIcon color="grey-700" />}
+                onClick={handleOnClose}
+                type="button"
+                variant="textColor"
+                className={classNamesUtil(
+                  classNames?.closeButton,
+                  'p0',
+                  styles.closeButton
+                )}
+              >
+                Close modal
+              </Button>
+            )}
+          </div>
+
+          <div
+            className={classNamesUtil(
+              classNames?.body,
+              styles.body
+            )}
+          >
+            {children}
+          </div>
+
+          {footer && (
+            <div
+              className={classNamesUtil(
+                classNames?.footer,
+                'bg-white',
+                styles.footer
+              )}
+            >
+              <div className="px24 py16">
+                {footer?.(handleOnClose)}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/components/modal/genericModal/index.tsx
+++ b/src/lib/components/modal/genericModal/index.tsx
@@ -32,12 +32,14 @@ export const GenericModal = ({
 }: GenericModalProps) => {
   const {
     isClosing,
+    isVisible,
     handleContainerClick,
+    handleOnCloseAnimationEnded,
     handleOnClose,
     handleOnOverlayClick,
   } = useOnClose(onClose, isOpen, dismissible);
 
-  return !isOpen ? null : (
+  return !isVisible ? null : (
     <div
       className={classNamesUtil(
         classNames?.overlay,
@@ -45,6 +47,7 @@ export const GenericModal = ({
           [styles.overlayClose]: isClosing,
         }
       )}
+      onAnimationEnd={handleOnCloseAnimationEnded}
       onClick={handleOnOverlayClick}
     >
       <div 
@@ -119,7 +122,7 @@ export const GenericModal = ({
               )}
             >
               <div className="px24 py16">
-                {footer?.(handleOnClose)}
+                {footer}
               </div>
             </div>
           )}

--- a/src/lib/components/modal/genericModal/style.module.scss
+++ b/src/lib/components/modal/genericModal/style.module.scss
@@ -1,0 +1,71 @@
+@use "../../../scss/public/colors" as *;
+
+@keyframes fade-in {
+  0% {
+    background-color: rgba($color: #000, $alpha: 0);
+    visibility: hidden;
+  }
+  100% {
+    background-color: rgba($color: #000, $alpha: 0.3);
+    visibility: visible;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    background-color: rgba($color: #000, $alpha: 0.3);
+    visibility: visible;
+  }
+  to {
+    background-color: rgba($color: #000, $alpha: 0);
+    visibility: hidden;
+  }
+}
+
+.overlay {
+  z-index: 100;
+  overflow: auto;
+  
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  animation: fade-in 0.3s both;
+
+  &Close {
+    animation-delay: 0.1s;
+    animation: fade-out 0.3s both;
+  }
+}
+
+.header {
+  position: sticky;
+  top: 0;
+}
+
+.closeButton {
+  width: 32px;
+  height: 32px;
+}
+
+.body {
+  flex-grow: 1;
+  overflow: auto;
+
+  background:
+    linear-gradient($ds-white 30%, $ds-white),
+    linear-gradient($ds-white, $ds-white 70%),
+    linear-gradient($ds-grey-300 30%, $ds-grey-300),
+    linear-gradient($ds-grey-300, $ds-grey-300 70%) 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 1px;
+  background-attachment: local, local, scroll, scroll;
+}
+
+.footer {
+  width: 100%;
+  position: sticky;
+  bottom: 0;
+}

--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 interface OnCloseReturn {
   isClosing: boolean;
+  isVisible: boolean;
+  handleOnCloseAnimationEnded: () => void;
   handleContainerClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   handleOnClose: () => void;
   handleOnOverlayClick: () => void;
@@ -12,15 +14,20 @@ const useOnClose = (
   isOpen: boolean,
   dismissable: boolean
 ): OnCloseReturn => {
+  const [isVisible, setIsVisible] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
   const handleOnClose = useCallback(() => {
     setIsClosing(true);
-    setTimeout(() => {
+  }, []);
+
+  const handleOnCloseAnimationEnded = useCallback(() => {
+    if (isVisible && isClosing) {
       onClose();
+      setIsVisible(false);
       setIsClosing(false);
-    }, 300);
-  }, [setIsClosing, onClose]);
+    }
+  }, [isClosing, isVisible, onClose]);
 
   const handleOnOverlayClick = useCallback(() => {
     if (!dismissable) {
@@ -50,12 +57,20 @@ const useOnClose = (
   }, [handleEscKey]);
 
   useEffect(() => {
+    if (isOpen) {
+      setIsVisible(true);
+    }
+    
+    if (!isOpen && isVisible){
+      handleOnClose();
+    }
+
     document.body.style.overflow = isOpen ? 'hidden' : 'auto';
 
     return () => {
       document.body.style.overflow = 'auto';
     };
-  }, [isOpen]);
+  }, [handleOnClose, isOpen, isVisible]);
 
   const handleContainerClick = (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>
@@ -63,7 +78,14 @@ const useOnClose = (
     e.stopPropagation();
   };
 
-  return { isClosing, handleContainerClick, handleOnClose, handleOnOverlayClick };
+  return {
+    isClosing,
+    isVisible,
+    handleContainerClick,
+    handleOnCloseAnimationEnded,
+    handleOnClose,
+    handleOnOverlayClick
+  };
 };
 
 export default useOnClose;

--- a/src/lib/components/modal/index.stories.tsx
+++ b/src/lib/components/modal/index.stories.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { BottomModal, BottomOrRegularModal, Props, RegularModal } from '.';
 import { Markdown } from '../markdown';
+import { Button } from '../button';
 
 const story = {
   title: 'JSX/Modals',
@@ -245,6 +246,100 @@ export const NonDismissibleModal = ({
           >
             Continue
           </button>
+        </div>
+      </BottomOrRegularModal>
+    </>
+  );
+}
+
+export const ModalWithFooter = ({
+  children,
+  isOpen,
+  onClose,
+  title,
+}: Props) => {
+  const [display, setDisplay] = useState(isOpen);
+  const handleOnClose = () => {
+    onClose();
+    setDisplay(false);
+  };
+
+  return (
+    <>
+      <button
+        className="p-btn--primary wmn2"
+        onClick={() => setDisplay(true)}
+      >
+        Click to open modal
+      </button>
+
+      <BottomOrRegularModal
+        title={title}
+        isOpen={display}
+        onClose={handleOnClose}
+        footer={(onClose) => (
+          <div className='d-flex fd-row gap8'>
+            <Button variant='textColor' className='w100' onClick={onClose}>
+              Skip
+            </Button>
+            <Button className='w100' onClick={onClose}>
+              Continue
+            </Button>
+          </div>
+        )}
+      >
+        <div className='p24'>
+          <div>
+            {children}
+          </div>
+        </div>
+      </BottomOrRegularModal>
+    </>
+  );
+}
+
+export const ModalWithFooterAndScroll = ({
+  children,
+  isOpen,
+  onClose,
+  title,
+}: Props) => {
+  const [display, setDisplay] = useState(isOpen);
+  const handleOnClose = () => {
+    onClose();
+    setDisplay(false);
+  };
+
+  return (
+    <>
+      <button
+        className="p-btn--primary wmn2"
+        onClick={() => setDisplay(true)}
+      >
+        Click to open modal
+      </button>
+
+      <BottomOrRegularModal
+        title={title}
+        isOpen={display}
+        onClose={handleOnClose}
+        footer={(onClose) => (
+          <div className='d-flex fd-row gap8'>
+            <Button variant='textColor' className='w100' onClick={onClose}>
+              Skip
+            </Button>
+            <Button className='w100' onClick={onClose}>
+              Continue
+            </Button>
+          </div>
+        )}
+      >
+        <div className='p24'>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            <div style={{ height: '840px' }} />
+            {children}
+          </div>
         </div>
       </BottomOrRegularModal>
     </>

--- a/src/lib/components/modal/index.stories.tsx
+++ b/src/lib/components/modal/index.stories.tsx
@@ -277,12 +277,12 @@ export const ModalWithFooter = ({
         title={title}
         isOpen={display}
         onClose={handleOnClose}
-        footer={(onClose) => (
+        footer={(
           <div className='d-flex fd-row gap8'>
-            <Button variant='textColor' className='w100' onClick={onClose}>
+            <Button variant='textColor' className='w100' onClick={handleOnClose}>
               Skip
             </Button>
-            <Button className='w100' onClick={onClose}>
+            <Button className='w100' onClick={handleOnClose}>
               Continue
             </Button>
           </div>
@@ -323,12 +323,12 @@ export const ModalWithFooterAndScroll = ({
         title={title}
         isOpen={display}
         onClose={handleOnClose}
-        footer={(onClose) => (
+        footer={(
           <div className='d-flex fd-row gap8'>
-            <Button variant='textColor' className='w100' onClick={onClose}>
+            <Button variant='textColor' className='w100' onClick={handleOnClose}>
               Skip
             </Button>
-            <Button className='w100' onClick={onClose}>
+            <Button className='w100' onClick={handleOnClose}>
               Continue
             </Button>
           </div>

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -9,6 +9,7 @@ export interface Props {
   onClose: () => void;
   className?: string;
   dismissible?: boolean;
+  footer?: (onClose: () => void) => React.ReactNode;
 }
 
 export { BottomModal, RegularModal, BottomOrRegularModal };

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -1,15 +1,16 @@
 import { BottomModal } from './bottomModal';
 import { RegularModal } from './regularModal';
 import { BottomOrRegularModal } from './bottomOrRegularModal';
+import { ReactNode } from 'react';
 
 export interface Props {
-  title?: string;
+  title?: ReactNode;
   isOpen: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
   onClose: () => void;
   className?: string;
   dismissible?: boolean;
-  footer?: (onClose: () => void) => React.ReactNode;
+  footer?: ReactNode;
 }
 
 export { BottomModal, RegularModal, BottomOrRegularModal };

--- a/src/lib/components/modal/regularModal/img/close.svg
+++ b/src/lib/components/modal/regularModal/img/close.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18 6L6 18" stroke="#26262E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-<path d="M6 6L18 18" stroke="#26262E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-</svg>

--- a/src/lib/components/modal/regularModal/index.tsx
+++ b/src/lib/components/modal/regularModal/index.tsx
@@ -1,66 +1,25 @@
-import React from 'react';
-
 import { Props } from '..';
-import useOnClose from '../hooks/useOnClose';
-
 import styles from './style.module.scss';
-import { XIcon } from '../../icon/icons';
 import classNames from 'classnames';
+import { GenericModal } from '../genericModal';
 
-export const RegularModal = ({
-  title,
-  isOpen,
-  children,
-  onClose,
-  className = '',
-  dismissible = true,
-}: Props) => {
-  const {
-    isClosing,
-    handleContainerClick,
-    handleOnClose,
-    handleOnOverlayClick,
-  } = useOnClose(onClose, isOpen, dismissible);
+const RegularModal = ({ className = '', ...rest }: Props) => (
+  <GenericModal
+    classNames={{
+      wrapper: ({ isClosing }) => classNames(
+        'd-flex ai-center w90 mx-auto my0',
+        className,
+        styles.wrapper, {
+          [styles.wrapperClose]: isClosing,
+        }
+      ),
+      container: classNames(
+        'bg-white br8 d-flex ai-center fd-column mx-auto my0 wmx8',
+        styles.container
+      )
+    }}
+    {...rest}
+  />
+);
 
-  if (!isOpen) {
-    return <></>;
-  }
-
-  return (
-    <div
-      className={isClosing ? styles['overlay--close'] : styles.overlay}
-      onClick={handleOnOverlayClick}
-    >
-      <div
-        className={`${
-          isClosing ? styles['container--close'] : styles.container
-        } ${className}`}
-      >
-        <div className={styles.body} onClick={handleContainerClick}>
-          <div
-            className={classNames(styles.header, {
-              'jc-between': !!title,
-              'jc-end': !title,
-            })}
-          >
-            {title && <div className={`p-h2 ${styles.title}`}>{title}</div>}
-            {dismissible && (
-              <button
-                type="button"
-                className={styles.close}
-                onClick={handleOnClose}
-              >
-                <XIcon
-                  size={24}
-                  color={'grey-700'}
-                  className={`${styles.closeIcon}`}
-                />
-              </button>
-            )}
-          </div>
-          {children}
-        </div>
-      </div>
-    </div>
-  );
-};
+export { RegularModal };

--- a/src/lib/components/modal/regularModal/style.module.scss
+++ b/src/lib/components/modal/regularModal/style.module.scss
@@ -1,24 +1,4 @@
-@keyframes fade-in {
-  0% {
-    background-color: rgba($color: #000000, $alpha: 0);
-    visibility: hidden;
-  }
-  100% {
-    background-color: rgba($color: #000000, $alpha: 0.3);
-    visibility: visible;
-  }
-}
-
-@keyframes fade-out {
-  from {
-    background-color: rgba($color: #000000, $alpha: 0.3);
-    visibility: visible;
-  }
-  to {
-    background-color: rgba($color: #000000, $alpha: 0);
-    visibility: hidden;
-  }
-}
+@use "../../../scss/public/colors" as *;
 
 @keyframes appear-in {
   0% {
@@ -46,46 +26,16 @@
   }
 }
 
-.overlay {
-  position: fixed;
-
-  z-index: 100;
-
-  overflow: auto;
-
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-
-  animation: fade-in 0.3s both;
-
-  &--close {
-    @extend .overlay;
-    animation-delay: 0.1s;
-    animation: fade-out 0.3s both;
-  }
-}
-
-.container {
+.wrapper {
   position: relative;
-
-  display: flex;
-  align-items: center;
-
-  max-width: 592px;
-  width: 100%;
   min-height: 100%;
-
-  margin: 0 auto;
 
   animation-name: appear-in;
   animation-duration: 0.4s;
   animation-fill-mode: both;
   animation-timing-function: ease-out;
 
-  &--close {
-    @extend .container;
+  &Close {
     animation-name: disappear-out;
     animation-duration: 0.4s;
     animation-delay: 0s;
@@ -94,25 +44,7 @@
   }
 }
 
-.body {
-  background-color: white;
-  border-radius: 8px;
-  margin: 80px auto;
-}
-
-.header {
-  display: flex;
-  align-items: center;
-
-  padding: 24px 24px 0 24px;
-}
-
-.close {
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
-}
-
-.closeIcon {
-  margin: 0;
+.container {
+  max-height: 96vh;
+  overflow: hidden;
 }


### PR DESCRIPTION
### What this PR does
Refactors and cleans the modals that now:
- have a `footer` prop to add a fixed footer
- reorganised and share most of the code between regular and bottom modal
- removed lots of duplicated code by the doing the above one
- modal body is now scrollable and not the whole modal
- header and footer are sticky with the bottom border of the modal header only showing on scroll
- all styling is now done using CSS instead of JS.

### How to test?
<img width="789" alt="Screenshot 2024-06-20 at 12 47 17" src="https://github.com/getPopsure/dirty-swan/assets/4015038/bdde3015-0b31-434d-bc40-2a0deeb4ea45">
<img width="636" alt="Screenshot 2024-06-20 at 12 47 22" src="https://github.com/getPopsure/dirty-swan/assets/4015038/e6e53edc-c70c-4a03-9523-355e6bffe898">
<img width="518" alt="Screenshot 2024-06-20 at 12 47 46" src="https://github.com/getPopsure/dirty-swan/assets/4015038/4f9069ca-dd9d-4ffb-95a9-96ed5ecf9176">


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
