### PR TITLE
fix(modal): Add modal fixes

### DIFF
--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -15,6 +15,7 @@ const BottomModal = ({ className, ...rest }: Props) => (
           [styles.containerClose]: isClosing, 
         }
       ),
+      body: styles.body,
     }}
     {...rest}
   />

--- a/src/lib/components/modal/bottomModal/style.module.scss
+++ b/src/lib/components/modal/bottomModal/style.module.scss
@@ -39,10 +39,6 @@
   bottom: 0;
   position: fixed;
 
-  @include p-size-mobile {
-    padding-bottom: 48px;
-  }
-
   animation-name: appear-in;
   animation-duration: 0.4s;
   animation-fill-mode: both;
@@ -54,5 +50,11 @@
     animation-delay: 0s;
     animation-fill-mode: both;
     animation-timing-function: ease-out;
+  }
+}
+
+.body {
+  @include p-size-mobile {
+    padding-bottom: 48px;
   }
 }

--- a/src/lib/components/modal/genericModal/index.tsx
+++ b/src/lib/components/modal/genericModal/index.tsx
@@ -70,8 +70,8 @@ export const GenericModal = ({
             className={classNamesUtil(
               'bg-white d-flex ai-center w100 px24 pt24 pb16',
               styles.header, {
-                'jc-between': !!children,
-                'jc-end': !children,
+                'jc-between': !!title,
+                'jc-end': !title,
               }
             )}
           >
@@ -117,7 +117,7 @@ export const GenericModal = ({
             <div
               className={classNamesUtil(
                 classNames?.footer,
-                'bg-white',
+                'w100 bg-white',
                 styles.footer
               )}
             >

--- a/src/lib/components/modal/genericModal/style.module.scss
+++ b/src/lib/components/modal/genericModal/style.module.scss
@@ -58,14 +58,14 @@
     linear-gradient($ds-white 30%, $ds-white),
     linear-gradient($ds-white, $ds-white 70%),
     linear-gradient($ds-grey-300 30%, $ds-grey-300),
-    linear-gradient($ds-grey-300, $ds-grey-300 70%) 0 100%;
+    linear-gradient($ds-grey-300, $ds-grey-300 70%);
   background-repeat: no-repeat;
   background-size: 100% 1px;
   background-attachment: local, local, scroll, scroll;
 }
 
 .footer {
-  width: 100%;
   position: sticky;
   bottom: 0;
+  border-top: 1px solid $ds-grey-300;
 }


### PR DESCRIPTION
### What this PR does
This PR adds fixes to the below modal issues:
- Close button aligning to the left if there is no title
- BottomModal padding bottom needs to be applied to body, not container
- Footer border was showing even if there was no footer

<img width="406" alt="Screenshot 2024-06-21 at 11 28 14" src="https://github.com/getPopsure/dirty-swan/assets/4015038/76ae8d3e-bafd-4729-9ef7-40e91118b3b5">
<img width="405" alt="Screenshot 2024-06-21 at 11 28 30" src="https://github.com/getPopsure/dirty-swan/assets/4015038/9349d09a-d2f5-41e9-92a0-526c16b6a594">


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
