### PR TITLE
fix(table): Fix useTableNavigation hook

### DIFF
--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -60,7 +60,6 @@ const Table = ({
   const { activeSection, navigateTable } = useTableNavigation({
     enabled: isMobile,
     containerRef,
-    columnsLength,
     onSelectionChanged,
   });
 

--- a/src/lib/components/table/components/TableCell/TableCell.test.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.test.tsx
@@ -1,25 +1,39 @@
 import { render, screen } from '../../../../util/testUtils';
-import { TableCell } from './TableCell';
+import { TableCell, TableCellProps } from './TableCell';
 
 const openModal = jest.fn();
 
+const setup = ({ isNavigation, ...rest }: TableCellProps = {}) => render(
+  isNavigation 
+    ? <TableCell {...rest} isNavigation />
+    : (
+      <table>
+        <tbody>
+          <tr>
+            <TableCell {...rest} />
+          </tr>
+        </tbody>
+      </table>  
+    )
+  );
+
 describe('TableCell', () => {
   it('renders the component with boolean true', () => {
-    render(<TableCell checkmarkValue={true} />);
+    setup({ checkmarkValue: true });
 
     expect(screen.getByTitle('Yes')).toBeInTheDocument();
     expect(screen.getByTestId('table-cell-boolean-yes')).toBeInTheDocument();
   });
 
   it('renders the component with boolean false', () => {
-    render(<TableCell checkmarkValue={false} />);
+    setup({ checkmarkValue: false });
 
     expect(screen.getByTitle('No')).toBeInTheDocument();
     expect(screen.getByTestId('table-cell-boolean-no')).toBeInTheDocument();
   });
 
   it('renders the component without boolean', () => {
-    render(<TableCell />);
+    setup();
 
     expect(screen.queryByTitle('Yes')).not.toBeInTheDocument();
     expect(screen.queryByTitle('No')).not.toBeInTheDocument();
@@ -32,39 +46,37 @@ describe('TableCell', () => {
   });
 
   it('renders the component with rating', () => {
-    render(<TableCell rating={{ type: 'star', value: 2 }} />);
+    setup({ rating: { type: 'star', value: 2 } });
 
     expect(screen.getByTitle('2 out of 3')).toBeInTheDocument();
   });
 
   it('renders the component without rating', () => {
-    render(<TableCell />);
+    setup();
 
     expect(screen.queryByTestId('table-cell-rating')).not.toBeInTheDocument();
   });
 
   it('renders the component with text', () => {
-    render(<TableCell content="Sample text" />);
+    setup({ content: "Sample text" });
 
     expect(screen.getByText('Sample text')).toBeInTheDocument();
   });
 
   it('renders the component without text', () => {
-    render(<TableCell />);
+    setup();
 
     expect(screen.queryByTestId('table-cell-text')).not.toBeInTheDocument();
   });
 
   it('renders the component without info', () => {
-    render(<TableCell />);
+    setup();
 
     expect(screen.queryByText('View more info')).not.toBeInTheDocument();
   });
 
   it('calls openModal when info button is clicked', () => {
-    render(
-      <TableCell modalContent="Additional information" openModal={openModal} />
-    );
+    setup({ modalContent: "Additional information", openModal });
 
     // Click info button
     screen.getByText('View more info').click();

--- a/src/lib/components/table/utils/useTableNavigation/useTableNavigation.test.tsx
+++ b/src/lib/components/table/utils/useTableNavigation/useTableNavigation.test.tsx
@@ -11,7 +11,6 @@ const defaultContainerRef = {
 } as unknown as RefObject<HTMLElement>;
 
 describe('useTableNavigation', () => {
-  const columnsLength = 4;
   let onSelectionChanged = jest.fn();
   let containerRef = defaultContainerRef;
 
@@ -25,7 +24,6 @@ describe('useTableNavigation', () => {
       useTableNavigation({
         enabled: false,
         containerRef,
-        columnsLength,
         onSelectionChanged,
       })
     );
@@ -44,7 +42,6 @@ describe('useTableNavigation', () => {
       useTableNavigation({
         enabled: true,
         containerRef,
-        columnsLength,
         onSelectionChanged,
       })
     );
@@ -67,7 +64,6 @@ describe('useTableNavigation', () => {
       useTableNavigation({
         enabled: true,
         containerRef,
-        columnsLength,
         onSelectionChanged,
       })
     );

--- a/src/lib/components/table/utils/useTableNavigation/useTableNavigation.ts
+++ b/src/lib/components/table/utils/useTableNavigation/useTableNavigation.ts
@@ -8,7 +8,6 @@ interface UseTableNavigationReturn {
 
 interface UseTableNavigationProps {
   containerRef: React.RefObject<HTMLElement>,
-  columnsLength: number,
   enabled?: boolean,
   onSelectionChanged?: (index: number) => void
 }
@@ -16,22 +15,18 @@ interface UseTableNavigationProps {
 export const useTableNavigation = ({
   enabled,
   containerRef,
-  columnsLength,
   onSelectionChanged
 }: UseTableNavigationProps): UseTableNavigationReturn => {
-  const [activeSection, setActiveSection] = useState(1);
-  const [isIncrease, setIsIncrease] = useState<boolean>();
+  const [activeSection, setActiveSection] = useState(0);
 
   const handleScrollToSection = (increase?: boolean) => {
     if (!enabled) {
       return;
     }
 
-    setActiveSection((prevSection) => {
-      setIsIncrease(!!increase);
-
-      return prevSection + (increase ? 1 : -1);
-    });
+    setActiveSection((prevSection) => 
+      prevSection + (increase ? 1 : -1)
+    );
   };
 
   const handleTableScroll = useCallback(() => {
@@ -39,14 +34,12 @@ export const useTableNavigation = ({
       return;
     }
 
-    const scrollLeft = containerRef.current.scrollLeft;
     const containerWidth = containerRef.current.getBoundingClientRect().width;
-    const cellWidth = containerWidth / (columnsLength  - 1);
-    const newValue = Math.floor(scrollLeft / cellWidth * 0.8) + 1;
+    const scrollLeft = containerRef.current.scrollLeft;
+    const cellWidth = containerWidth / 2;
 
-    setIsIncrease(newValue > activeSection);
-    setActiveSection(newValue);
-   }, [activeSection, columnsLength, containerRef, enabled]);
+    setActiveSection(Math.floor(scrollLeft / cellWidth));
+   }, [activeSection, containerRef, enabled]);
 
   const debouncedTableScroll = debounce(handleTableScroll, 150);
 
@@ -61,26 +54,26 @@ export const useTableNavigation = ({
   }, [enabled]);
 
   useEffect(() => {
-    if (!enabled || typeof isIncrease === 'undefined') {
+    if (!enabled) {
       return
     }
 
-    onSelectionChanged?.(activeSection);
+    onSelectionChanged?.(activeSection + 1);
 
     if (containerRef.current) {
       const containerWidth = containerRef.current.getBoundingClientRect().width;
-      const cellWidth = containerWidth / columnsLength;
+      const cellWidth = containerWidth / 2;
 
       containerRef.current.scroll({
         top: 0,
-        left: (cellWidth * activeSection) * (isIncrease ? 1.2 : 0.8),
+        left: cellWidth * activeSection,
         behavior: 'smooth',
       });
     }
   }, [enabled, activeSection]);
 
   return {
-    activeSection,
+    activeSection: activeSection + 1,
     navigateTable: handleScrollToSection,
   }
 }


### PR DESCRIPTION
### What this PR does
This PR fixes the `useTableNavigation` hook and cleans warning messages from table test files.
Shortly, width of a cell is container width divided by two (because we're forcing the cell to be 50% of the screen) instead of containerWidth divided by the amount of columns.


### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
