### PR TITLE
fix(table): [SIDE-535][SIDE-536][SIDE-537] Fix styles on table

### DIFF
--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -80,21 +80,11 @@ h4.cell {
 
   display: none;
 
-  &:after {
-    content: '';
-    display: block;
-
-    position: absolute;
-    top: calc(
-      50% + 16px
-    ); // Display bottom border at the same distance regardless of cell height
-
-    height: 4px;
-    width: 100%;
-    max-width: 140px;
-
-    background-color: $ds-primary-500;
-  }
+  line-height: 38px;
+  text-decoration: underline;
+  text-decoration-color: $ds-primary-500;
+  text-decoration-thickness: 4px;
+  text-underline-offset: 8px;
 
   @include p-size-tablet {
     display: flex;

--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -84,7 +84,7 @@ const initialData: TableData = [
       [
         {
           text: 'Regular vet visits & medication',
-          description: 'Annual Only',
+          description: 'Pflegepflichtversicherungrightno',
           modalContent: 'Some stories about vets',
         },
         { text: 'No', description: 'Annual Only' },

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
@@ -14,23 +14,18 @@
   margin: 2px;
 }
 
+.description {
+  word-break: break-word;
+}
+
 .bigWithUnderline {
   position: relative;
   display: none;
-
-  &:after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: calc(
-      50% + 16px
-    ); // Display bottom border at the same distance regardless of cell height
-
-    height: 4px;
-    width: 100%;
-    max-width: 140px;
-    background-color: $ds-primary-500;
-  }
+  line-height: 38px;
+  text-decoration: underline;
+  text-decoration-color: $ds-primary-500;
+  text-decoration-thickness: 4px;
+  text-underline-offset: 8px;
 
   @include p-size-tablet {
     display: flex;

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -170,6 +170,7 @@ export const BaseCell = ({
         {description && (
           <div
             className={classNames(
+              styles.description,
               'd-flex p-p--small tc-grey-500',
               alignClassName
             )}

--- a/src/lib/components/table/components/TableCell/TableCell.module.scss
+++ b/src/lib/components/table/components/TableCell/TableCell.module.scss
@@ -10,6 +10,10 @@
     width: auto;
     scroll-snap-align: unset;
   }
+
+  &Navigation {
+    width: auto;
+  }
 }
 
 .fixedCell {

--- a/src/lib/components/table/components/TableCell/TableCell.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.tsx
@@ -48,9 +48,10 @@ const TableCell = React.memo(
         {...scope}
         className={classNames('bg-white py24 px8', styles.th, {
           'ta-left': isFirstCellInRow,
+          [styles.thNavigation]: isNavigation,
           [styles.fixedCell]: isFirstCellInRow && colSpan < 1 ,
           [styles.fixedCard]: cellProps.type === 'CARD',
-          pl32: isFirstCellInRow,
+          pl16: isFirstCellInRow,
         })}
         colSpan={isBelowDesktop && cellProps.type === 'CARD' ? 2 : colSpan}
       >

--- a/src/lib/components/table/components/TableContents/TableContents.tsx
+++ b/src/lib/components/table/components/TableContents/TableContents.tsx
@@ -63,7 +63,7 @@ const TableContents = ({
             <div key={index}>
               {section?.title && (
                 <div className={styles.cardWrapper}>
-                  <div className={classNames(styles.card, 'p8')}>
+                  <div className={classNames(styles.card, 'p0')}>
                     <Card
                       actionIcon={
                         isExpanded ? (
@@ -75,7 +75,7 @@ const TableContents = ({
                       aria-expanded={isExpanded ? 'true' : 'false'}
                       aria-hidden
                       classNames={{
-                        wrapper: 'bg-grey-200',
+                        wrapper: 'bg-grey-200 pl16',
                         icon: 'tc-grey-900',
                       }}
                       dropShadow={false}


### PR DESCRIPTION
### What this PR does
Fix styles on table.

**Before/after:**
1. Fix underline styles when two lines:
<img width="299" alt="Screenshot 2024-08-27 at 15 15 59" src="https://github.com/user-attachments/assets/59d21087-0eb4-47a5-ac49-abe6eb6fc3b9">
<img width="222" alt="Screenshot 2024-08-27 at 15 15 40" src="https://github.com/user-attachments/assets/e80e107a-b30e-4359-b1c1-11d9615d91c5">

2. Fix mobile header not growing over 50%:
<img width="285" alt="Screenshot 2024-08-27 at 15 14 20" src="https://github.com/user-attachments/assets/52b3772e-c489-427e-a1bf-1e560965ad92">
<img width="310" alt="Screenshot 2024-08-27 at 15 14 12" src="https://github.com/user-attachments/assets/a01585bf-d2d6-4dc4-b5b0-1c85328effa9">

3. Fix word not breaking when too big:
<img width="295" alt="Screenshot 2024-08-27 at 15 14 28" src="https://github.com/user-attachments/assets/f82ca218-06cd-4aff-969c-95cee2103098">
<img width="196" alt="Screenshot 2024-08-27 at 15 14 02" src="https://github.com/user-attachments/assets/7d37cc31-7078-42b5-bc0e-bb12dea4f195">

4. Decrease left spacing on table headers:
<img width="477" alt="Screenshot 2024-08-27 at 15 15 11" src="https://github.com/user-attachments/assets/316af836-b672-41a8-8f4e-a4e762026b3e">
<img width="705" alt="Screenshot 2024-08-27 at 15 14 49" src="https://github.com/user-attachments/assets/3e3511ef-60c5-401f-a2fe-04ca4aff4d49">


Solves:
SIDE-535
SIDE-536
SIDE-537

### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
