### PR TITLE
ci(deploy): Add correct permissions to deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,8 @@ jobs:
 
     permissions:
       contents: write
+      pages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
### What this PR does
Add correct permissions according to package documentation:
https://github.com/bitovi/github-actions-storybook-to-github-pages