### PR TITLE
refactor(button): Make button a polymorphic component

### DIFF
--- a/src/lib/components/button/index.stories.tsx
+++ b/src/lib/components/button/index.stories.tsx
@@ -1,10 +1,14 @@
 import { Button, ButtonProps, ButtonVariant } from '.';
-import { PlusIcon, SendIcon } from '../icon';
+import { InfoIcon, PlusIcon, SendIcon } from '../icon';
 
 const story = {
   title: 'JSX/Button',
   component: Button,
   argTypes: {
+    as: {
+      control: { type: 'text' },
+      description: 'Allow wrapper element type to be custom defined'
+    },
     children: {
       control: 'text',
       description: 'Text that is displayed inside the button. Hidden when hideLabel is set as true',
@@ -46,6 +50,7 @@ const story = {
 };
 
 export const ButtonStory = ({
+  as,
   className,
   loading = false,
   children,
@@ -57,6 +62,7 @@ export const ButtonStory = ({
 }: ButtonProps) => (
   <div className='wmx6'>
     <Button
+      as={as}
       className={className}
       loading={loading}
       variant={variant}
@@ -198,6 +204,25 @@ export const ButtonDisabled = ({ children, onClick }: ButtonProps) => (
   <Button disabled onClick={onClick}>
     {children}
   </Button>
+);
+
+export const ButtonAsOtherComponents = ({ children, as, onClick }: ButtonProps) => (
+  <div className='d-flex fd-column gap16 p24 bg-grey-200'>
+    <h3 className='p-h3'>As an anchor:</h3>
+      <Button as="a" href="https://feather-insurance.com" target="_blank">
+        {children}
+      </Button>
+
+    <h3 className='p-h3'>As a button:</h3>
+      <Button as="button" onClick={onClick}>
+        {children}
+      </Button>
+
+    <p className='p-p p-p--small fw-bold d-flex ai-center gap8 mt32'>
+      <InfoIcon />
+      Inspect elements to see the different HTML tags being rendered.
+    </p>
+  </div>
 );
 
 export default story;

--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ElementType, ComponentProps, ReactNode } from 'react';
 
 type ButtonVariant =
   | 'filledColor'
@@ -22,7 +22,11 @@ const buttonTypeClassNameMap: { [K in ButtonVariant]: string } = {
   filledError: 'p-btn--danger',
 };
 
-type ButtonProps = {
+const buttonDefaultAs = 'button' as const;
+type ButtonDefaultAsType = typeof buttonDefaultAs;
+
+type ButtonOwnProps<E> = {
+  as?: E; 
   children: ReactNode;
   variant?: ButtonVariant;
   leftIcon?: ReactElement;
@@ -31,8 +35,12 @@ type ButtonProps = {
   hideLabel?: boolean;
 } & Omit<JSX.IntrinsicElements['button'], 'children'>;
 
-const Button = React.forwardRef((
+export type ButtonProps<E extends ElementType = ButtonDefaultAsType> = ButtonOwnProps<E> &
+  Omit<ComponentProps<E>, keyof ButtonOwnProps<E>>;
+
+const Button = React.forwardRef(<E extends ElementType = ButtonDefaultAsType>(
   {
+    as,
     className,
     loading = false,
     children,
@@ -41,10 +49,13 @@ const Button = React.forwardRef((
     rightIcon,
     hideLabel,
     ...props
-  }: ButtonProps,
-  ref?: React.ForwardedRef<HTMLButtonElement>
-) => (
-    <button
+  }: ButtonProps<E>,
+  ref?: React.ForwardedRef<E>
+) => {
+  const ButtonTag = as || 'button';
+
+  return (
+    <ButtonTag
       ref={ref}
       className={classNames(
         buttonTypeClassNameMap[variant], 
@@ -92,9 +103,9 @@ const Button = React.forwardRef((
           )}
         </div>
       ) : children}
-    </button>
+    </ButtonTag>
   )
-);
+});
 
 export { Button };
-export type { ButtonProps, ButtonVariant };
+export type { ButtonVariant };

--- a/src/lib/components/cards/card/index.tsx
+++ b/src/lib/components/cards/card/index.tsx
@@ -38,7 +38,7 @@ type CardOwnProps<E extends ElementType = CardDefaultAsType> = {
 } 
 
 export type CardProps<E extends ElementType = CardDefaultAsType> = CardOwnProps<E> &
-  Omit<ComponentProps<E>, keyof CardOwnProps<E>>
+  Omit<ComponentProps<E>, keyof CardOwnProps<E>>;
 
 const Card = <E extends ElementType = CardDefaultAsType>({
   as,

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -193,8 +193,9 @@ const Table = ({
             : infoModalData?.body}
         </div>
       </BottomOrRegularModal>
-    </div>
+    </div> 
   );
 };
 
+export type { TableData };
 export { Table };


### PR DESCRIPTION
### What this PR does
Make button a polymorphic component which means you can now pass the `as` prop and define the component as a nextjs or react-router `Link` (or other frameworks) or `a` HTML tag.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
