### PR TITLE
fix(modal): Update Modal close button styles

### DIFF
--- a/src/lib/components/modal/genericModal/style.module.scss
+++ b/src/lib/components/modal/genericModal/style.module.scss
@@ -48,6 +48,7 @@
 .closeButton {
   width: 32px;
   height: 32px;
+  padding: 0;
 }
 
 .body {


### PR DESCRIPTION
### What this PR does
Update Modal close button styles to not have any padding.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
