### PR TITLE
fix(accordion): Update accordion item styles

### DIFF
--- a/src/lib/components/accordion/index.tsx
+++ b/src/lib/components/accordion/index.tsx
@@ -94,14 +94,16 @@ const Accordion = ({
                   'tc-grey-700',
                 ),
                 buttonWrapper: classnamesUtil(
+                  'py8 my8',
                   classNames?.buttonWrapper,
                   styles.buttonWrapper, {
-                    [styles.buttonWrapperDefault]: isDefaultVariant
+                    [styles.buttonWrapperDefault]: isDefaultVariant,
+                    [styles.buttonWrapperOpen]: isOpen
                   },
                 ),
                 wrapper: classnamesUtil(
                   classNames?.wrapper,
-                  'bg-transparent br0 px8 py8',
+                'bg-transparent br0 py0',
                   { 'pl0': isDefaultVariant },
                 ),
                 title: classnamesUtil(
@@ -133,8 +135,12 @@ const Accordion = ({
               <div 
                 className={classnamesUtil(
                   classNames?.answer,
-                  'tc-grey-600 pr16 pb16', 
-                  { 'pl16': !isDefaultVariant },
+                  'tc-grey-600 pr16 pb24', 
+                  { 
+                    'pl16': !isDefaultVariant,
+                    [styles?.answerIcon]: !isDefaultVariant && icon,
+                    [styles?.answerIconDefault]: isDefaultVariant && icon,
+                  },
                 )}
               >
                   {answer}

--- a/src/lib/components/accordion/style.module.scss
+++ b/src/lib/components/accordion/style.module.scss
@@ -25,17 +25,27 @@
   }
 }
 
+.answer {
+  &Icon {
+    padding-left: 20px;
+  }
+  
+  &IconDefault {
+    padding-left: 4px;
+  }
+}
+
 .buttonWrapper {
   background-color: transparent!important;
   color: $ds-primary-500;
-  margin-top: 8px;
-  margin-bottom: 8px;
   outline-offset: -4px;
 
   &Default {
-    margin-top: 12px;
-    margin-bottom: 12px;
-    outline-offset: -2px;
+    outline-offset: 0;
+  }
+
+  &Open {
+    margin-bottom: 4px !important;
   }
 
   &:hover,


### PR DESCRIPTION
### What this PR does
This PR makes minor accordion adjustments to styles after syncing with design.

### How to test?
Run storybook and [visit Accordion story](http://localhost:9009/?path=/docs/jsx-accordion--docs)


**Before:**
<img width="563" alt="Screenshot 2024-06-24 at 16 02 37" src="https://github.com/getPopsure/dirty-swan/assets/4015038/18140252-5e00-454d-bcad-9e1673e0f834">
<img width="567" alt="Screenshot 2024-06-24 at 16 02 45" src="https://github.com/getPopsure/dirty-swan/assets/4015038/5be5f7ff-3a35-447b-a7f2-8155cd4b48aa">


**After:**
<img width="574" alt="Screenshot 2024-06-24 at 16 01 11" src="https://github.com/getPopsure/dirty-swan/assets/4015038/478c4c86-092e-44b7-bc8c-e91fac407f38">
<img width="568" alt="Screenshot 2024-06-24 at 16 01 00" src="https://github.com/getPopsure/dirty-swan/assets/4015038/c7c2701e-9668-46e2-b948-2b3f73004106">

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
