### PR TITLE
fix(card): Add missing border-radius on Card

### DIFF
--- a/src/lib/components/cards/card/index.tsx
+++ b/src/lib/components/cards/card/index.tsx
@@ -81,7 +81,7 @@ const Card = <E extends ElementType = CardDefaultAsType>({
     >
       <div
         className={classNamesUtil(
-          'd-flex fd-column jc-center w100 ta-left',
+          'd-flex fd-column jc-center w100 ta-left br8',
           { 'bs-sm': dropShadow },
           {
             compact: 'p16',


### PR DESCRIPTION
### What this PR does
This PR adds the missing border-radius on Card component.

### How to test?
Run storybook and visit [Card story](http://localhost:9009/?path=/docs/jsx-cards-card--docs).


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
