### PR TITLE
refactor(date-selector): [SIDE-380] Disable DateSelector auto-advance

### DIFF
--- a/src/lib/components/dateSelector/index.test.tsx
+++ b/src/lib/components/dateSelector/index.test.tsx
@@ -82,7 +82,7 @@ describe('DateSelector component', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('should show error boundaries error for ,ax date onChange empty when year out of boundaries', async () => {
+  it('should show error boundaries error for max date onChange empty when year out of boundaries', async () => {
     const callback = jest.fn();
     const date = '2100-01-01';
     const { getByTestId } = setup(date, callback);
@@ -126,18 +126,6 @@ describe('DateSelector component', () => {
     expect(getByLabelText('Day')).toHaveValue('3');
     expect(getByLabelText('Month')).toHaveValue('7');
     expect(callback).toHaveBeenCalledWith('2023-07-03');
-  });
-
-  it('should navigate inputs from day to month when day is over 3', async () => {
-    const callback = jest.fn();
-    const date = '2024-01-01';
-    const { getByLabelText, user } = setup(date, callback);
-
-    await user.type(getByLabelText('Day'), '{backspace}45');
-
-    expect(getByLabelText('Day')).toHaveValue('4');
-    expect(getByLabelText('Month')).toHaveValue('5');
-    expect(callback).toHaveBeenCalledWith('2024-05-04');
   });
 
   describe('Calendar button', () => {

--- a/src/lib/components/dateSelector/index.tsx
+++ b/src/lib/components/dateSelector/index.tsx
@@ -147,68 +147,6 @@ export const DateSelector = ({
     }
   };
 
-  const handleOnKeyDown = (event: KeyboardEvent<HTMLInputElement>, index: number) => {
-    const currentInput = itemsRef.current?.[index];
-    const inputSelectionStart = currentInput?.selectionStart;
-    const inputSelectionEnd = currentInput?.selectionEnd;
-
-    if (
-      // is not day input
-      index > 0 &&
-      // has clicked backspace or arrow left
-      ['Backspace', "ArrowLeft"].includes(event.key) && 
-      // is focused at the first character of the input
-      inputSelectionStart === 0 && inputSelectionEnd === 0
-    ) {
-      const prevInput = itemsRef.current?.[index - 1];
-
-      event.preventDefault();
-      prevInput?.focus();
-      prevInput?.setSelectionRange(0, 3);
-    }
-
-    if (
-        // is not year input
-        index < 2
-        // has clicked arrow right
-        && event.key === "ArrowRight"
-        // is focused at the last character of the input value
-        && inputSelectionStart === currentInput.value.length
-      ) {
-      const nextInput = itemsRef.current?.[index + 1];
-      
-      event.preventDefault();
-      nextInput?.focus();
-      nextInput?.setSelectionRange(0, index === 1 ? 4 : 3);
-    }
-  }
-
-  const handleOnKeyUp = (event: KeyboardEvent<HTMLInputElement>, index: number) => {
-    const currentInput = itemsRef.current?.[index];
-    const inputSelectionStart = currentInput?.selectionStart;
-
-    if (
-        // is not year input
-        index < 2
-        // is a number key
-        && /^\d+$/.test(event.key)
-        && (
-          // is focused at the last character of the input value
-          inputSelectionStart === currentInput.maxLength 
-          // or month value is over 1 or day value is over 3
-          || Number(currentInput.value) > (index === 1 ? 1 : 3)
-        )
-      ) {
-      const nextInput = itemsRef.current?.[index + 1];
-      
-      event.preventDefault();
-      event.stopPropagation();
-      
-      nextInput?.focus();
-      nextInput?.setSelectionRange(0, index === 1 ? 4 : 3);
-    }
-  }
-
   const getInputProps = (key: keyof CalendarDate, index: number): DateSelectorInputProps => ({
     'data-cy': `date-selector-${key}`,
     'data-testid': `date-selector-${key}`,
@@ -225,8 +163,6 @@ export const DateSelector = ({
     type: "text", 
     inputMode: "numeric",
     ref: (el: HTMLInputElement) => { itemsRef.current[index] = el }, 
-    onKeyUp: (event: KeyboardEvent<HTMLInputElement>) => handleOnKeyUp(event, index),
-    onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => handleOnKeyDown(event, index),
     onChange: ({ target }: ChangeEvent<HTMLInputElement>) => handleOnChange(key, target.value),
     ...inputProps?.(key) || {},
   });


### PR DESCRIPTION
### What this PR does
This PR removes the auto-advance from DateSelector where a cursor would move to the next input if reaching end of current input (e.g. typed 12 on day would move cursor automatically to month or typing 4 in month would move cursor to year).

Solves:
SIDE-380

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
