### PR TITLE
feat(icons): [EPIC-419] add BlogIcon to icon library

### DIFF
--- a/src/lib/components/icon/assets/blog.svg
+++ b/src/lib/components/icon/assets/blog.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 8.00001H16M8 12H16M8 16H11M21 20.2L21 3.80001C21 2.69544 20.1046 1.80001 19 1.80001H5C3.89543 1.80001 3 2.69544 3 3.80001V20.2C3 21.3046 3.89543 22.2 5 22.2H19C20.1046 22.2 21 21.3046 21 20.2Z" stroke="#8E8CEE" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/lib/components/icon/icons/Blog.tsx
+++ b/src/lib/components/icon/icons/Blog.tsx
@@ -1,0 +1,15 @@
+/* Generated file. Do not modify. */
+import { createElement } from 'react';
+import { IconWrapper } from '../IconWrapper';
+import type { IconWrapperProps } from '../IconWrapper';
+export default (props: IconWrapperProps) =>
+  createElement(
+    IconWrapper,
+    props,
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth={2}
+      d="M8 8h8m-8 4h8m-8 4h3m10 4.2V3.8a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v16.4a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2Z"
+    />
+  );

--- a/src/lib/components/icon/icons/index.ts
+++ b/src/lib/components/icon/icons/index.ts
@@ -47,6 +47,7 @@ export { default as BatteryChargingIcon } from './BatteryCharging';
 export { default as BatteryIcon } from './Battery';
 export { default as BellOffIcon } from './BellOff';
 export { default as BellIcon } from './Bell';
+export { default as BlogIcon } from './Blog';
 export { default as BluetoothIcon } from './Bluetooth';
 export { default as BoldIcon } from './Bold';
 export { default as BookOpenIcon } from './BookOpen';


### PR DESCRIPTION
### What this PR does

This PR adds `BlogIcon` to the icon library.
![image 47](https://github.com/user-attachments/assets/052b7b69-32b5-4724-beeb-bf01990e96e3)

Solves:
[EPIC-419](https://linear.app/feather-insurance/issue/EPIC-419/add-blogicon-to-ds-icon-library)

### How to test?

Check that `BlogIcon` is part of the library: http://localhost:9009/?path=/docs/jsx-icon-iconslist--docs 

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
