### PR TITLE
fix(table): Remove pointer events none from ButtonCell

### DIFF
--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.module.scss
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.module.scss
@@ -18,10 +18,6 @@
       background-color: $ds-grey-200;
     }
   }
-
-  @include p-size-mobile {
-    pointer-events: none;
-  }
 }
 
 .withoutPrice {


### PR DESCRIPTION
### What this PR does
Remove pointer events none from ButtonCell as this prevents the button from being clicked on mobile.
### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
