### PR TITLE
fix(table): [SIDE-637] do not push info button to next column

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -122,7 +122,10 @@ const initialData: TableData = [
       ],
       [
         { text: 'Operations', modalContent: 'info' },
-        { checkmarkValue: true, modalContent: 'Maybe' },
+        {
+          text: 'This is a table cell with a lot of text',
+          modalContent: 'Maybe',
+        },
         { checkmarkValue: false },
         { checkmarkValue: true },
       ],

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
@@ -5,6 +5,12 @@
   position: relative;
 }
 
+.maxWidth {
+  @include p-size-mobile {
+    max-width: calc(100% - 64px);
+  }
+}
+
 .infoButtonAbsolute {
   position: absolute;
   right: -32px;

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import {
   CheckIcon,
-  XIcon,
   StarFilledIcon,
+  XIcon,
   ZapFilledIcon,
 } from '../../../../icon';
 import { ReactNode } from 'react';
@@ -80,7 +80,8 @@ export const BaseCell = ({
         className={classNames(
           'd-flex fd-column',
           alignClassName,
-          styles.relative
+          styles.relative,
+          { [styles.maxWidth]: align === 'center' }
         )}
       >
         {progressBarValue !== undefined && (


### PR DESCRIPTION
### What this PR does

This PR updates the `<Table />` component to prevent long strings of text to push info buttons:

| Before | After |
|--------|--------|
| <img width="320" alt="Screenshot 2024-09-20 at 10 14 20" src="https://github.com/user-attachments/assets/f706300f-1855-41e4-b277-175ee3b86510"> | <img width="321" alt="Screenshot 2024-09-20 at 10 13 18" src="https://github.com/user-attachments/assets/1a69f4ff-4d7d-4247-874f-e6ee839c43ce"> | 

### Why is this needed?

To keep info buttons on the same column as the content

Solves:
SIDE-637

### How to test?
You can check the new behavior [on Storybook](http://localhost:9009/?path=/story/jsx-table--table-story&globals=viewport:mobile1). You can try and change the text length of the cells content and see how the info button behaves on both mobile and desktop.

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)
- [ ] 

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
