### PR TITLE
fix(address): Make countryCode prop optional in AutoCompleteAddress component

### DIFF
--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -81,7 +81,7 @@ export interface AutocompleteAddressProps {
     preText?: string;
     cta?: string;
   };
-  countryCode: Alpha2CountryCode;
+  countryCode?: string;
 }
 
 const AutocompleteAddress = ({


### PR DESCRIPTION
### What this PR does
Make countryCode prop explicitly optional in AutoCompleteAddress component. It also makes it a string to match the Google Maps configuration.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
