### PR TITLE
feat(button): [SIDE-647] introduce the `filledBlack` variant

### DIFF
--- a/src/lib/components/button/index.stories.tsx
+++ b/src/lib/components/button/index.stories.tsx
@@ -76,7 +76,7 @@ export const ButtonVariants = ({ children, onClick }: ButtonProps) => (
   <div>
     <h3 className='p-h3 mb24'>Filled variants</h3>
     <div className='d-flex gap16 p24 bg-grey-300 br8'>
-      {[ "filledColor", "filledGray", "filledWhite"].map((variant) => (
+      {[ "filledColor", "filledGray", "filledWhite", "filledBlack"].map((variant) => (
           <div key={variant}>
             <h4 className='p-h4 mb16'>
               {variant}

--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -5,6 +5,7 @@ type ButtonVariant =
   | 'filledColor'
   | 'filledGray'
   | 'filledWhite'
+  | 'filledBlack'
   | 'textColor'
   | 'textWhite'
   | 'outlineWhite'
@@ -15,6 +16,7 @@ const buttonTypeClassNameMap: { [K in ButtonVariant]: string } = {
   filledColor: 'p-btn--primary',
   filledGray: 'p-btn--secondary-grey',
   filledWhite: 'p-btn--secondary-white',
+  filledBlack: 'p-btn--secondary-black',
   textColor: 'p-btn--secondary',
   textWhite: 'p-btn--secondary-inverted',
   outlineWhite: 'p-btn--outline-white',

--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -113,8 +113,29 @@
       @extend .p-btn--secondary;
       color: $ds-white;
 
-      &:hover, &:focus {
+      &:hover,
+      &:focus {
         background-color: $ds-primary-700;
+      }
+    }
+
+    &-black {
+      @extend .p-btn--secondary;
+      background-color: $ds-grey-900;
+      color: white;
+
+      &:hover {
+        background-color: $ds-grey-700;
+      }
+
+      &[disabled] {
+        background-color: $ds-grey-300;
+        opacity: 1;
+      }
+
+      &:focus {
+        outline: none;
+        box-shadow: 0 0 0 1px $ds-grey-900;
       }
     }
   }
@@ -271,14 +292,13 @@
       animation: spinner-rotate 0.9s infinite;
     }
 
-    &.p-btn--secondary,
+    &.p-btn--secondary:not(.p-btn--secondary-black),
     &.p-btn--secondary-grey,
     &.p-btn--secondary-white {
       &::before {
-      border-color: rgba($color: $ds-primary-500, $alpha: 0.5);
-      border-left-color: $ds-primary-500;
+        border-color: rgba($color: $ds-primary-500, $alpha: 0.5);
+        border-left-color: $ds-primary-500;
       }
     }
   }
-
 }

--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -129,13 +129,13 @@
       }
 
       &[disabled] {
-        background-color: $ds-grey-300;
+        background-color: $ds-grey-700;
         opacity: 1;
       }
 
       &:focus {
-        outline: none;
-        box-shadow: 0 0 0 1px $ds-grey-900;
+        box-shadow: 0 0 0 1px white,
+          0 0 0 3px rgba($color: $ds-primary-900, $alpha: 0.5);
       }
     }
   }

--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -129,8 +129,12 @@
       }
 
       &[disabled] {
-        background-color: $ds-grey-700;
-        opacity: 1;
+        background-color: $ds-grey-900;
+        color: white;
+
+        &:hover {
+          background-color: $ds-grey-900;
+        }
       }
 
       &:focus {


### PR DESCRIPTION
### What this PR does

This PR introduces a new button variant (`filledBlack`) -> [Figma](https://www.figma.com/design/MKs4cbojdVOBKUxv7okb93/Dirty-Swan-Design-System?node-id=17167-87383&t=O1Hc6mhD7LNMUBMU-4)

<img width="583" alt="image 16" src="https://github.com/user-attachments/assets/8ef0b1cb-ab45-4f91-8ff4-f0ce54f79653">

<img width="156" alt="image 15" src="https://github.com/user-attachments/assets/77082ab2-96d2-4033-8ff8-403856365287">


### Why is this needed?

The Design team is introducing this variant in our system. 
We need to implement this variant with high priority in the B2B website banner (as a start). 

Solves:
SIDE-647

### How to test?

You can check the new button variant locally [here](http://localhost:9009/?path=/story/jsx-button--button-variants), also for the hover, focus, and disabled state. 

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
