### PR TITLE
fix(comparisonTable): [NoTicket] Use old workaround again and remove scroll

### DIFF
--- a/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
+++ b/src/lib/components/comparisonTable/hooks/useComparisonTable.ts
@@ -1,6 +1,6 @@
 import debounce from 'lodash.debounce';
 import { useCallback, useEffect, useRef, useState } from 'react';
-
+import generateId from '../../../util/generateId';
 import { ArrowValues } from '../components/TableArrows';
 
 export const useComparisonTable = ({
@@ -12,12 +12,12 @@ export const useComparisonTable = ({
   const [headerWidth, setHeaderWidth] = useState(1400);
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [selectedSection, setSelectedSection] = useState('');
-
+  const [headerId, setHeaderId] = useState('');
   const headerRef = useRef<HTMLDivElement | null>(null);
   const contentContainerRef = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
 
-  const scrollContainerCallbackRef = useCallback((node) => {
+  const headerRefCallbackRef = useCallback((node) => {
     if (node) {
       setHeaderWidth(node.clientWidth);
     }
@@ -112,17 +112,24 @@ export const useComparisonTable = ({
   };
 
   const toggleMoreRows = async () => {
-    if (showMore && headerRef.current && contentContainerRef.current) {
-      window.scroll(
-        0,
-        window.scrollY +
-          (contentContainerRef.current.getBoundingClientRect().y -
-            headerRef.current.getBoundingClientRect().bottom)
-      );
-    }
-
     setShowMore(!showMore);
   };
+
+  useEffect(() => {
+    if (headerRef.current) {
+      return;
+    }
+
+    const headerById = document.getElementById(headerId);
+
+    if (headerById) {
+      headerRefCallbackRef(headerById);
+    }
+  }, [headerId, headerRefCallbackRef]);
+
+  useEffect(() => {
+    setHeaderId(generateId());
+  }, []);
 
   useEffect(() => {
     onSelectionChanged?.(selectedTabIndex);
@@ -131,12 +138,13 @@ export const useComparisonTable = ({
 
   return {
     headerWidth,
+    headerId,
     contentContainerRef,
     selectedSection,
     setSelectedSection,
     selectedTabIndex,
     setSelectedTabIndex,
-    scrollContainerCallbackRef,
+    headerRefCallbackRef,
     handleArrowsClick,
     toggleMoreRows,
     showMore,

--- a/src/lib/components/comparisonTable/index.mdx
+++ b/src/lib/components/comparisonTable/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta } from '@storybook/blocks';
+import { Canvas, Meta, Unstyled } from '@storybook/blocks';
 
 import { CardButton } from '../cards';
 
@@ -16,13 +16,18 @@ import {
 
 The Comparison Table component provides an easy way to compare vast amounts of information in a fast and easy way.
 
-<iframe width="100%" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FMKs4cbojdVOBKUxv7okb93%2FDirty-Swan-Design-System%3Fnode-id%3D2025%253A12194" allowFullScreen />
+<iframe
+  width="100%"
+  height="450"
+  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FMKs4cbojdVOBKUxv7okb93%2FDirty-Swan-Design-System%3Fnode-id%3D2025%253A12194"
+  allowFullScreen
+/>
 
 ## Arguments
 
 | attribute             | unit                                      | description                                                         | default value  | required |
 | --------------------- | ----------------------------------------- | ------------------------------------------------------------------- | -------------- | -------- |
-| headers               | [Header\[\]](#header)                       | The structure of the table                                          | n/a            | true     |
+| headers               | [Header\[\]](#header)                     | The structure of the table                                          | n/a            | true     |
 | data                  | array                                     | The title text that needs to be displayed                           | n/a            | true     |
 | hideDetails           | boolean                                   | Hide table groups that do not have the `default` attribute          | false          | false    |
 | hideDetailsCaption    | string                                    | Caption of the button to hide the details                           | 'Hide details' | false    |
@@ -309,7 +314,9 @@ export const ComparisonTableWithData = () => {
   );
 };
 
-<ComparisonTableWithData />
+<Unstyled>
+  <ComparisonTableWithData />
+</Unstyled>
 
 ```typescript jsx
 import ComparisonTable, {

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -92,11 +92,12 @@ const ComparisonTable = <T extends { id: number }>(
 
   const {
     headerWidth,
+    headerId,
     contentContainerRef,
     selectedSection,
     setSelectedSection,
     selectedTabIndex,
-    scrollContainerCallbackRef,
+    headerRefCallbackRef,
     handleArrowsClick,
     toggleMoreRows,
     showMore,
@@ -115,7 +116,7 @@ const ComparisonTable = <T extends { id: number }>(
   } as React.CSSProperties;
 
   return (
-    <ScrollSync>
+    <ScrollSync onSync={headerRefCallbackRef}>
       <div
         style={cssVariablesStyle}
         className={classNames({
@@ -124,9 +125,10 @@ const ComparisonTable = <T extends { id: number }>(
         })}
       >
         <div
+          id={headerId}
           className={classNames(baseStyles.header, classNameOverrides?.header)}
         >
-          <ScrollSyncPane innerRef={scrollContainerCallbackRef}>
+          <ScrollSyncPane>
             <div className={classNames(baseStyles.container)}>
               <div className={classNames(baseStyles['overflow-container'])}>
                 <div className={baseStyles['group-container']}>


### PR DESCRIPTION
### What this PR does

This PR reverts back to the old workaround that had a bug when you opened and then closed via "Hide details" button where the TableArrows stopped working.

To get rid of the error the forced scroll on the closing the details was removed.

### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
STO-XXX
EMU-XXX
RVN-XXX

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
