### PR TITLE
ci(deploy): Remove hardcoded v16 node version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,9 +17,6 @@ jobs:
 
       - name: Install NodeJS
         uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
### What this PR does
This PR removes the hardcoded v16 node version that is now not supported by storybook anymore.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
