### PR TITLE
fix(google-check): Fix AutoCompleteAddress checking google

### DIFF
--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -101,7 +101,7 @@ const AutocompleteAddress = ({
   const marker = useRef<google.maps.Marker | null>(null);
   const [address, setAddress] = useState(initialAddress);
   const [hasLoadedGoogleAPI, setHasLoadedGoogleAPI] = useState(
-    window.google !== undefined
+    window.google?.maps !== undefined
   );
 
   loadGoogleMapsApiDynamically(() => {


### PR DESCRIPTION
### What this PR does
 Fix AutoCompleteAddress checking google initialised state. Since this was just checking if google was initialised, it could break if there are other google APIs present on the same codebase also using the `window.google` namespace.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
