### PR TITLE
refactor(modal): Increase modal z-index value

### DIFF
--- a/src/lib/components/modal/genericModal/style.module.scss
+++ b/src/lib/components/modal/genericModal/style.module.scss
@@ -23,7 +23,7 @@
 }
 
 .overlay {
-  z-index: 100;
+  z-index: 1000;
   overflow: auto;
   
   position: fixed;


### PR DESCRIPTION
### What this PR does
 Increase modal z-index value to 1000 to make sure it is above other UI elements.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
