### PR TITLE
refactor(table): [SIDE-553] Show header title (first cell in first row) on mobile screens

### DIFF
--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -78,6 +78,10 @@ const Table = ({
     onSelectionChanged,
   });
 
+  const titleCell = {
+    text: '',
+    ...tableData?.[0]?.rows?.[0]?.[0] || {},
+  };
   const currentActiveSection = tableData?.[0]?.rows?.[0]?.[activeSection];
   const currentActiveSectionReplacements =
     (currentActiveSection.cellId &&
@@ -97,27 +101,39 @@ const Table = ({
   return (
     <div className={classNames(styles.wrapper, 'bg-white')}>
       {isMobile ? (
-        <TableControls
-          activeSection={activeSection}
-          columnsLength={columnsLength}
-          navigateTable={navigateTable}
-          stickyHeaderTopOffset={stickyHeaderTopOffset}
-        >
-          <TableCell
-            {...(isBaseCell(currentActiveSection)
-              ? {
-                  openModal: (body: ReactNode) =>
-                    handleOpenModal({
-                      body,
-                      title: currentActiveSection?.text,
-                    }),
-                }
-              : {})}
-            {...activeCellProps}
-            imageComponent={imageComponent}
-            isNavigation
-          />
-        </TableControls>
+        <>
+          {titleCell?.text && (
+            <TableCell
+              {...titleCell}
+              align='left'
+              isNavigation
+              isTopLeftCell
+              type={undefined}
+            />
+          )}
+
+          <TableControls
+            activeSection={activeSection}
+            columnsLength={columnsLength}
+            navigateTable={navigateTable}
+            stickyHeaderTopOffset={stickyHeaderTopOffset}
+          >
+            <TableCell
+              {...(isBaseCell(currentActiveSection)
+                ? {
+                    openModal: (body: ReactNode) =>
+                      handleOpenModal({
+                        body,
+                        title: currentActiveSection?.text,
+                      }),
+                  }
+                : {})}
+              {...activeCellProps}
+              imageComponent={imageComponent}
+              isNavigation
+            />
+          </TableControls>
+        </>
       ) : (
         <div
           aria-hidden

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
@@ -20,14 +20,10 @@
 
 .bigWithUnderline {
   position: relative;
-  display: none;
+  display: flex;
   line-height: 38px;
   text-decoration: underline;
   text-decoration-color: $ds-primary-500;
   text-decoration-thickness: 4px;
   text-underline-offset: 8px;
-
-  @include p-size-tablet {
-    display: flex;
-  }
 }


### PR DESCRIPTION
### What this PR does
Show header title (first cell in first row) on mobile screens

Solves:
SIDE-553

**Before:**
<img width="457" alt="Screenshot 2024-08-30 at 10 02 48" src="https://github.com/user-attachments/assets/3e9a5979-ec19-484c-bba2-56707f535af7">


**After:**
<img width="467" alt="Screenshot 2024-08-30 at 10 02 27" src="https://github.com/user-attachments/assets/4198fc8d-6a7b-4b19-a789-602309c355e7">


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
