### PR TITLE
fix(a11y): Add focus-visible states to radio and checkbox

### DIFF
--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -98,11 +98,16 @@
 .p-radio--no-icon + label::before {
   display: none !important;
 }
+
 .p-radio:checked {
   & + label::before {
     border-color: $ds-primary-500;
     background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 20 20" stroke="white" stroke-width="4" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="50%" fill="#{util.url-encoded-color($ds-primary-500)}"/></svg>');
   }
+}
+
+.p-radio:focus-visible + label {
+  outline: 1px solid $ds-primary-500;
 }
 
 .p-radio:disabled {
@@ -161,6 +166,10 @@
 
     border-color: $ds-primary-500;
   }
+}
+
+.p-checkbox:focus-visible + label {
+  outline: 1px solid $ds-primary-500;
 }
 
 .p-checkbox--no-icon + label::before {


### PR DESCRIPTION
### What this PR does
This PR adds focus-visible states to radio and checkbox.

**Before:**
<img width="490" alt="Screenshot 2024-08-21 at 11 04 53" src="https://github.com/user-attachments/assets/33656466-1fcc-4f2b-be4f-280040bcff64">
<img width="465" alt="Screenshot 2024-08-21 at 11 05 16" src="https://github.com/user-attachments/assets/f7c50d79-bb3c-47c5-bde9-26487df7e55b">

**After:**
<img width="392" alt="Screenshot 2024-08-21 at 11 04 45" src="https://github.com/user-attachments/assets/e773b1a0-5496-4c26-88ef-4e61c39133af">
<img width="371" alt="Screenshot 2024-08-21 at 11 05 26" src="https://github.com/user-attachments/assets/5ec8846c-861c-419d-82c6-ac2e212e43bb">

### Checklist:
- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
