### PR TITLE
feat(table): [SIDE-411] Last minute changes

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -77,6 +77,7 @@ const initialData: TableData = [
         {
           text: 'Regular vet visits & medication',
           description: 'Annual Only',
+          modalContent: 'Some stories about vets',
         },
         { text: 'No', description: 'Annual Only' },
         { text: '50%' },

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
@@ -1,11 +1,13 @@
 @use "../../../../../scss/public/grid" as *;
 @use "../../../../../scss/public/colors" as *;
 
-.infoButton {
-  min-height: initial;
-  height: initial;
-  width: initial;
-  padding: 0;
+.relative {
+  position: relative;
+}
+
+.infoButtonAbsolute {
+  position: absolute;
+  right: -32px;
 }
 
 .icon {

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.stories.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.stories.tsx
@@ -25,6 +25,7 @@ export const BaseCellStory = ({
   rating,
   fontVariant,
   align,
+  hideProgressBar,
 }: React.ComponentProps<typeof BaseCell>) => (
   <div className="p48 d-flex fd-column gap16 bg-white">
     <BaseCell
@@ -33,6 +34,7 @@ export const BaseCellStory = ({
       fontVariant={fontVariant}
       description={description}
       modalContent={modalContent}
+      hideProgressBar={hideProgressBar}
       openModal={() => {}}
       rating={rating}
       text={text}

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -69,7 +69,13 @@ export const BaseCell = ({
         'jc-center': align === 'center',
       })}
     >
-      <div className={classNames('d-flex fd-column', alignClassName)}>
+      <div
+        className={classNames(
+          'd-flex fd-column',
+          alignClassName,
+          styles.relative
+        )}
+      >
         {progressBarValue !== undefined && (
           <MiniProgressBar nFilledBars={progressBarValue} />
         )}
@@ -111,32 +117,40 @@ export const BaseCell = ({
             </span>
           )}
 
-          {text && fontVariant === 'NORMAL' && (
-            <div className="p-p" data-testid="table-cell-text">
-              {text}
-            </div>
-          )}
+          <div className="d-inline">
+            {text && fontVariant === 'NORMAL' && (
+              <div className="p-p d-inline" data-testid="table-cell-text">
+                {text}
+              </div>
+            )}
 
-          {text && fontVariant === 'PRICE' && (
-            <div
-              className="p-h1 p--serif tc-primary-500"
-              data-testid="table-cell-content"
-            >
-              {text}
-            </div>
-          )}
+            {text && fontVariant === 'PRICE' && (
+              <div
+                className="p-h1 p--serif tc-primary-500"
+                data-testid="table-cell-content"
+              >
+                {text}
+              </div>
+            )}
 
-          {text && fontVariant === 'BIG_WITH_UNDERLINE' && (
-            <div
-              aria-hidden
-              className={classNames(
-                'tc-grey-800 p-h2 p--serif',
-                styles.bigWithUnderline
-              )}
-            >
-              {text}
-            </div>
-          )}
+            {text && fontVariant === 'BIG_WITH_UNDERLINE' && (
+              <div
+                aria-hidden
+                className={classNames(
+                  'tc-grey-800 p-h2 p--serif',
+                  styles.bigWithUnderline
+                )}
+              >
+                {text}
+              </div>
+            )}
+
+            {modalContent && openModal && align == 'left' && (
+              <span className="ml8">
+                <TableInfoButton onClick={() => openModal(modalContent)} />
+              </span>
+            )}
+          </div>
         </div>
 
         {description && (
@@ -149,10 +163,13 @@ export const BaseCell = ({
             {description}
           </div>
         )}
+
+        {modalContent && openModal && align == 'center' && (
+          <span className={styles.infoButtonAbsolute}>
+            <TableInfoButton onClick={() => openModal(modalContent)} />
+          </span>
+        )}
       </div>
-      {modalContent && openModal && (
-        <TableInfoButton onClick={() => openModal(modalContent)} />
-      )}
     </div>
   );
 };

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -30,8 +30,9 @@ export type Alignment = 'center' | 'left' | 'right';
 export type BaseCellProps = {
   align?: Alignment;
   checkmarkValue?: boolean;
-  fontVariant?: FontVariant;
   description?: ReactNode;
+  fontVariant?: FontVariant;
+  hideProgressBar?: boolean;
   modalContent?: ReactNode;
   openModal?: (modalContent: ReactNode) => void;
   text?: ReactNode;
@@ -44,8 +45,9 @@ export type BaseCellProps = {
 export const BaseCell = ({
   align = 'center',
   checkmarkValue,
-  fontVariant = 'NORMAL',
   description = '',
+  fontVariant = 'NORMAL',
+  hideProgressBar = false,
   modalContent = '',
   openModal,
   rating,
@@ -61,7 +63,9 @@ export const BaseCell = ({
   const SelectedIcon = rating?.type === 'zap' ? ZapFilledIcon : StarFilledIcon;
 
   const progressBarValue =
-    typeof text === 'string' ? progressLookup[text] : undefined;
+    !hideProgressBar && typeof text === 'string'
+      ? progressLookup[text]
+      : undefined;
 
   return (
     <div

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.stories.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.stories.tsx
@@ -1,3 +1,4 @@
+import { PlaneIcon } from '../../../../icon';
 import { CTACell } from './CTACell';
 
 const story = {
@@ -5,8 +6,9 @@ const story = {
   component: CTACell,
   argTypes: {},
   args: {
-    title: 'Premium',
+    title: 'BARMER',
     price: '€277',
+    icon: <PlaneIcon size={24} noMargin />,
     buttonCaption: 'Get covered',
     grey: false,
     narrow: false,
@@ -16,6 +18,7 @@ const story = {
 export const CTACellStory = ({
   title,
   price,
+  icon,
   buttonCaption,
   grey,
   narrow,
@@ -24,6 +27,7 @@ export const CTACellStory = ({
     <CTACell
       title={title}
       price={price}
+      icon={icon}
       buttonCaption={buttonCaption}
       href=""
       grey={grey}

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 export type CTACellProps = {
   title: ReactNode;
   price?: ReactNode;
+  icon?: ReactNode;
   buttonCaption?: ReactNode;
   grey?: boolean;
   narrow?: boolean;
@@ -14,19 +15,24 @@ import styles from './CTACell.module.scss';
 export const CTACell = ({
   title,
   price,
+  icon,
   grey,
   narrow,
   href,
   buttonCaption,
 }: CTACellProps) => {
   return (
-    <div className="wmn3 ta-center">
-      <p className="p-h3">
-        {title}
-        {price && <span className="tc-purple-500"> {price}</span>}
-      </p>
+    <div className="ta-center">
+      <div className="d-flex jc-center ai-center gap8">
+        {icon}
+        <p className="p-h3">
+          {title}
+          {price && <span className="tc-purple-500"> {price}</span>}
+        </p>
+      </div>
+
       <a
-        className={classNames('mt16', {
+        className={classNames('mt16 w100 wmx3', {
           'p-btn--primary': !grey,
           'p-btn--secondary-grey': grey,
           [styles.narrow]: narrow,


### PR DESCRIPTION
### What this PR does

This PR implements these last minute changes:
* Adjust positioning of (i) icon
![image](https://github.com/user-attachments/assets/ece44700-bb48-4e44-b0c5-203c0d8c1000)

* Add ability to hide progress bar

* Add icon prop to CTA Cell
![image](https://github.com/user-attachments/assets/3b3ef10d-a80a-4911-8c65-718abd7a5485)

### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
SIDE-411

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
