### PR TITLE
fix(table): Styling fixes to Table buttons

### DIFF
--- a/src/lib/components/table/components/TableCell/TableCell.module.scss
+++ b/src/lib/components/table/components/TableCell/TableCell.module.scss
@@ -5,6 +5,7 @@
   min-height: initial;
   height: initial;
   width: initial;
+  padding: 0;
 }
 
 .icon {

--- a/src/lib/components/table/components/TableControls/TableControls.module.scss
+++ b/src/lib/components/table/components/TableControls/TableControls.module.scss
@@ -5,11 +5,12 @@
   left: 0;
   right: 0;
   min-height: 72px;
-  z-index: 3;
+  z-index: 9;
 }
 
 .controlButton {
   border-radius: 50%!important;
   width: 32px;
   height: 32px;
+  padding: 0;
 }


### PR DESCRIPTION
### What this PR does
Styling fixes to Table buttons:
- Fixes button paddings
- Increases zIndex to mobile sticky header

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
