### PR TITLE
feat(table): [NoTicket] Support icon urls

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -11,7 +11,7 @@ const initialData: TableData = [
         { text: 'Our plans' },
         {
           type: 'CTA',
-          icon: 'https://placehold.co/400x400/orange/white',
+          icon: 'https://placehold.co/24x24/orange/white',
           title: 'Standard',
           price: '€234',
           buttonCaption: 'Get covered',
@@ -19,7 +19,7 @@ const initialData: TableData = [
         },
         {
           type: 'CTA',
-          icon: 'https://placehold.co/400x400/green/white',
+          icon: 'https://placehold.co/24x24/green/white',
           title: 'Plus',
           price: '€344',
           buttonCaption: 'Get covered',
@@ -138,7 +138,7 @@ const initialData: TableData = [
           colSpan: 3,
           title: 'Dental add-on',
           href: 'https://example.com',
-          icon: 'https://placehold.co/400x400/green/yellow',
+          icon: 'https://placehold.co/24x24/green/yellow',
           description:
             'Get your dental cleanings and additional treatments covered for just 10.90€ a month.',
         },
@@ -148,7 +148,7 @@ const initialData: TableData = [
   {
     section: {
       title: 'Travel',
-      icon: 'https://placehold.co/400x400/red/yellow',
+      icon: 'https://placehold.co/24x24/red/yellow',
     },
     rows: [
       [

--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -11,6 +11,7 @@ const initialData: TableData = [
         { text: 'Our plans' },
         {
           type: 'CTA',
+          icon: 'https://placehold.co/400x400/orange/white',
           title: 'Standard',
           price: '€234',
           buttonCaption: 'Get covered',
@@ -18,6 +19,7 @@ const initialData: TableData = [
         },
         {
           type: 'CTA',
+          icon: 'https://placehold.co/400x400/green/white',
           title: 'Plus',
           price: '€344',
           buttonCaption: 'Get covered',
@@ -25,6 +27,7 @@ const initialData: TableData = [
         },
         {
           type: 'CTA',
+          icon: <PlaneIcon size={24} noMargin />,
           title: 'Premium',
           price: '€556',
           buttonCaption: 'Get covered',
@@ -135,7 +138,9 @@ const initialData: TableData = [
           colSpan: 3,
           title: 'Dental add-on',
           href: 'https://example.com',
-          description: 'Get your dental cleanings and additional treatments covered for just 10.90€ a month.',
+          icon: 'https://placehold.co/400x400/green/yellow',
+          description:
+            'Get your dental cleanings and additional treatments covered for just 10.90€ a month.',
         },
       ],
     ],
@@ -143,7 +148,7 @@ const initialData: TableData = [
   {
     section: {
       title: 'Travel',
-      icon: <PlaneIcon size={24} noMargin />,
+      icon: 'https://placehold.co/400x400/red/yellow',
     },
     rows: [
       [
@@ -199,8 +204,7 @@ const story = {
         'This property allows to set custom text for the show and hide details buttons.',
     },
     hideColumns: {
-      subContent:
-        'This property allows to hide defined columns by index.',
+      subContent: 'This property allows to hide defined columns by index.',
     },
     onSelectionChanged: {
       subContent:

--- a/src/lib/components/table/Table.test.tsx
+++ b/src/lib/components/table/Table.test.tsx
@@ -13,7 +13,7 @@ const tableData: TableSectionData[] = [
   {
     section: {
       title: 'Section 2',
-      icon: <span>Icon 2</span>,
+      icon: 'https://placehold.co/30x30/orange/white',
     },
     rows: [
       [{ text: 'Item 3' }, { text: 'Item 4', modalContent: 'Additional item' }],
@@ -103,5 +103,24 @@ describe('Table', () => {
     expect(screen.getAllByText('Item 2')[0]).toBeInTheDocument();
     expect(screen.getAllByText('Item 3')[0]).toBeInTheDocument();
     expect(screen.getAllByText('Item 4')[0]).toBeInTheDocument();
+  });
+
+  it('renders icons with a custom image component', () => {
+    const CustomImageComponent = ({ src }: { src: string }) => (
+      <>
+        <p>I am custom</p>
+        <img src={src} alt="" />
+      </>
+    );
+
+    render(
+      <Table
+        tableData={tableData}
+        title="Test Table"
+        imageComponent={CustomImageComponent}
+      />
+    );
+
+    expect(screen.getByText('I am custom')).toBeInTheDocument();
   });
 });

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -27,17 +27,18 @@ type TextOverrides = {
 };
 
 export interface TableProps {
+  cellReplacements?: CellReplacements;
   className?: string;
   collapsibleSections?: boolean;
-  tableData: TableData;
   hideColumns?: number[];
   hideDetails?: boolean;
+  imageComponent?: (args: any) => JSX.Element;
   onModalOpen?: ModalFunction;
   onSelectionChanged?: (index: number) => void;
   stickyHeaderTopOffset?: number;
+  tableData: TableData;
   textOverrides?: TextOverrides;
   title: string;
-  cellReplacements?: CellReplacements;
 }
 
 const defaultTextOverrides = {
@@ -46,15 +47,16 @@ const defaultTextOverrides = {
 };
 
 const Table = ({
-  className,
   cellReplacements,
+  className,
   collapsibleSections,
-  tableData,
   hideColumns = [],
   hideDetails,
+  imageComponent,
   onModalOpen,
   onSelectionChanged,
   stickyHeaderTopOffset = 0,
+  tableData,
   textOverrides: definedTextOverrides,
   title,
 }: TableProps) => {
@@ -110,6 +112,7 @@ const Table = ({
                 }
               : {})}
             {...activeCellProps}
+            imageComponent={imageComponent}
             isNavigation
           />
         </TableControls>
@@ -127,6 +130,7 @@ const Table = ({
               openModal={handleOpenModal}
               tableCellRows={[tableData?.[0]?.rows?.[0]]}
               title={title}
+              imageComponent={imageComponent}
             />
           </div>
         </div>
@@ -144,6 +148,7 @@ const Table = ({
           shouldHideDetails={shouldHideDetails}
           openModal={handleOpenModal}
           cellReplacements={cellReplacements}
+          imageComponent={imageComponent}
         />
       </div>
 

--- a/src/lib/components/table/components/IconRenderer/IconRenderer.tsx
+++ b/src/lib/components/table/components/IconRenderer/IconRenderer.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+export type IconRendererProps = {
+  icon?: ReactNode;
+  imageComponent?: (args: any) => JSX.Element;
+};
+
+export const IconRenderer = ({ icon, imageComponent }: IconRendererProps) => {
+  const ImageComponent = imageComponent ?? 'img';
+  const iconIsUrl = typeof icon === 'string';
+
+  const renderedIcon = iconIsUrl ? (
+    <ImageComponent src={icon} width={24} alt="" />
+  ) : (
+    icon
+  );
+
+  return <>{renderedIcon}</>;
+};

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
@@ -1,16 +1,19 @@
 import classNames from 'classnames';
 import { ReactNode } from 'react';
 
+import styles from './CTACell.module.scss';
+import { IconRenderer } from '../../IconRenderer/IconRenderer';
+
 export type CTACellProps = {
   title: ReactNode;
   price?: ReactNode;
   icon?: ReactNode;
+  imageComponent?: (args: any) => JSX.Element;
   buttonCaption?: ReactNode;
   grey?: boolean;
   narrow?: boolean;
   href: string;
 };
-import styles from './CTACell.module.scss';
 
 export const CTACell = ({
   title,
@@ -20,11 +23,16 @@ export const CTACell = ({
   narrow,
   href,
   buttonCaption,
+  imageComponent,
 }: CTACellProps) => {
+  const renderedIcon = (
+    <IconRenderer icon={icon} imageComponent={imageComponent} />
+  );
+
   return (
     <div className="ta-center">
       <div className="d-flex jc-center ai-center gap8">
-        {icon}
+        {renderedIcon}
         <p className="p-h3">
           {title}
           {price && <span className="tc-purple-500"> {price}</span>}

--- a/src/lib/components/table/components/TableCell/CardCell/CardCell.tsx
+++ b/src/lib/components/table/components/TableCell/CardCell/CardCell.tsx
@@ -1,10 +1,11 @@
 import { ReactNode } from 'react';
 import { Card } from '../../../../cards/card';
-
+import { IconRenderer } from '../../IconRenderer/IconRenderer';
 export type CardCellProps = {
   title: ReactNode;
   description?: ReactNode;
   icon?: ReactNode;
+  imageComponent?: (args: any) => JSX.Element;
   onClick?: () => void;
   href: string;
 };
@@ -15,14 +16,19 @@ export const CardCell = ({
   icon,
   onClick,
   href,
+  imageComponent,
 }: CardCellProps) => {
+  const renderedIcon = (
+    <IconRenderer icon={icon} imageComponent={imageComponent} />
+  );
+
   return (
     <div className="ta-left">
       <Card
         title={title}
         description={description}
         density="balanced"
-        icon={icon}
+        icon={renderedIcon}
         onClick={onClick}
         {...(href && { href, as: 'a' })}
         actionIcon={null}

--- a/src/lib/components/table/components/TableCell/TableCell.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.tsx
@@ -13,6 +13,7 @@ type ExtraTableCellProps = {
   isFirstCellInRow?: boolean;
   isTopLeftCell?: boolean;
   isNavigation?: boolean;
+  imageComponent?: (args: any) => JSX.Element;
 };
 
 export type TableCellProps = TableCellData & ExtraTableCellProps;

--- a/src/lib/components/table/components/TableContents/TableContents.tsx
+++ b/src/lib/components/table/components/TableContents/TableContents.tsx
@@ -7,6 +7,7 @@ import styles from './TableContents.module.scss';
 import classNames from 'classnames';
 import { Collapsible } from './Collapsible';
 import { CellReplacements, ModalFunction, TableData } from '../../types';
+import { IconRenderer } from '../IconRenderer/IconRenderer';
 
 export interface TableContentsProps {
   className?: string;
@@ -19,6 +20,7 @@ export interface TableContentsProps {
   shouldHideDetails?: boolean;
   title: string;
   cellReplacements?: CellReplacements;
+  imageComponent?: (args: any) => JSX.Element;
 }
 
 const TableContents = ({
@@ -32,6 +34,7 @@ const TableContents = ({
   shouldHideDetails,
   title,
   cellReplacements,
+  imageComponent,
 }: TableContentsProps) => {
   const [isSectionOpen, setOpenSection] = useState<number | null>(null);
   const firstHeadRow = tableData?.[0]?.rows?.[0];
@@ -50,6 +53,10 @@ const TableContents = ({
           ? true
           : isSectionOpen === index || isFirstSection;
         const isVisible = hideDetails ? !shouldHideDetails : true;
+
+        const renderedIcon = (
+          <IconRenderer icon={section.icon} imageComponent={imageComponent} />
+        );
 
         return (
           (isFirstSection || isVisible) && (
@@ -72,7 +79,7 @@ const TableContents = ({
                         icon: 'tc-grey-900',
                       }}
                       dropShadow={false}
-                      icon={section?.icon}
+                      icon={renderedIcon}
                       title={section.title}
                       titleVariant="medium"
                       {...(collapsibleSections
@@ -99,6 +106,7 @@ const TableContents = ({
                   }`}
                   width={tableWidth}
                   cellReplacements={cellReplacements}
+                  imageComponent={imageComponent}
                 />
               </Collapsible>
             </div>

--- a/src/lib/components/table/components/TableSection/TableSection.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.tsx
@@ -20,6 +20,7 @@ export interface TableSectionProps {
   title: string;
   width?: number | string;
   cellReplacements?: CellReplacements;
+  imageComponent?: (args: any) => JSX.Element;
 }
 
 const TableSection = ({
@@ -31,6 +32,7 @@ const TableSection = ({
   title,
   width,
   cellReplacements,
+  imageComponent,
 }: TableSectionProps) => {
   const headerRow = tableCellRows?.[0];
 
@@ -103,6 +105,7 @@ const TableSection = ({
                     isFirstCellInRow={isFirstCellInRow}
                     isTopLeftCell={isFirstCellInRow}
                     {...cellProps}
+                    imageComponent={imageComponent}
                   />
                 )
               );
@@ -148,6 +151,7 @@ const TableSection = ({
                         isFirstCellInRow={isFirstCellInRow}
                         key={key}
                         {...cellProps}
+                        imageComponent={imageComponent}
                       />
                     )
                   );


### PR DESCRIPTION
### What this PR does

This PR adds support for icon urls and custom image components.

![image](https://github.com/user-attachments/assets/c9768df8-6629-4e88-a47b-4005c188a874)

### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
STO-XXX
EMU-XXX
RVN-XXX

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
