### PR TITLE
refactor(autocomplete-address): Expose countryCode option

### DIFF
--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -81,6 +81,7 @@ export interface AutocompleteAddressProps {
     preText?: string;
     cta?: string;
   };
+  countryCode: Alpha2CountryCode;
 }
 
 const AutocompleteAddress = ({
@@ -90,6 +91,7 @@ const AutocompleteAddress = ({
   placeholders,
   manualAddressEntryTexts,
   inputProps,
+  countryCode = GERMANY_ALPHA_CODE
 }: AutocompleteAddressProps) => {
   const [manualAddressEntry, setManualAddressEntry] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -131,7 +133,7 @@ const AutocompleteAddress = ({
 
     autocomplete.current = new google.maps.places.Autocomplete(reference, {
       types: ['address'],
-      componentRestrictions: { country: GERMANY_ALPHA_CODE },
+      componentRestrictions: { country: countryCode },
     });
 
     autocomplete.current.addListener('place_changed', onPlaceChanged);
@@ -231,7 +233,7 @@ const AutocompleteAddress = ({
       const newAddress = {
         ...address,
         [e.target.name]: e.target.value,
-        country: GERMANY_ALPHA_CODE,
+        country: countryCode,
       };
       setAddress(newAddress);
       onAddressChange(newAddress);


### PR DESCRIPTION
### What this PR does
Expose countryCode option so that we can render addresses that are not in germany.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
