### PR TITLE
refactor(button): Make button a polymorphic component

### DIFF
--- a/src/lib/components/button/index.stories.tsx
+++ b/src/lib/components/button/index.stories.tsx
@@ -1,10 +1,15 @@
+import { ElementType } from 'react';
 import { Button, ButtonProps, ButtonVariant } from '.';
-import { PlusIcon, SendIcon } from '../icon';
+import { InfoIcon, PlusIcon, SendIcon } from '../icon';
 
 const story = {
   title: 'JSX/Button',
   component: Button,
   argTypes: {
+    as: {
+      control: { type: 'text' },
+      description: 'Allow wrapper element type to be custom defined'
+    },
     children: {
       control: 'text',
       description: 'Text that is displayed inside the button. Hidden when hideLabel is set as true',
@@ -198,6 +203,30 @@ export const ButtonDisabled = ({ children, onClick }: ButtonProps) => (
   <Button disabled onClick={onClick}>
     {children}
   </Button>
+);
+
+export const ButtonAsOtherComponents = ({ children, as, onClick }: ButtonProps) => (
+  <div className='d-flex fd-column gap16 p24 bg-grey-200'>
+    <h3 className='p-h3'>As an anchor:</h3>
+      <Button as="a" href="https://feather-insurance.com" target="_blank">
+        {children}
+      </Button>
+
+  <h3 className='p-h3'>As a button:</h3>
+    <Button as="button" onClick={onClick}>
+      {children}
+    </Button>
+
+  <h3 className='p-h3'>As a h3:</h3>
+    <Button as="h3">
+      {children}
+    </Button>
+
+    <p className='p-p p-p--small fw-bold d-flex ai-center gap8 mt32'>
+      <InfoIcon />
+      Inspect elements to see the different HTML tags being rendered.
+    </p>
+  </div>
 );
 
 export default story;

--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -23,6 +23,7 @@ const buttonTypeClassNameMap: { [K in ButtonVariant]: string } = {
 };
 
 type ButtonProps = {
+  as?: React.ElementType
   children: ReactNode;
   variant?: ButtonVariant;
   leftIcon?: ReactElement;
@@ -31,8 +32,24 @@ type ButtonProps = {
   hideLabel?: boolean;
 } & Omit<JSX.IntrinsicElements['button'], 'children'>;
 
+const buttonDefaultAsType = 'button' as const;
+type ButtonDefaultAsType = typeof buttonDefaultAsType;
+
+type Merge<P1 = {}, P2 = {}> = Omit<P1, keyof P2> & P2;
+type IntrinsicElement<E> = E extends PolymorphicButton ? IntrinsicElement<E> : never;
+
+interface PolymorphicButton {
+  <As = ButtonDefaultAsType>(props:
+  As extends React.ComponentType<infer P> ? Merge<P, ButtonProps & {
+      as?: As;
+  }> : As extends keyof JSX.IntrinsicElements ? Merge<JSX.IntrinsicElements[As], ButtonProps & {
+      as?: As;
+  }> : never): React.ReactElement | null;
+}
+
 const Button = React.forwardRef((
   {
+    as: ButtonTag = buttonDefaultAsType,
     className,
     loading = false,
     children,
@@ -44,7 +61,7 @@ const Button = React.forwardRef((
   }: ButtonProps,
   ref?: React.ForwardedRef<HTMLButtonElement>
 ) => (
-    <button
+    <ButtonTag
       ref={ref}
       className={classNames(
         buttonTypeClassNameMap[variant], 
@@ -92,9 +109,9 @@ const Button = React.forwardRef((
           )}
         </div>
       ) : children}
-    </button>
+    </ButtonTag>
   )
-);
+) as PolymorphicButton;
 
 export { Button };
 export type { ButtonProps, ButtonVariant };

--- a/src/lib/components/cards/card/index.stories.tsx
+++ b/src/lib/components/cards/card/index.stories.tsx
@@ -3,6 +3,7 @@ import { illustrations } from '../../../util/images';
 import { Button } from '../../button';
 import { Badge } from '../../badge';
 import { CheckIcon, InfoIcon, MehIcon, PlusCircleIcon, XIcon } from '../../icon';
+import { Link } from '../../link';
 
 const story = {
   title: 'JSX/Cards/Card',
@@ -241,10 +242,11 @@ export const CardsWithinCardsAndComplexLayout = () => (
           Coverage overview
 
           <Button
-            onClick={() => {}}
-            variant='filledGray'
+          as="a"
+          href="#"
+            onClick={console.log}
           >
-            Full coverage details
+            Full covxerage details
           </Button>
         </div>
       )}


### PR DESCRIPTION
### What this PR does
Make button a polymorphic component which means you can now pass the `as` prop and define the component as a nextjs or react-router `Link` (or other frameworks) or `a` HTML tag.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
