### PR TITLE
refactor(table): [NoTicket] Rename fields again

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -1,69 +1,95 @@
 import { Table, TableProps } from './Table';
 import { DentalPlusIcon, PlaneIcon } from '../icon';
-import { TableData } from './types';
+import { TableCellData, TableData } from './types';
 
 const initialData: TableData = [
   {
     rows: [
       [
-        { content: 'Our plans' },
+        { text: 'Our plans' },
         {
           type: 'CTA',
-          content: 'Standard',
-          subContent: '€234',
+          title: 'Standard',
+          price: '€234',
+          buttonCaption: 'Get covered',
           href: 'http://example.com',
         },
         {
           type: 'CTA',
-          content: 'Plus',
-          subContent: '€344',
+          title: 'Plus',
+          price: '€344',
+          buttonCaption: 'Get covered',
           href: 'http://example.com',
         },
         {
           type: 'CTA',
-          content: 'Premium',
-          subContent: '€556',
+          title: 'Premium',
+          price: '€556',
+          buttonCaption: 'Get covered',
           href: 'http://example.com',
         },
       ],
       [
-        { content: 'Select a plan' },
+        { text: 'Select a plan' },
         {
           type: 'BUTTON',
-          content: 'Standard',
-          subContent: '€234',
+          buttonCaption: 'Standard',
+          price: '€234',
           onClick: () => {},
         },
         {
           type: 'BUTTON',
-          content: 'Plus',
-          subContent: '€344',
+          buttonCaption: 'Plus',
+          price: '€344',
           onClick: () => {},
         },
         {
           type: 'BUTTON',
-          content: 'Premium',
-          subContent: '€556',
+          buttonCaption: 'Premium',
+          price: '€556',
           onClick: () => {},
         },
       ],
       [
         {
-          content: 'Regular vet visits & medication',
-          subContent: 'Annual Only',
+          text: 'Your contribution',
         },
-        { content: 'No', subContent: 'Annual Only' },
-        { content: '50%' },
-        { content: '80%-100%' },
+        {
+          text: '€210',
+          description: 'per month',
+          fontVariant: 'PRICE',
+          modalContent: 'Price info',
+        },
+        {
+          text: '€275',
+          description: 'per month',
+          fontVariant: 'PRICE',
+          modalContent: 'Price info',
+        },
+        {
+          text: '€310',
+          description: 'per month',
+          fontVariant: 'PRICE',
+          modalContent: 'Price info',
+        },
       ],
       [
-        { content: 'Operations', modalContent: 'Operations info' },
+        {
+          text: 'Regular vet visits & medication',
+          description: 'Annual Only',
+        },
+        { text: 'No', description: 'Annual Only' },
+        { text: '50%' },
+        { text: '80%-100%' },
+      ],
+      [
+        { text: 'Operations', modalContent: 'Operations info' },
         { checkmarkValue: true, modalContent: 'Operations info column 2' },
         { checkmarkValue: false },
         { checkmarkValue: true },
       ],
       [
-        { content: 'Rating', modalContent: 'Rating info' },
+        { text: 'Rating', modalContent: 'Rating info' },
         { rating: { type: 'zap', value: 1 } },
         {
           rating: { type: 'zap', value: 3 },
@@ -80,19 +106,19 @@ const initialData: TableData = [
     },
     rows: [
       [
-        { content: 'Regular vet visits & medication' },
-        { content: 'No' },
-        { content: 'Yes' },
-        { content: 'Yes' },
+        { text: 'Regular vet visits & medication' },
+        { text: 'No' },
+        { text: 'Yes' },
+        { text: 'Yes' },
       ],
       [
-        { content: 'Operations', modalContent: 'info' },
+        { text: 'Operations', modalContent: 'info' },
         { checkmarkValue: true, modalContent: 'Maybe' },
         { checkmarkValue: false },
         { checkmarkValue: true },
       ],
       [
-        { content: 'Rating', modalContent: 'info' },
+        { text: 'Rating', modalContent: 'info' },
         { rating: { type: 'zap', value: 1 }, modalContent: 'Maybe' },
         { rating: { type: 'zap', value: 3 } },
         { rating: { type: 'star', value: 3 } },
@@ -106,19 +132,19 @@ const initialData: TableData = [
     },
     rows: [
       [
-        { content: 'Regular vet visits & medication' },
-        { content: 'No', checkmarkValue: false },
-        { content: 'Yes' },
-        { content: 'Yes' },
+        { text: 'Regular vet visits & medication' },
+        { text: 'No', checkmarkValue: false },
+        { text: 'Yes' },
+        { text: 'Yes' },
       ],
       [
-        { content: 'Operations', modalContent: 'info' },
+        { text: 'Operations', modalContent: 'info' },
         { checkmarkValue: true, modalContent: 'Maybe' },
         { checkmarkValue: false },
         { checkmarkValue: true },
       ],
       [
-        { content: 'Rating', modalContent: 'info' },
+        { text: 'Rating', modalContent: 'info' },
         { rating: { type: 'zap', value: 1 }, modalContent: 'Maybe' },
         { rating: { type: 'zap', value: 3 } },
         { rating: { type: 'star', value: 3 } },
@@ -216,7 +242,7 @@ type TableData = {
   rows: {
     align?: 'center' | 'left' | 'right';
     checkmarkValue?: boolean;
-    content?: ReactNode;
+    text?: ReactNode;
     modalContent?: ReactNode;
     subContent?: ReactNode;
     rating?: {

--- a/src/lib/components/table/Table.test.tsx
+++ b/src/lib/components/table/Table.test.tsx
@@ -8,7 +8,7 @@ const tableData: TableSectionData[] = [
       title: 'Section 1',
       icon: <span>Icon 1</span>,
     },
-    rows: [[{ content: 'Item 1' }, { content: 'Item 2' }]],
+    rows: [[{ text: 'Item 1' }, { text: 'Item 2' }]],
   },
   {
     section: {
@@ -16,10 +16,7 @@ const tableData: TableSectionData[] = [
       icon: <span>Icon 2</span>,
     },
     rows: [
-      [
-        { content: 'Item 3' },
-        { content: 'Item 4', modalContent: 'Additional item' },
-      ],
+      [{ text: 'Item 3' }, { text: 'Item 4', modalContent: 'Additional item' }],
     ],
   },
 ];

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -12,7 +12,7 @@ import { useTableNavigation } from './utils/useTableNavigation/useTableNavigatio
 import { TableControls } from './components/TableControls/TableControls';
 import { TableSection } from './components/TableSection/TableSection';
 import { useScrollSync } from './utils/useScrollSync/useScrollSync';
-import { ModalData, ModalFunction, TableData } from './types';
+import { isBaseCell, ModalData, ModalFunction, TableData } from './types';
 
 type TextOverrides = {
   showDetails?: string;
@@ -70,17 +70,6 @@ const Table = ({
     setInfoModalData({ body, title });
   };
 
-  const isBaseCell = !currentActiveSection.type;
-  let openModal;
-
-  if (isBaseCell) {
-    openModal = (body: ReactNode) =>
-      handleOpenModal({
-        body,
-        title: currentActiveSection?.content,
-      });
-  }
-
   return (
     <div className={classNames(styles.wrapper, 'bg-white')}>
       {isMobile ? (
@@ -92,9 +81,13 @@ const Table = ({
         >
           <TableCell
             {...currentActiveSection}
-            {...(isBaseCell
+            {...(isBaseCell(currentActiveSection)
               ? {
-                  openModal,
+                  openModal: (body: ReactNode) =>
+                    handleOpenModal({
+                      body,
+                      title: currentActiveSection?.text,
+                    }),
                 }
               : {})}
             isNavigation

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.stories.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.stories.tsx
@@ -5,37 +5,37 @@ const story = {
   component: BaseCell,
   argTypes: {},
   args: {
+    text: 'For dogs',
+    description: 'Annual only',
+    modalContent: 'More info',
+    fontVariant: 'NORMAL',
+    checkmarkValue: undefined,
     rating: {
       value: 2,
       type: 'zap',
     },
-    content: 'For dogs',
-    subContent: 'Annual only',
-    modalContent: 'More info',
-    checkmarkValue: undefined,
-    contentFontVariant: 'NORMAL',
   },
 };
 
 export const BaseCellStory = ({
-  content,
-  subContent,
+  text,
+  description,
   modalContent,
   checkmarkValue,
   rating,
-  contentFontVariant,
+  fontVariant,
   align,
 }: React.ComponentProps<typeof BaseCell>) => (
   <div className="p48 d-flex fd-column gap16 bg-white">
     <BaseCell
       align={align}
       checkmarkValue={checkmarkValue}
-      content={content}
-      contentFontVariant={contentFontVariant}
+      fontVariant={fontVariant}
+      description={description}
       modalContent={modalContent}
       openModal={() => {}}
       rating={rating}
-      subContent={subContent}
+      text={text}
     />
   </div>
 );

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -1,9 +1,7 @@
 import classNames from 'classnames';
-import { Button } from '../../../../button';
 import {
   CheckIcon,
   XIcon,
-  InfoIcon,
   StarFilledIcon,
   ZapFilledIcon,
 } from '../../../../icon';
@@ -12,7 +10,7 @@ import styles from './BaseCell.module.scss';
 import { MiniProgressBar } from './MiniProgressBar/MiniProgressBar';
 import { TableInfoButton } from '../../../../comparisonTable';
 
-export type ContentFontVariant = 'NORMAL' | 'BIG_WITH_UNDERLINE' | 'PRICE';
+export type FontVariant = 'NORMAL' | 'BIG_WITH_UNDERLINE' | 'PRICE';
 
 const progressLookup: Record<string, number> = {
   '30%': 1,
@@ -32,26 +30,26 @@ export type Alignment = 'center' | 'left' | 'right';
 export type BaseCellProps = {
   align?: Alignment;
   checkmarkValue?: boolean;
-  content?: ReactNode;
+  fontVariant?: FontVariant;
+  description?: ReactNode;
   modalContent?: ReactNode;
   openModal?: (modalContent: ReactNode) => void;
-  subContent?: ReactNode;
+  text?: ReactNode;
   rating?: {
     value: number;
     type: 'zap' | 'star';
   };
-  contentFontVariant?: ContentFontVariant;
 };
 
 export const BaseCell = ({
   align = 'center',
   checkmarkValue,
-  content = '',
+  fontVariant = 'NORMAL',
+  description = '',
   modalContent = '',
   openModal,
   rating,
-  subContent = '',
-  contentFontVariant = 'NORMAL',
+  text = '',
 }: BaseCellProps) => {
   const alignClassName = {
     center: 'ta-center jc-center ai-center',
@@ -63,7 +61,7 @@ export const BaseCell = ({
   const SelectedIcon = rating?.type === 'zap' ? ZapFilledIcon : StarFilledIcon;
 
   const progressBarValue =
-    typeof content === 'string' ? progressLookup[content] : undefined;
+    typeof text === 'string' ? progressLookup[text] : undefined;
 
   return (
     <div
@@ -113,22 +111,22 @@ export const BaseCell = ({
             </span>
           )}
 
-          {content && contentFontVariant === 'NORMAL' && (
-            <div className="p-p" data-testid="table-cell-content">
-              {content}
+          {text && fontVariant === 'NORMAL' && (
+            <div className="p-p" data-testid="table-cell-text">
+              {text}
             </div>
           )}
 
-          {content && contentFontVariant === 'PRICE' && (
+          {text && fontVariant === 'PRICE' && (
             <div
               className="p-h1 p--serif tc-primary-500"
               data-testid="table-cell-content"
             >
-              {content}
+              {text}
             </div>
           )}
 
-          {content && contentFontVariant === 'BIG_WITH_UNDERLINE' && (
+          {text && fontVariant === 'BIG_WITH_UNDERLINE' && (
             <div
               aria-hidden
               className={classNames(
@@ -136,19 +134,19 @@ export const BaseCell = ({
                 styles.bigWithUnderline
               )}
             >
-              {content}
+              {text}
             </div>
           )}
         </div>
 
-        {subContent && (
+        {description && (
           <div
             className={classNames(
               'd-flex p-p--small tc-grey-500',
               alignClassName
             )}
           >
-            {subContent}
+            {description}
           </div>
         )}
       </div>

--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.module.scss
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.module.scss
@@ -28,11 +28,11 @@
   }
 }
 
-.withoutSubContent {
+.withoutPrice {
   height: 64px;
 }
 
-.withSubContent {
+.withPrice {
   height: 75px;
 }
 

--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.stories.tsx
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.stories.tsx
@@ -5,58 +5,58 @@ const story = {
   component: ButtonCell,
   argTypes: {},
   args: {
+    buttonCaption: 'Premium',
+    price: '€277/mo',
     isSelected: false,
-    content: 'Premium',
-    subContent: '€277/mo',
     disabled: false,
   },
 };
 
 export const ButtonCellStory = ({
   isSelected,
-  content,
-  subContent,
+  buttonCaption,
+  price,
   disabled,
 }: React.ComponentProps<typeof ButtonCell>) => (
   <div className="p48 d-flex fd-column gap16 bg-white">
     <ButtonCell
-      content={content}
-      subContent={subContent}
+      buttonCaption={buttonCaption}
+      price={price}
       isSelected={isSelected}
       disabled={disabled}
       onClick={() => {}}
     />
 
     <ButtonCell
-      content={content}
-      subContent={subContent}
+      buttonCaption={buttonCaption}
+      price={price}
       isSelected
       disabled={disabled}
       onClick={() => {}}
     />
 
     <ButtonCell
-      content={content}
-      subContent={subContent}
+      buttonCaption={buttonCaption}
+      price={price}
       disabled
       onClick={() => {}}
     />
 
     <ButtonCell
-      content={content}
+      buttonCaption={buttonCaption}
       isSelected={isSelected}
       disabled={disabled}
       onClick={() => {}}
     />
 
     <ButtonCell
-      content={content}
+      buttonCaption={buttonCaption}
       isSelected
       disabled={disabled}
       onClick={() => {}}
     />
 
-    <ButtonCell content={content} disabled onClick={() => {}} />
+    <ButtonCell buttonCaption={buttonCaption} disabled onClick={() => {}} />
   </div>
 );
 

--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
@@ -5,18 +5,18 @@ import { Button } from '../../../../button';
 import { ReactNode } from 'react';
 
 export type ButtonCellProps = {
-  content?: ReactNode;
+  buttonCaption: ReactNode;
   disabled?: boolean;
   isSelected?: boolean;
   onClick: () => void;
-  subContent?: ReactNode;
+  price?: ReactNode;
 };
 
 export const ButtonCell = ({
   isSelected,
   onClick,
-  content,
-  subContent,
+  buttonCaption,
+  price,
   disabled,
 }: ButtonCellProps) => {
   return (
@@ -24,16 +24,16 @@ export const ButtonCell = ({
       <Button
         className={classNames('w100 wmx5 d-flex fd-column', styles.buttonCell, {
           [styles.selected]: isSelected,
-          [styles.withoutSubContent]: !subContent,
-          [styles.withSubContent]: !!subContent,
+          [styles.withoutPrice]: !price,
+          [styles.withPrice]: !!price,
         })}
         variant="filledWhite"
         type="submit"
         onClick={onClick}
         disabled={disabled}
       >
-        {content}
-        {subContent && <span className="p-p tc-purple-500">{subContent}</span>}
+        {buttonCaption}
+        {price && <span className="p-p tc-purple-500">{price}</span>}
       </Button>
     </div>
   );

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.stories.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.stories.tsx
@@ -5,23 +5,26 @@ const story = {
   component: CTACell,
   argTypes: {},
   args: {
-    content: 'Premium',
-    subContent: '€277',
+    title: 'Premium',
+    price: '€277',
+    buttonCaption: 'Get covered',
     grey: false,
     narrow: false,
   },
 };
 
 export const CTACellStory = ({
-  content,
-  subContent,
+  title,
+  price,
+  buttonCaption,
   grey,
   narrow,
 }: React.ComponentProps<typeof CTACell>) => (
   <div className="p48 d-flex fd-column gap16 bg-white">
     <CTACell
-      content={content}
-      subContent={subContent}
+      title={title}
+      price={price}
+      buttonCaption={buttonCaption}
       href=""
       grey={grey}
       narrow={narrow}

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
@@ -2,8 +2,9 @@ import classNames from 'classnames';
 import { ReactNode } from 'react';
 
 export type CTACellProps = {
-  content?: ReactNode;
-  subContent?: ReactNode;
+  title: ReactNode;
+  price?: ReactNode;
+  buttonCaption?: ReactNode;
   grey?: boolean;
   narrow?: boolean;
   href: string;
@@ -11,17 +12,18 @@ export type CTACellProps = {
 import styles from './CTACell.module.scss';
 
 export const CTACell = ({
-  content,
-  subContent,
+  title,
+  price,
   grey,
   narrow,
   href,
+  buttonCaption,
 }: CTACellProps) => {
   return (
     <div className="wmn3 ta-center">
       <p className="p-h3">
-        {content}
-        {subContent && <span className="tc-purple-500"> {subContent}</span>}
+        {title}
+        {price && <span className="tc-purple-500"> {price}</span>}
       </p>
       <a
         className={classNames('mt16', {
@@ -33,7 +35,7 @@ export const CTACell = ({
         target="_blank"
         rel="noopener noreferrer"
       >
-        Get covered
+        {buttonCaption}
       </a>
     </div>
   );

--- a/src/lib/components/table/components/TableCell/TableCell.test.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.test.tsx
@@ -3,17 +3,18 @@ import { TableCell, TableCellProps } from './TableCell';
 
 const openModal = jest.fn();
 
-const setup = ({ isNavigation, ...rest }: TableCellProps = {}) => render(
-  isNavigation 
-    ? <TableCell {...rest} isNavigation />
-    : (
+const setup = ({ isNavigation, ...rest }: TableCellProps = {}) =>
+  render(
+    isNavigation ? (
+      <TableCell {...rest} isNavigation />
+    ) : (
       <table>
         <tbody>
           <tr>
             <TableCell {...rest} />
           </tr>
         </tbody>
-      </table>  
+      </table>
     )
   );
 
@@ -58,7 +59,7 @@ describe('TableCell', () => {
   });
 
   it('renders the component with text', () => {
-    setup({ content: "Sample text" });
+    setup({ text: 'Sample text' });
 
     expect(screen.getByText('Sample text')).toBeInTheDocument();
   });
@@ -76,7 +77,7 @@ describe('TableCell', () => {
   });
 
   it('calls openModal when info button is clicked', () => {
-    setup({ modalContent: "Additional information", openModal });
+    setup({ modalContent: 'Additional information', openModal });
 
     // Click info button
     screen.getByTestId('ds-table-info-button').click();

--- a/src/lib/components/table/components/TableCell/TableCell.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.tsx
@@ -48,7 +48,11 @@ const TableCell = ({
       {!cellProps.type && (
         <BaseCell
           {...cellProps}
-          contentFontVariant={isTopLeftCell ? 'BIG_WITH_UNDERLINE' : 'NORMAL'}
+          fontVariant={
+            isTopLeftCell
+              ? 'BIG_WITH_UNDERLINE'
+              : cellProps.fontVariant ?? 'NORMAL'
+          }
         />
       )}
       {cellProps.type === 'CTA' && <CTACell {...cellProps} />}

--- a/src/lib/components/table/components/TableContents/TableContents.test.tsx
+++ b/src/lib/components/table/components/TableContents/TableContents.test.tsx
@@ -4,8 +4,8 @@ import { TableContents, TableContentsProps } from './TableContents';
 const mockData: TableContentsProps['tableData'] = [
   {
     rows: [
-      [{ content: 'Item 1.1.1' }, { content: 'Item 1.1.2' }],
-      [{ content: 'Item 1.2.1' }, { content: 'Item 1.2.2' }],
+      [{ text: 'Item 1.1.1' }, { text: 'Item 1.1.2' }],
+      [{ text: 'Item 1.2.1' }, { text: 'Item 1.2.2' }],
     ],
   },
   {
@@ -13,8 +13,8 @@ const mockData: TableContentsProps['tableData'] = [
       title: 'Section 2',
     },
     rows: [
-      [{ content: 'Item 2.1.1' }, { content: 'Item 2.1.2' }],
-      [{ content: 'Item 2.2.1' }, { content: 'Item 2.2.2' }],
+      [{ text: 'Item 2.1.1' }, { text: 'Item 2.1.2' }],
+      [{ text: 'Item 2.2.1' }, { text: 'Item 2.2.2' }],
     ],
   },
 ];

--- a/src/lib/components/table/components/TableSection/TableSection.test.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '../../../../util/testUtils';
 import { TableSection, TableSectionProps } from './TableSection';
 
 const tableCellRows: TableSectionProps['tableCellRows'] = [
-  [{ content: 'Cell 1.1' }, { content: 'Cell 1.2' }, { content: 'Cell 1.3' }],
-  [{ content: 'Cell 2.1' }, { content: 'Cell 2.2' }, { content: 'Cell 2.3' }],
+  [{ text: 'Cell 1.1' }, { text: 'Cell 1.2' }, { text: 'Cell 1.3' }],
+  [{ text: 'Cell 2.1' }, { text: 'Cell 2.2' }, { text: 'Cell 2.3' }],
 ];
 
 const mockTitle = 'Test Table';

--- a/src/lib/components/table/components/TableSection/TableSection.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.tsx
@@ -113,14 +113,20 @@ const TableSection = ({
                       {...tableCellData}
                       {...(isBaseCell(tableCellData)
                         ? {
-                            openModal: (body: ReactNode) =>
-                              openModal?.({
+                            openModal: (body: ReactNode) => {
+                              const titleFromRow =
+                                getModalTitleFromRowHeader(row);
+                              const titleFromColumnOrRow =
+                                getModalTitleFromColumnHeader(cellIndex) ||
+                                getModalTitleFromRowHeader(row);
+
+                              return openModal?.({
                                 body,
                                 title: isFirstCellInRow
-                                  ? getModalTitleFromRowHeader(row)
-                                  : getModalTitleFromColumnHeader(cellIndex) ||
-                                    getModalTitleFromRowHeader(row),
-                              }),
+                                  ? titleFromRow
+                                  : titleFromColumnOrRow,
+                              });
+                            },
                             align: isFirstCellInRow ? 'left' : 'center',
                           }
                         : {})}

--- a/src/lib/components/table/components/TableSection/TableSection.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.tsx
@@ -2,9 +2,13 @@ import classNames from 'classnames';
 
 import styles from './TableSection.module.scss';
 import { TableCell, TableCellProps } from '../TableCell/TableCell';
-import React, { ReactNode, useCallback } from 'react';
-import { ModalData, ModalFunction, TableCellRowData } from '../../types';
-import { Alignment } from '../TableCell/BaseCell/BaseCell';
+import { ReactNode, useCallback } from 'react';
+import {
+  isBaseCell,
+  ModalData,
+  ModalFunction,
+  TableCellRowData,
+} from '../../types';
 
 export interface TableSectionProps {
   className?: string;
@@ -25,22 +29,32 @@ const TableSection = ({
 }: TableSectionProps) => {
   const headerRow = tableCellRows?.[0];
 
-  const getColumnContentByKey = useCallback(
-    (key: number) => tableCellRows?.[0]?.[key]?.content || '',
-    [tableCellRows]
-  );
+  const getModalTitleFromColumnHeader = (cellIndex: number) => {
+    const firstCellInColumn = tableCellRows?.[0]?.[cellIndex];
+    let titleFromColumn;
 
-  const handleOpenModal = ({
-    cellIndex,
-    body,
-    title,
-  }: ModalData & {
-    cellIndex: number;
-  }) =>
-    openModal?.({
-      body,
-      title: title || getColumnContentByKey(cellIndex),
-    });
+    switch (firstCellInColumn.type) {
+      case 'BUTTON':
+        titleFromColumn = firstCellInColumn.buttonCaption;
+        break;
+      case 'CTA':
+        titleFromColumn = firstCellInColumn.title;
+        break;
+      case undefined:
+        titleFromColumn = firstCellInColumn.text || '';
+        break;
+    }
+
+    return titleFromColumn;
+  };
+
+  const getModalTitleFromRowHeader = (currentRow: TableCellRowData) => {
+    const firstCellInRow = currentRow?.[0];
+    const titleFromRow =
+      (isBaseCell(firstCellInRow) && firstCellInRow.text) || '';
+
+    return titleFromRow;
+  };
 
   return (
     <table
@@ -52,23 +66,8 @@ const TableSection = ({
       {headerRow && (
         <thead className={hideHeader ? 'sr-only' : ''}>
           <tr>
-            {headerRow.map((tableCellProps, cellIndex) => {
+            {headerRow.map((tableCellData, cellIndex) => {
               const isFirstCellInRow = cellIndex === 0;
-
-              const isBaseCell = !tableCellProps.type;
-
-              let openModal;
-              let align: Alignment = 'left';
-
-              if (isBaseCell) {
-                openModal = (body: ReactNode) =>
-                  handleOpenModal({
-                    cellIndex,
-                    body,
-                    title: tableCellProps?.content,
-                  });
-                align = isFirstCellInRow ? 'left' : 'center';
-              }
 
               return (
                 <TableCell
@@ -76,11 +75,17 @@ const TableSection = ({
                   isHeader
                   isFirstCellInRow={isFirstCellInRow}
                   isTopLeftCell={isFirstCellInRow}
-                  {...tableCellProps}
-                  {...(isBaseCell
+                  {...tableCellData}
+                  {...(isBaseCell(tableCellData)
                     ? {
-                        openModal,
-                        align,
+                        openModal: (body: ReactNode) =>
+                          openModal?.({
+                            body,
+                            title:
+                              tableCellData.text ||
+                              getModalTitleFromColumnHeader(cellIndex),
+                          }),
+                        align: isFirstCellInRow ? 'left' : 'center',
                       }
                     : {})}
                 />
@@ -97,40 +102,28 @@ const TableSection = ({
           return (
             rowIndex > 0 && (
               <tr key={rowIndex} className={styles.tr}>
-                {row.map((tableCellProps, cellIndex) => {
+                {row.map((tableCellData, cellIndex) => {
                   const key = `${rowIndex}-${cellIndex}`;
                   const isFirstCellInRow = cellIndex === 0;
 
-                  const onCelInfoClick = (body: ReactNode) =>
-                    handleOpenModal({
-                      cellIndex,
-                      body,
-                      title: isFirstCellInRow
-                        ? tableCellProps.content
-                        : undefined,
-                    });
-
-                  let openModal;
-                  let align: Alignment = 'left';
-
-                  const isBaseCell = !tableCellProps.type;
-
-                  if (isBaseCell) {
-                    openModal = onCelInfoClick;
-                    align = isFirstCellInRow ? 'left' : 'center';
-                  }
-
                   return (
                     <TableCell
-                      {...(isBaseCell
-                        ? {
-                            openModal,
-                            align,
-                          }
-                        : {})}
                       isFirstCellInRow={isFirstCellInRow}
                       key={key}
-                      {...tableCellProps}
+                      {...tableCellData}
+                      {...(isBaseCell(tableCellData)
+                        ? {
+                            openModal: (body: ReactNode) =>
+                              openModal?.({
+                                body,
+                                title: isFirstCellInRow
+                                  ? getModalTitleFromRowHeader(row)
+                                  : getModalTitleFromColumnHeader(cellIndex) ||
+                                    getModalTitleFromRowHeader(row),
+                              }),
+                            align: isFirstCellInRow ? 'left' : 'center',
+                          }
+                        : {})}
                     />
                   );
                 })}

--- a/src/lib/components/table/types.ts
+++ b/src/lib/components/table/types.ts
@@ -4,9 +4,9 @@ import { CTACellProps } from './components/TableCell/CTACell/CTACell';
 import { ButtonCellProps } from './components/TableCell/ButtonCell/ButtonCell';
 
 export type TableCellData =
-  | (BaseCellProps & { type?: undefined })
-  | (CTACellProps & { type: 'CTA' })
-  | (ButtonCellProps & { type: 'BUTTON' });
+  | (BaseCellProps & { type?: undefined; cellId?: string })
+  | (CTACellProps & { type: 'CTA'; cellId?: string })
+  | (ButtonCellProps & { type: 'BUTTON'; cellId?: string });
 
 export type TableSectionType = {
   title?: string;

--- a/src/lib/components/table/types.ts
+++ b/src/lib/components/table/types.ts
@@ -3,10 +3,17 @@ import { BaseCellProps } from './components/TableCell/BaseCell/BaseCell';
 import { CTACellProps } from './components/TableCell/CTACell/CTACell';
 import { ButtonCellProps } from './components/TableCell/ButtonCell/ButtonCell';
 
-export type TableCellData =
-  | (BaseCellProps & { type?: undefined; cellId?: string })
-  | (CTACellProps & { type: 'CTA'; cellId?: string })
-  | (ButtonCellProps & { type: 'BUTTON'; cellId?: string });
+type BaseCellData = BaseCellProps & { type?: undefined; cellId?: string };
+type CTACellData = CTACellProps & { type: 'CTA'; cellId?: string };
+type ButtonCellData = ButtonCellProps & { type: 'BUTTON'; cellId?: string };
+
+export type TableCellData = BaseCellData | CTACellData | ButtonCellData;
+
+export const isBaseCell = (
+  tableCellData: TableCellData
+): tableCellData is BaseCellData => {
+  return !tableCellData.type;
+};
 
 export type TableSectionType = {
   title?: string;


### PR DESCRIPTION
### What this PR does

This PR renames the cell properties again to make working with them easier.

It also introduces a type guard for `BaseCell` to simplify the code in sections where this is needed.

### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
STO-XXX
EMU-XXX
RVN-XXX

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
