### PR TITLE
fix(modal): Fix modal glitch with scroll bar on open/close

### DIFF
--- a/src/lib/components/modal/genericModal/style.module.scss
+++ b/src/lib/components/modal/genericModal/style.module.scss
@@ -24,7 +24,7 @@
 
 .overlay {
   z-index: 1000;
-  overflow: auto;
+  overflow: hidden;
   
   position: fixed;
   top: 0;


### PR DESCRIPTION
### What this PR does
Fix modal glitch with scroll bar on open/close.

**Before:**
https://github.com/user-attachments/assets/739ea49f-b378-41e0-af7b-5d1ed0e6e4ae

**After:**
https://github.com/user-attachments/assets/c6ad4f50-79fb-4328-ae22-5070675ae76e


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
