### PR TITLE
feat(table): [SIDE-412] Add ability to replace cell props

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -1,6 +1,8 @@
 import { Table, TableProps } from './Table';
 import { DentalPlusIcon, PlaneIcon } from '../icon';
-import { TableCellData, TableData } from './types';
+import { TableData } from './types';
+import { useState } from 'react';
+import { Input } from '../input';
 
 const initialData: TableData = [
   {
@@ -55,18 +57,21 @@ const initialData: TableData = [
           text: 'Your contribution',
         },
         {
+          cellId: '#1',
           text: '€210',
           description: 'per month',
           fontVariant: 'PRICE',
           modalContent: 'Price info',
         },
         {
+          cellId: '#2',
           text: '€275',
           description: 'per month',
           fontVariant: 'PRICE',
           modalContent: 'Price info',
         },
         {
+          cellId: '#3',
           text: '€310',
           description: 'per month',
           fontVariant: 'PRICE',
@@ -220,16 +225,47 @@ export const TableStory = ({
   stickyHeaderTopOffset,
   textOverrides,
   title,
-}: TableProps) => (
-  <Table
-    collapsibleSections={collapsibleSections}
-    tableData={tableData}
-    hideDetails={hideDetails}
-    stickyHeaderTopOffset={stickyHeaderTopOffset}
-    textOverrides={textOverrides}
-    title={title}
-  />
-);
+}: TableProps) => {
+  const [price, setPrice] = useState(999);
+  return (
+    <div>
+      <div className="d-flex fd-column p24 mb80 gap16 wmx5">
+        <label htmlFor="">Change price to see replacement in action: </label>
+        <Input
+          id="#stuff"
+          type="text"
+          onChange={(e) => setPrice(Number(e.target.value))}
+          value={price}
+        />
+      </div>
+
+      <Table
+        cellReplacements={{
+          '#1': {
+            type: 'CTA',
+            title: 'Replaced!',
+            price: `€${price}`,
+            buttonCaption: 'I got replaced',
+            href: 'http://example.com',
+          },
+          '#2': {
+            type: 'BUTTON',
+            buttonCaption: 'I got replaced too',
+          },
+          '#3': {
+            description: 'per year',
+          },
+        }}
+        collapsibleSections={collapsibleSections}
+        tableData={tableData}
+        hideDetails={hideDetails}
+        stickyHeaderTopOffset={stickyHeaderTopOffset}
+        textOverrides={textOverrides}
+        title={title}
+      />
+    </div>
+  );
+};
 
 export const TableDataType = () => {
   return (

--- a/src/lib/components/table/Table.test.tsx
+++ b/src/lib/components/table/Table.test.tsx
@@ -8,7 +8,7 @@ const tableData: TableSectionData[] = [
       title: 'Section 1',
       icon: <span>Icon 1</span>,
     },
-    rows: [[{ text: 'Item 1' }, { text: 'Item 2' }]],
+    rows: [[{ text: 'Item 1', cellId: '#item1' }, { text: 'Item 2' }]],
   },
   {
     section: {
@@ -81,5 +81,27 @@ describe('Table', () => {
     await user.click(screen.getByTestId('ds-table-info-button'));
 
     expect(screen.getByText('Additional item')).toBeVisible();
+  });
+
+  it('renders the table with cell replacements', () => {
+    render(
+      <Table
+        tableData={tableData}
+        title="Test Table"
+        cellReplacements={{
+          '#item1': {
+            text: 'I was replaced',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Section 1')).toBeInTheDocument();
+    expect(screen.getByText('Section 2')).toBeInTheDocument();
+
+    expect(screen.getAllByText('I was replaced')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Item 2')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Item 3')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('Item 4')[0]).toBeInTheDocument();
   });
 });

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -1,6 +1,6 @@
-import { TableCell, TableCellProps } from './components/TableCell/TableCell';
+import { TableCell } from './components/TableCell/TableCell';
 import { BottomOrRegularModal } from '../modal';
-import { ReactNode, useRef, useState } from 'react';
+import { ReactNode, useCallback, useRef, useState } from 'react';
 import { ChevronDownIcon, ChevronUpIcon } from '../icon';
 import { Card } from '../cards/card';
 
@@ -12,7 +12,14 @@ import { useTableNavigation } from './utils/useTableNavigation/useTableNavigatio
 import { TableControls } from './components/TableControls/TableControls';
 import { TableSection } from './components/TableSection/TableSection';
 import { useScrollSync } from './utils/useScrollSync/useScrollSync';
-import { isBaseCell, ModalData, ModalFunction, TableData } from './types';
+import {
+  CellReplacements,
+  isBaseCell,
+  ModalData,
+  ModalFunction,
+  TableCellData,
+  TableData,
+} from './types';
 
 type TextOverrides = {
   showDetails?: string;
@@ -29,6 +36,7 @@ export interface TableProps {
   stickyHeaderTopOffset?: number;
   textOverrides?: TextOverrides;
   title: string;
+  cellReplacements?: CellReplacements;
 }
 
 const defaultTextOverrides = {
@@ -38,6 +46,7 @@ const defaultTextOverrides = {
 
 const Table = ({
   className,
+  cellReplacements,
   collapsibleSections,
   tableData,
   hideDetails,
@@ -64,11 +73,20 @@ const Table = ({
   });
 
   const currentActiveSection = tableData?.[0]?.rows?.[0]?.[activeSection];
+  const currentActiveSectionReplacements =
+    (currentActiveSection.cellId &&
+      cellReplacements?.[currentActiveSection.cellId]) ||
+    {};
 
-  const handleOpenModal: ModalFunction = ({ body, title }) => {
+  const activeCellProps = {
+    ...currentActiveSection,
+    ...currentActiveSectionReplacements,
+  } as TableCellData;
+
+  const handleOpenModal: ModalFunction = useCallback(({ body, title }) => {
     onModalOpen?.({ body, title });
     setInfoModalData({ body, title });
-  };
+  }, []);
 
   return (
     <div className={classNames(styles.wrapper, 'bg-white')}>
@@ -80,7 +98,6 @@ const Table = ({
           stickyHeaderTopOffset={stickyHeaderTopOffset}
         >
           <TableCell
-            {...currentActiveSection}
             {...(isBaseCell(currentActiveSection)
               ? {
                   openModal: (body: ReactNode) =>
@@ -90,6 +107,7 @@ const Table = ({
                     }),
                 }
               : {})}
+            {...activeCellProps}
             isNavigation
           />
         </TableControls>
@@ -120,6 +138,7 @@ const Table = ({
           isMobile={isMobile}
           shouldHideDetails={shouldHideDetails}
           openModal={handleOpenModal}
+          cellReplacements={cellReplacements}
         />
       </div>
 

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -9,6 +9,7 @@ import { ReactNode } from 'react';
 import styles from './BaseCell.module.scss';
 import { MiniProgressBar } from './MiniProgressBar/MiniProgressBar';
 import { TableInfoButton } from '../../../../comparisonTable';
+import { ModalFunction } from '../../../types';
 
 export type FontVariant = 'NORMAL' | 'BIG_WITH_UNDERLINE' | 'PRICE';
 
@@ -33,13 +34,15 @@ export type BaseCellProps = {
   description?: ReactNode;
   fontVariant?: FontVariant;
   hideProgressBar?: boolean;
+  modalTitle?: ReactNode;
   modalContent?: ReactNode;
-  openModal?: (modalContent: ReactNode) => void;
+  openModal?: ModalFunction;
   text?: ReactNode;
   rating?: {
     value: number;
     type: 'zap' | 'star';
   };
+  cellId?: string;
 };
 
 export const BaseCell = ({
@@ -48,6 +51,7 @@ export const BaseCell = ({
   description = '',
   fontVariant = 'NORMAL',
   hideProgressBar = false,
+  modalTitle = '',
   modalContent = '',
   openModal,
   rating,
@@ -151,7 +155,14 @@ export const BaseCell = ({
 
             {modalContent && openModal && align == 'left' && (
               <span className="ml8">
-                <TableInfoButton onClick={() => openModal(modalContent)} />
+                <TableInfoButton
+                  onClick={() =>
+                    openModal({
+                      title: modalTitle,
+                      body: modalContent,
+                    })
+                  }
+                />
               </span>
             )}
           </div>
@@ -170,7 +181,14 @@ export const BaseCell = ({
 
         {modalContent && openModal && align == 'center' && (
           <span className={styles.infoButtonAbsolute}>
-            <TableInfoButton onClick={() => openModal(modalContent)} />
+            <TableInfoButton
+              onClick={() =>
+                openModal({
+                  title: modalTitle,
+                  body: modalContent,
+                })
+              }
+            />
           </span>
         )}
       </div>

--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
@@ -10,6 +10,7 @@ export type ButtonCellProps = {
   isSelected?: boolean;
   onClick: () => void;
   price?: ReactNode;
+  cellId?: string;
 };
 
 export const ButtonCell = ({

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
@@ -9,6 +9,7 @@ export type CTACellProps = {
   grey?: boolean;
   narrow?: boolean;
   href: string;
+  cellId?: string;
 };
 import styles from './CTACell.module.scss';
 

--- a/src/lib/components/table/components/TableCell/TableCell.test.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.test.tsx
@@ -83,6 +83,9 @@ describe('TableCell', () => {
     screen.getByTestId('ds-table-info-button').click();
 
     // Assert openModal is called with info prop
-    expect(openModal).toHaveBeenCalledWith('Additional information');
+    expect(openModal).toHaveBeenCalledWith({
+      body: 'Additional information',
+      title: '',
+    });
   });
 });

--- a/src/lib/components/table/components/TableCell/TableCell.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.tsx
@@ -1,64 +1,67 @@
 import classNames from 'classnames';
 
 import styles from './TableCell.module.scss';
-import { BaseCell, BaseCellProps } from './BaseCell/BaseCell';
+import { BaseCell } from './BaseCell/BaseCell';
 import { TableCellData } from '../../types';
 import { CTACell } from './CTACell/CTACell';
 import { ButtonCell } from './ButtonCell/ButtonCell';
+import React from 'react';
 
-type PositionalTableCellProps = {
+type ExtraTableCellProps = {
   isHeader?: boolean;
   isFirstCellInRow?: boolean;
   isTopLeftCell?: boolean;
   isNavigation?: boolean;
 };
 
-export type TableCellProps = TableCellData & PositionalTableCellProps;
+export type TableCellProps = TableCellData & ExtraTableCellProps;
 
-const TableCell = ({
-  isFirstCellInRow = false,
-  isHeader = false,
-  isNavigation = false,
-  isTopLeftCell = false,
-  ...cellProps
-}: TableCellProps) => {
-  // prettier-ignore
-  const Tag = isNavigation
+const TableCell = React.memo(
+  ({
+    isFirstCellInRow = false,
+    isHeader = false,
+    isNavigation = false,
+    isTopLeftCell = false,
+    ...cellProps
+  }: TableCellProps) => {
+    // prettier-ignore
+    const Tag = isNavigation
     ? 'div'
     : isHeader || isFirstCellInRow ? 'th' : 'td';
 
-  // prettier-ignore
-  const thScope = isHeader
+    // prettier-ignore
+    const thScope = isHeader
     ? 'col'
     : isFirstCellInRow ? 'row' : undefined;
 
-  const scope = {
-    scope: thScope,
-  };
+    const scope = {
+      scope: thScope,
+    };
 
-  return (
-    <Tag
-      {...scope}
-      className={classNames('bg-white py24 px8', styles.th, {
-        'ta-left': isFirstCellInRow,
-        [styles.fixedCell]: isFirstCellInRow,
-        pl32: isFirstCellInRow,
-      })}
-    >
-      {!cellProps.type && (
-        <BaseCell
-          {...cellProps}
-          fontVariant={
-            isTopLeftCell
-              ? 'BIG_WITH_UNDERLINE'
-              : cellProps.fontVariant ?? 'NORMAL'
-          }
-        />
-      )}
-      {cellProps.type === 'CTA' && <CTACell {...cellProps} />}
-      {cellProps.type === 'BUTTON' && <ButtonCell {...cellProps} />}
-    </Tag>
-  );
-};
+    return (
+      <Tag
+        {...scope}
+        className={classNames('bg-white py24 px8', styles.th, {
+          'ta-left': isFirstCellInRow,
+          [styles.fixedCell]: isFirstCellInRow,
+          pl32: isFirstCellInRow,
+        })}
+      >
+        {!cellProps.type && (
+          <BaseCell
+            {...cellProps}
+            fontVariant={
+              isTopLeftCell
+                ? 'BIG_WITH_UNDERLINE'
+                : cellProps.fontVariant ?? 'NORMAL'
+            }
+          />
+        )}
+        {cellProps.type === 'CTA' && <CTACell {...cellProps} />}
+        {cellProps.type === 'BUTTON' && <ButtonCell {...cellProps} />}
+      </Tag>
+    );
+  }
+);
 
 export { TableCell };

--- a/src/lib/components/table/components/TableContents/TableContents.tsx
+++ b/src/lib/components/table/components/TableContents/TableContents.tsx
@@ -6,7 +6,7 @@ import { Card } from '../../../cards/card';
 import styles from './TableContents.module.scss';
 import classNames from 'classnames';
 import { Collapsible } from './Collapsible';
-import { ModalFunction, TableData } from '../../types';
+import { CellReplacements, ModalFunction, TableData } from '../../types';
 
 export interface TableContentsProps {
   className?: string;
@@ -17,6 +17,7 @@ export interface TableContentsProps {
   openModal?: ModalFunction;
   shouldHideDetails?: boolean;
   title: string;
+  cellReplacements?: CellReplacements;
 }
 
 const TableContents = ({
@@ -28,6 +29,7 @@ const TableContents = ({
   openModal,
   shouldHideDetails,
   title,
+  cellReplacements,
 }: TableContentsProps) => {
   const [isSectionOpen, setOpenSection] = useState<number | null>(null);
   const firstHeadRow = tableData?.[0]?.rows?.[0];
@@ -93,6 +95,7 @@ const TableContents = ({
                     section?.title ? ` - ${section.title}` : ''
                   }`}
                   width={tableWidth}
+                  cellReplacements={cellReplacements}
                 />
               </Collapsible>
             </div>

--- a/src/lib/components/table/components/TableSection/TableSection.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.tsx
@@ -2,11 +2,11 @@ import classNames from 'classnames';
 
 import styles from './TableSection.module.scss';
 import { TableCell, TableCellProps } from '../TableCell/TableCell';
-import { ReactNode, useCallback } from 'react';
 import {
+  CellReplacements,
   isBaseCell,
-  ModalData,
   ModalFunction,
+  TableCellData,
   TableCellRowData,
 } from '../../types';
 
@@ -17,6 +17,7 @@ export interface TableSectionProps {
   openModal?: ModalFunction;
   title: string;
   width?: number | string;
+  cellReplacements?: CellReplacements;
 }
 
 const TableSection = ({
@@ -26,6 +27,7 @@ const TableSection = ({
   openModal,
   title,
   width,
+  cellReplacements,
 }: TableSectionProps) => {
   const headerRow = tableCellRows?.[0];
 
@@ -68,6 +70,22 @@ const TableSection = ({
           <tr>
             {headerRow.map((tableCellData, cellIndex) => {
               const isFirstCellInRow = cellIndex === 0;
+              const cellReplacementData =
+                (tableCellData.cellId &&
+                  cellReplacements?.[tableCellData.cellId]) ||
+                {};
+
+              const cellProps = {
+                ...tableCellData,
+                ...cellReplacementData,
+                ...{
+                  openModal,
+                  modalTitle:
+                    (isBaseCell(tableCellData) && tableCellData.text) ||
+                    getModalTitleFromColumnHeader(cellIndex),
+                  align: isFirstCellInRow ? 'left' : 'center',
+                },
+              } as TableCellData;
 
               return (
                 <TableCell
@@ -75,19 +93,7 @@ const TableSection = ({
                   isHeader
                   isFirstCellInRow={isFirstCellInRow}
                   isTopLeftCell={isFirstCellInRow}
-                  {...tableCellData}
-                  {...(isBaseCell(tableCellData)
-                    ? {
-                        openModal: (body: ReactNode) =>
-                          openModal?.({
-                            body,
-                            title:
-                              tableCellData.text ||
-                              getModalTitleFromColumnHeader(cellIndex),
-                          }),
-                        align: isFirstCellInRow ? 'left' : 'center',
-                      }
-                    : {})}
+                  {...cellProps}
                 />
               );
             })}
@@ -106,30 +112,33 @@ const TableSection = ({
                   const key = `${rowIndex}-${cellIndex}`;
                   const isFirstCellInRow = cellIndex === 0;
 
+                  const titleFromRow = getModalTitleFromRowHeader(row);
+                  const titleFromColumnOrRow =
+                    getModalTitleFromColumnHeader(cellIndex) ||
+                    getModalTitleFromRowHeader(row);
+
+                  const cellReplacementData =
+                    (tableCellData.cellId &&
+                      cellReplacements?.[tableCellData.cellId]) ||
+                    {};
+
+                  const cellProps = {
+                    ...tableCellData,
+                    ...cellReplacementData,
+                    ...{
+                      openModal,
+                      modalTitle: isFirstCellInRow
+                        ? titleFromRow
+                        : titleFromColumnOrRow,
+                      align: isFirstCellInRow ? 'left' : 'center',
+                    },
+                  } as TableCellData;
+
                   return (
                     <TableCell
                       isFirstCellInRow={isFirstCellInRow}
                       key={key}
-                      {...tableCellData}
-                      {...(isBaseCell(tableCellData)
-                        ? {
-                            openModal: (body: ReactNode) => {
-                              const titleFromRow =
-                                getModalTitleFromRowHeader(row);
-                              const titleFromColumnOrRow =
-                                getModalTitleFromColumnHeader(cellIndex) ||
-                                getModalTitleFromRowHeader(row);
-
-                              return openModal?.({
-                                body,
-                                title: isFirstCellInRow
-                                  ? titleFromRow
-                                  : titleFromColumnOrRow,
-                              });
-                            },
-                            align: isFirstCellInRow ? 'left' : 'center',
-                          }
-                        : {})}
+                      {...cellProps}
                     />
                   );
                 })}

--- a/src/lib/components/table/types.ts
+++ b/src/lib/components/table/types.ts
@@ -3,9 +3,9 @@ import { BaseCellProps } from './components/TableCell/BaseCell/BaseCell';
 import { CTACellProps } from './components/TableCell/CTACell/CTACell';
 import { ButtonCellProps } from './components/TableCell/ButtonCell/ButtonCell';
 
-type BaseCellData = BaseCellProps & { type?: undefined; cellId?: string };
-type CTACellData = CTACellProps & { type: 'CTA'; cellId?: string };
-type ButtonCellData = ButtonCellProps & { type: 'BUTTON'; cellId?: string };
+type BaseCellData = BaseCellProps & { type?: undefined };
+type CTACellData = CTACellProps & { type: 'CTA' };
+type ButtonCellData = ButtonCellProps & { type: 'BUTTON' };
 
 export type TableCellData = BaseCellData | CTACellData | ButtonCellData;
 
@@ -35,3 +35,5 @@ export type TableSectionData = {
 export type TableData = TableSectionData[];
 
 export type ModalFunction = (modalData: ModalData) => void;
+
+export type CellReplacements = Record<string, Partial<TableCellData>>;


### PR DESCRIPTION
### What this PR does

This PR adds the ability to replace cell props. Only cells affected by changes to the cellReplacements will be rerendered.

https://github.com/user-attachments/assets/953202d6-9ced-49f5-b821-b273aeb6d1ba


### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
SIDE-412

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
