### PR TITLE
refactor(comparison-table): [SIDE-179] Make hideScrollBarsMobile prop default to true

### DIFF
--- a/src/lib/components/comparisonTable/index.stories.tsx
+++ b/src/lib/components/comparisonTable/index.stories.tsx
@@ -277,7 +277,7 @@ const story = {
     hideDetailsCaption: 'Hide details',
     showDetailsCaption: 'Show details',
     hideScrollBars: false,
-    hideScrollBarsMobile: false,
+    hideScrollBarsMobile: true,
     collapsibleSections: false,
     cellWidth: undefined,
     firstColumnWidth: undefined,

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -81,7 +81,7 @@ const ComparisonTable = <T extends { id: number }>(
     showDetailsCaption = 'Show details',
     classNameOverrides,
     hideScrollBars,
-    hideScrollBarsMobile,
+    hideScrollBarsMobile = true,
     collapsibleSections,
     cellWidth,
     firstColumnWidth,


### PR DESCRIPTION
### What this PR does
This PR updates the `ComparisonTable` to have the `hideScrollBarsMobile` default to true.

Solves:
SIDE-179

**Before:**
<img width="385" alt="Screenshot 2024-06-28 at 15 13 09" src="https://github.com/getPopsure/dirty-swan/assets/4015038/eb248b14-d4e8-4a30-a1d0-60ace08d7c43">


**After:**
<img width="395" alt="Screenshot 2024-06-28 at 15 12 55" src="https://github.com/getPopsure/dirty-swan/assets/4015038/db3602ca-c43f-4734-8fe8-b5ff3591b726">


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
