### PR TITLE
ci(deploy): Upgrade to use github-actions-storybook-to-github-pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,13 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install NodeJS
-        uses: actions/setup-node@v3
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Deploy storybook to GitHub Pages
-        run: yarn deploy-storybook -- --ci
-        env:
-          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+      - uses: bitovi/github-actions-storybook-to-github-pages@v1.2.4
+        with:
+          install_command: yarn install
+          build_command: yarn build-storybook
+          path: storybook-static

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "test": "jest",
     "test:ci": "CI=true jest",
     "build-storybook": "storybook build",
-    "deploy-storybook": "storybook-to-ghpages",
     "generate-icons": "svgr src/lib/components/icon/assets"
   },
   "eslintConfig": {


### PR DESCRIPTION
### What this PR does
Replaces `storybook-to-ghpages` with `github-actions-storybook-to-github-pages` for deploying storybook to GH pages.

### Why is this needed?
`storybook-to-ghpages` is now deprecated and doesn't work with storybook v8+.
### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
