### PR TITLE
refactor(table): Update BIG_WITH_UNDERLINE to be an h2

### DIFF
--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -141,7 +141,7 @@ export const BaseCell = ({
             )}
 
             {text && fontVariant === 'BIG_WITH_UNDERLINE' && (
-              <div
+              <h2
                 aria-hidden
                 className={classNames(
                   'tc-grey-800 p-h2 p--serif',
@@ -149,7 +149,7 @@ export const BaseCell = ({
                 )}
               >
                 {text}
-              </div>
+              </h2>
             )}
 
             {modalContent && openModal && align == 'left' && (


### PR DESCRIPTION
### What this PR does
Update BIG_WITH_UNDERLINE to be an h2.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
