### PR TITLE
refactor(table): update info button positioning

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -162,7 +162,11 @@ const initialData: TableData = [
       ],
       [
         { text: 'Operations', modalContent: 'info' },
-        { checkmarkValue: true, modalContent: 'Maybe' },
+        {
+          checkmarkValue: true,
+          modalContent: 'Maybe',
+          description: 'This is a table cell with a long subtitle',
+        },
         { checkmarkValue: false },
         { checkmarkValue: true },
       ],

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.module.scss
@@ -1,19 +1,10 @@
 @use "../../../../../scss/public/grid" as *;
 @use "../../../../../scss/public/colors" as *;
 
-.relative {
-  position: relative;
-}
-
 .maxWidth {
   @include p-size-mobile {
     max-width: calc(100% - 64px);
   }
-}
-
-.infoButtonAbsolute {
-  position: absolute;
-  right: -32px;
 }
 
 .icon {

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -77,38 +77,36 @@ export const BaseCell = ({
       })}
     >
       <div
-        className={classNames(
-          'd-flex fd-column',
-          alignClassName,
-          styles.relative,
-          { [styles.maxWidth]: modalContent && align === 'center' }
-        )}
+        className={classNames('d-flex fd-column', alignClassName, {
+          [styles.maxWidth]: modalContent && align === 'center',
+        })}
       >
         {progressBarValue !== undefined && (
           <MiniProgressBar nFilledBars={progressBarValue} />
         )}
 
-        {rating?.value && (
-          <span
-            data-testid="table-cell-rating"
-            title={`${rating?.value} out of 3`}
-          >
-            {validRatingValues.map((value) => (
-              <SelectedIcon
-                aria-hidden="true"
-                key={value}
-                color={value <= rating?.value ? 'primary-500' : 'grey-400'}
-                className={styles.icon}
-              />
-            ))}
-          </span>
-        )}
-
         <div className="d-flex ai-center">
+          {rating?.value && (
+            <span
+              data-testid="table-cell-rating"
+              title={`${rating?.value} out of 3`}
+            >
+              {validRatingValues.map((value) => (
+                <SelectedIcon
+                  aria-hidden="true"
+                  key={value}
+                  color={value <= rating?.value ? 'primary-500' : 'grey-400'}
+                  className={styles.icon}
+                />
+              ))}
+            </span>
+          )}
+
           {checkmarkValue !== undefined && (
             <span title={checkmarkValue ? 'Yes' : 'No'}>
               {checkmarkValue ? (
                 <CheckIcon
+                  noMargin
                   data-testid="table-cell-boolean-yes"
                   size={24}
                   aria-hidden
@@ -116,6 +114,7 @@ export const BaseCell = ({
                 />
               ) : (
                 <XIcon
+                  noMargin
                   data-testid="table-cell-boolean-no"
                   size={24}
                   aria-hidden
@@ -127,7 +126,7 @@ export const BaseCell = ({
 
           <div className="d-inline">
             {text && fontVariant === 'NORMAL' && (
-              <div className="p-p d-inline" data-testid="table-cell-text">
+              <div className="p-p d-inline ml8" data-testid="table-cell-text">
                 {text}
               </div>
             )}
@@ -153,7 +152,7 @@ export const BaseCell = ({
               </h2>
             )}
 
-            {modalContent && openModal && align == 'left' && (
+            {modalContent && openModal && (
               <span className="ml8">
                 <TableInfoButton
                   onClick={() =>
@@ -178,19 +177,6 @@ export const BaseCell = ({
           >
             {description}
           </div>
-        )}
-
-        {modalContent && openModal && align == 'center' && (
-          <span className={styles.infoButtonAbsolute}>
-            <TableInfoButton
-              onClick={() =>
-                openModal({
-                  title: modalTitle,
-                  body: modalContent,
-                })
-              }
-            />
-          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
### What this PR does

This PR updates the position of table's info button component, so it doesn't get pushed whenever the table cell has long content.

**Before**
<img width="1010" alt="372394235-decd6b23-4f1c-485b-ab19-c278a907ba06" src="https://github.com/user-attachments/assets/97d39438-ca84-4e99-9d75-53ec6140bb6d">

**After**
<img width="1020" alt="Screenshot 2024-10-01 at 10 58 22" src="https://github.com/user-attachments/assets/54052e66-ce79-4d3f-bfa5-52785c413c1c">
