### PR TITLE
feat(card): [SIDE-384] update InfoCard heading tag

### DIFF
--- a/src/lib/components/cards/infoCard/index.tsx
+++ b/src/lib/components/cards/infoCard/index.tsx
@@ -42,7 +42,7 @@ export const InfoCard = ({
           alt={rightIcon === 'info' ? info.alt : rightIcon.alt}
         />
       )}
-      <div className="p-h4 ta-center mt64">{title}</div>
+      <h3 className="p-h4 ta-center mt64">{title}</h3>
       <div className="p-p mt16 tc-grey-600">{children}</div>
     </div>
   </div>


### PR DESCRIPTION
### What this PR does

Sets the title tag of the `InfoCard` component to `h3` instead of `div`. 

### Why is this needed?

- We're updating our website LP heading hierarchy for SEO reasons ([ticket](https://linear.app/feather-insurance/issue/SIDE-384/update-heading-tag-in-infocard-component) - [Figma](https://www.figma.com/design/5NkA1vw4SULFB8DciXBqaU/Untitled?node-id=0-6081&t=YhzBgNPtryiPUK4U-0))
- In the `Card` component the title is already set as h3. 

Solves:
[SIDE-384](https://linear.app/feather-insurance/issue/SIDE-384/update-heading-tag-in-infocard-component)

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge
