### PR TITLE
fix(table): Fix scroll navigation on mobile

### DIFF
--- a/src/lib/components/table/utils/useTableNavigation/useTableNavigation.ts
+++ b/src/lib/components/table/utils/useTableNavigation/useTableNavigation.ts
@@ -35,7 +35,7 @@ export const useTableNavigation = ({
     }
 
     const containerWidth = containerRef.current.getBoundingClientRect().width;
-    const scrollLeft = containerRef.current.scrollLeft;
+    const scrollLeft = containerRef.current.scrollLeft * 1.1;
     const cellWidth = containerWidth / 2;
 
     setActiveSection(Math.floor(scrollLeft / cellWidth));


### PR DESCRIPTION
### What this PR does
Fix scroll navigation on mobile by adding a 10% increase on scroll position. This has no visible effect changes but makes sure it has some margin for error (some screens fail this by half a pixel).


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
