### PR TITLE
feat(accessibility): [NoTicket] update modal and hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-autosuggest": "^10.1.0",
     "react-day-picker": "^7.4.10",
     "react-dropzone": "^14.2.2",
+    "react-focus-lock": "^2.13.2",
     "react-hot-toast": "^2.4.1",
     "react-scroll-sync": "^0.11.2",
     "sass": "^1.35.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ export {
   BottomModal,
   RegularModal,
   BottomOrRegularModal,
+  FullScreenModal,
   InfoCard,
   CardButton,
   Card,
@@ -40,6 +41,8 @@ export {
   Toggle,
   Toaster,
   toast,
+  useEscapeKey,
+  useFocusWithin,
 } from './lib';
 
 export * from './lib/components/icon';
@@ -58,7 +61,7 @@ export type {
   CardProps,
   IconWrapperProps,
   TableData,
-  TableProps
+  TableProps,
 } from './lib';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/lib/components/modal/fullScreenModal/index.tsx
+++ b/src/lib/components/modal/fullScreenModal/index.tsx
@@ -1,0 +1,24 @@
+import { Props } from "..";
+import styles from "./style.module.scss";
+import classNames from "classnames";
+import { GenericModal } from "../genericModal";
+
+const FullScreenModal = ({ className, ...rest }: Props) => (
+  <GenericModal
+    titleSize="small"
+    classNames={{
+      wrapper: "w100",
+      container: ({ isClosing }) => classNames(
+        "bg-white d-flex fd-column w100",
+        className,
+        styles.container, {
+          [styles.containerClose]: isClosing, 
+        }
+      ),
+      body: styles.body,
+    }}
+    {...rest}
+  />
+);
+
+export { FullScreenModal };

--- a/src/lib/components/modal/fullScreenModal/style.module.scss
+++ b/src/lib/components/modal/fullScreenModal/style.module.scss
@@ -1,0 +1,49 @@
+@use '../../../scss/public/grid' as *;
+@use '../../../scss/public/colors' as *;
+
+@keyframes appear-in {
+  0% {
+    opacity: 0;
+    visibility: hidden;
+  }
+  100% {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+@keyframes disappear-out {
+  0% {
+    opacity: 1;
+    visibility: visible;
+  }
+  100% {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+.container {
+  max-height: 100vh;
+  top: 0;
+  bottom: 0;
+  position: fixed;
+
+  animation-name: appear-in;
+  animation-duration: 0.4s;
+  animation-fill-mode: both;
+  animation-timing-function: ease-out;
+
+  &Close {
+    animation-name: disappear-out;
+    animation-duration: 0.4s;
+    animation-delay: 0s;
+    animation-fill-mode: both;
+    animation-timing-function: ease-out;
+  }
+}
+
+.body {
+  @include p-size-mobile {
+    padding-bottom: 48px;
+  }
+}

--- a/src/lib/components/modal/genericModal/index.tsx
+++ b/src/lib/components/modal/genericModal/index.tsx
@@ -73,6 +73,8 @@ const InnerModal = ({
         }
       >
         <div
+          aria-modal="true"
+          role="dialog"
           className={
             typeof classNames?.container === 'string' 
             ? classNames?.container 

--- a/src/lib/components/modal/genericModal/index.tsx
+++ b/src/lib/components/modal/genericModal/index.tsx
@@ -6,6 +6,7 @@ import classNamesUtil from 'classnames';
 import { Button } from '../../button';
 import { XIcon } from '../../icon';
 import { useRef, useEffect } from 'react';
+import FocusLock from 'react-focus-lock';
 
 interface GenericModalProps extends Props {
   classNames?: {
@@ -43,12 +44,12 @@ const InnerModal = ({
     }
     const handleOnScroll = () => {
       if (modalBodyRef.current) {
-        onModalScroll(modalBodyRef.current.scrollTop, modalBodyRef.current)
+        onModalScroll(modalBodyRef.current.scrollTop, modalBodyRef.current);
       }
-    }
-  
+    };
+
     modalBodyRef.current.addEventListener('scroll', handleOnScroll);
-  
+
     return () => {
       modalBodyRef.current?.removeEventListener('scroll', handleOnScroll);
     };
@@ -56,19 +57,16 @@ const InnerModal = ({
 
   return (
     <div
-      className={classNamesUtil(
-        classNames?.overlay,
-        styles.overlay, {
-          [styles.overlayClose]: isClosing,
-        }
-      )}
+      className={classNamesUtil(classNames?.overlay, styles.overlay, {
+        [styles.overlayClose]: isClosing,
+      })}
       onAnimationEnd={handleOnCloseAnimationEnded}
       onClick={handleOnOverlayClick}
     >
-      <div 
+      <div
         className={
-          typeof classNames?.wrapper === 'string' 
-            ? classNames?.wrapper 
+          typeof classNames?.wrapper === 'string'
+            ? classNames?.wrapper
             : classNames?.wrapper?.({ isClosing })
         }
       >
@@ -76,87 +74,80 @@ const InnerModal = ({
           aria-modal="true"
           role="dialog"
           className={
-            typeof classNames?.container === 'string' 
-            ? classNames?.container 
-            : classNames?.container?.({ isClosing })
+            typeof classNames?.container === 'string'
+              ? classNames?.container
+              : classNames?.container?.({ isClosing })
           }
           onClick={handleContainerClick}
         >
-
-          <div
-            className={classNamesUtil(
-              'bg-white d-flex ai-center w100 px24 pt24 pb16',
-              styles.header, {
-                'jc-between': !!title,
-                'jc-end': !title,
-              }
-            )}
-          >
-            {title && (
-              <div
-                className={classNamesUtil(
-                  styles.title,
-                  titleSize === 'small' ? 'p-h4' : 'p-h2'
-                )}
-              >
-                {title}
-              </div>
-            )}
-          
-            {dismissible && (
-              <Button
-                hideLabel
-                leftIcon={<XIcon color="grey-700" />}
-                onClick={handleOnClose}
-                type="button"
-                variant="textColor"
-                className={classNamesUtil(
-                  classNames?.closeButton,
-                  'p0',
-                  styles.closeButton
-                )}
-              >
-                Close modal
-              </Button>
-            )}
-          </div>
-
-          <div
-            className={classNamesUtil(
-              'w100',
-              classNames?.body,
-              styles.body
-            )}
-            ref={modalBodyRef}
-          >
-            {children}
-          </div>
-
-          {footer && (
+          <FocusLock returnFocus>
             <div
               className={classNamesUtil(
-                classNames?.footer,
-                'w100 bg-white',
-                styles.footer
+                'bg-white d-flex ai-center w100 px24 pt24 pb16',
+                styles.header,
+                {
+                  'jc-between': !!title,
+                  'jc-end': !title,
+                }
               )}
             >
-              <div className="p24 pt16">
-                {footer}
-              </div>
+              {title && (
+                <div
+                  className={classNamesUtil(
+                    styles.title,
+                    titleSize === 'small' ? 'p-h4' : 'p-h2'
+                  )}
+                >
+                  {title}
+                </div>
+              )}
+
+              {dismissible && (
+                <Button
+                  hideLabel
+                  leftIcon={<XIcon color="grey-700" />}
+                  onClick={handleOnClose}
+                  type="button"
+                  variant="textColor"
+                  className={classNamesUtil(
+                    classNames?.closeButton,
+                    'p0',
+                    styles.closeButton
+                  )}
+                >
+                  Close modal
+                </Button>
+              )}
             </div>
-          )}
+
+            <div
+              className={classNamesUtil('w100', classNames?.body, styles.body)}
+              ref={modalBodyRef}
+            >
+              {children}
+            </div>
+
+            {footer && (
+              <div
+                className={classNamesUtil(
+                  classNames?.footer,
+                  'w100 bg-white',
+                  styles.footer
+                )}
+              >
+                <div className="p24 pt16">{footer}</div>
+              </div>
+            )}
+          </FocusLock>
         </div>
       </div>
     </div>
   );
-}
+};
 
 export const GenericModal = (props: GenericModalProps) => {
-  const { isOpen, onClose, dismissible = true } = props; 
-  const {
-    isVisible,
-    ...rest
-  } = useOnClose(onClose, isOpen, dismissible);
+  const { isOpen, onClose, dismissible = true } = props;
+  const { isVisible, ...rest } = useOnClose(onClose, isOpen, dismissible);
 
   if (!isVisible) {
     return null;

--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -4,7 +4,9 @@ export interface OnCloseReturn {
   isClosing: boolean;
   isVisible: boolean;
   handleOnCloseAnimationEnded: () => void;
-  handleContainerClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  handleContainerClick: (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => void;
   handleOnClose: () => void;
   handleOnOverlayClick: () => void;
 }
@@ -16,11 +18,8 @@ const useOnClose = (
 ): OnCloseReturn => {
   const [isVisible, setIsVisible] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
-  const triggerButtonRef = useRef<HTMLElement | null>(null);
 
   const handleOnClose = useCallback(() => {
-    triggerButtonRef.current?.focus();
-    triggerButtonRef.current = null;  
     setIsClosing(true);
   }, []);
 
@@ -63,8 +62,8 @@ const useOnClose = (
     if (isOpen) {
       setIsVisible(true);
     }
-    
-    if (!isOpen && isVisible){
+
+    if (!isOpen && isVisible) {
       handleOnClose();
     }
 
@@ -74,16 +73,6 @@ const useOnClose = (
       document.body.style.overflow = 'auto';
     };
   }, [handleOnClose, isOpen, isVisible]);
-
-  useEffect(() => {
-    if (!isVisible) {
-      return;
-    }
-
-    if (document.activeElement && document.activeElement instanceof HTMLElement) {
-      triggerButtonRef.current = document.activeElement;
-    }
-  }, [isVisible]);
 
   const handleContainerClick = (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>
@@ -97,7 +86,7 @@ const useOnClose = (
     handleContainerClick,
     handleOnCloseAnimationEnded,
     handleOnClose,
-    handleOnOverlayClick
+    handleOnOverlayClick,
   };
 };
 

--- a/src/lib/components/modal/hooks/useOnClose.ts
+++ b/src/lib/components/modal/hooks/useOnClose.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface OnCloseReturn {
   isClosing: boolean;
@@ -16,8 +16,11 @@ const useOnClose = (
 ): OnCloseReturn => {
   const [isVisible, setIsVisible] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
+  const triggerButtonRef = useRef<HTMLElement | null>(null);
 
   const handleOnClose = useCallback(() => {
+    triggerButtonRef.current?.focus();
+    triggerButtonRef.current = null;  
     setIsClosing(true);
   }, []);
 
@@ -39,9 +42,9 @@ const useOnClose = (
 
   const handleEscKey = useCallback(
     (e: KeyboardEvent) => {
-      if (e.code !== 'Escape') return;
-      if (!dismissable) return null;
-      if (!isOpen) return null;
+      if (e.code !== 'Escape' || !dismissable || !isOpen) {
+        return null;
+      }
 
       handleOnClose();
     },
@@ -71,6 +74,16 @@ const useOnClose = (
       document.body.style.overflow = 'auto';
     };
   }, [handleOnClose, isOpen, isVisible]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
+
+    if (document.activeElement && document.activeElement instanceof HTMLElement) {
+      triggerButtonRef.current = document.activeElement;
+    }
+  }, [isVisible]);
 
   const handleContainerClick = (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>

--- a/src/lib/components/modal/index.stories.tsx
+++ b/src/lib/components/modal/index.stories.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { BottomModal, BottomOrRegularModal, Props, RegularModal } from '.';
 import { Button } from '../button';
+import { FullScreenModal } from './fullScreenModal';
 
 const story = {
   title: 'JSX/Modals',
@@ -88,7 +89,7 @@ export const BottomOrRegularModalStory = ({
   return (
     <>
       <button
-        className="p-btn--primary wmn2"
+        className="d-flex p-btn--primary wmn2"
         onClick={() => setDisplay(true)}
       >
         Click to open modal
@@ -140,7 +141,7 @@ export const RegularModalStory = ({
       Want to use either Regular Modal or Bottom Modal based on the screen width? You can use Bottom or Regular modal.
 
       <button
-        className="p-btn--primary wmn2 mt24"
+        className="d-flex p-btn--primary wmn2 mt24"
         onClick={() => setDisplay(true)}
       >
         Click to open modal
@@ -188,7 +189,7 @@ export const BottomModalStory = ({
       Want to use either Regular Modal or Bottom Modal based on the screen width? You can use Bottom or Regular modal.
 
       <button
-        className="p-btn--primary wmn2 mt24"
+        className="d-flex p-btn--primary wmn2 mt24"
         onClick={() => setDisplay(true)}
       >
         Click to open modal
@@ -217,6 +218,53 @@ export const BottomModalStory = ({
 
 BottomModalStory.storyName = 'BottomModal';
 
+export const FullScreenModalStory = ({
+  children,
+  isOpen,
+  onClose,
+  title,
+}: Props) => {
+  const [display, setDisplay] = useState(isOpen);
+  const handleOnClose = () => {
+    onClose();
+    setDisplay(false);
+  };
+
+  return (
+    <>
+      Full screen modals are primary meant to be used as blocker screens. The modal will cover the entire screen and the user will be able to dismiss them using the top left "X" icon.  
+
+      <button
+        className="d-flex p-btn--primary wmn2 mt24"
+        onClick={() => setDisplay(true)}
+      >
+        Click to open modal
+      </button>
+
+      <FullScreenModal
+        title={title}
+        isOpen={display}
+        onClose={handleOnClose}
+      >
+        <div style={{ padding: '0 24px 24px 24px' }}>
+          <div>
+            {children}
+          </div>
+
+          <button
+            className="p-btn--primary mt24 wmn3"
+            onClick={() => setDisplay(false)}
+          >
+            Continue
+          </button>
+        </div>
+      </FullScreenModal>
+    </>
+  );
+}
+
+FullScreenModalStory.storyName = 'FullScreenModal';
+
 export const NonDismissibleModal = ({
   children,
   isOpen,
@@ -237,7 +285,7 @@ export const NonDismissibleModal = ({
       <strong>Warning:</strong> a modal with the dismissible prop can only be closed by changing the isOpen prop to false.
 
       <button
-        className="p-btn--primary wmn2 mt24"
+        className="d-flex p-btn--primary wmn2 mt24"
         onClick={() => setDisplay(true)}
       >
         Click to open modal
@@ -280,7 +328,7 @@ export const ModalWithFooter = ({
   return (
     <>
       <button
-        className="p-btn--primary wmn2"
+        className="d-flex p-btn--primary wmn2"
         onClick={() => setDisplay(true)}
       >
         Click to open modal
@@ -326,7 +374,7 @@ export const ModalWithFooterAndScroll = ({
   return (
     <>
       <button
-        className="p-btn--primary wmn2"
+        className="d-flex p-btn--primary wmn2"
         onClick={() => setDisplay(true)}
       >
         Click to open modal

--- a/src/lib/components/modal/index.ts
+++ b/src/lib/components/modal/index.ts
@@ -1,6 +1,7 @@
 import { BottomModal } from './bottomModal';
 import { RegularModal } from './regularModal';
 import { BottomOrRegularModal } from './bottomOrRegularModal';
+import { FullScreenModal } from './fullScreenModal';
 import { ReactNode } from 'react';
 
 export interface Props {
@@ -15,4 +16,4 @@ export interface Props {
   footer?: ReactNode;
 }
 
-export { BottomModal, RegularModal, BottomOrRegularModal };
+export { BottomModal, RegularModal, BottomOrRegularModal, FullScreenModal };

--- a/src/lib/hooks/useEscapeKey.ts
+++ b/src/lib/hooks/useEscapeKey.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect } from 'react';
+
+export const useEscapeKey = (callback: () => void) => {
+  const handleOnEscape = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        callback();
+      }
+    },
+    [callback]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleOnEscape);
+
+    return () => window.removeEventListener('keydown', handleOnEscape);
+  }, [handleOnEscape]);
+};

--- a/src/lib/hooks/useFocusWithin.ts
+++ b/src/lib/hooks/useFocusWithin.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+export const useFocusWithin = (
+  ref: HTMLElement | null,
+  callback: (isFocusWithin: boolean) => void
+) => {
+  useEffect(() => {
+    const handleOnFocusIn = () => {
+      if (!ref) {
+        return;
+      }
+
+      const hasFocus = ref?.contains(document.activeElement);
+
+      callback(Boolean(hasFocus));
+    };
+
+    document.addEventListener('focusin', handleOnFocusIn);
+
+    return () => document?.removeEventListener('focusin', handleOnFocusIn);
+  }, [callback, ref]);
+};

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -23,6 +23,7 @@ import {
   BottomModal,
   RegularModal,
   BottomOrRegularModal,
+  FullScreenModal,
 } from './components/modal';
 import { InfoCard, CardButton } from './components/cards';
 import { Card, CardProps } from './components/cards/card';
@@ -48,6 +49,8 @@ import { Toaster, toast } from './components/toast';
 import { IconWrapperProps } from './components/icon/IconWrapper';
 import { Accordion, AccordionProps } from './components/accordion';
 import { Table, TableData, TableProps } from './components/table/Table';
+import { useEscapeKey } from './hooks/useEscapeKey';
+import { useFocusWithin } from './hooks/useFocusWithin';
 
 export * from './components/icon';
 
@@ -63,6 +66,7 @@ export {
   BottomModal,
   RegularModal,
   BottomOrRegularModal,
+  FullScreenModal,
   InfoCard,
   Card,
   CardButton,
@@ -90,6 +94,8 @@ export {
   Toggle,
   Toaster,
   toast,
+  useEscapeKey,
+  useFocusWithin,
 };
 
 export type {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,6 +1414,13 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz"
@@ -5943,6 +5950,13 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.238.0.tgz#b465753c2630a38f459413a745c69ec11a0b5291"
   integrity sha512-VE7XSv1epljsIN2YeBnxCmGJihpNIAnLLu/pPOdA+Gkso7qDltJwUi6vfHjgxdBbjSdAuPGnhuOHJUQG+yYwIg==
 
+focus-lock@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-1.3.5.tgz#aa644576e5ec47d227b57eb14e1efb2abf33914c"
+  integrity sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==
+  dependencies:
+    tslib "^2.0.3"
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -9481,6 +9495,13 @@ react-autosuggest@^10.1.0:
     section-iterator "^2.0.0"
     shallow-equal "^1.2.1"
 
+react-clientside-effect@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz#29f9b14e944a376b03fb650eed2a754dd128ea3a"
+  integrity sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+
 react-colorful@^5.1.2:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.6.1.tgz#7dc2aed2d7c72fac89694e834d179e32f3da563b"
@@ -9555,6 +9576,18 @@ react-error-boundary@^3.1.0:
   integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+react-focus-lock@^2.13.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.13.2.tgz#e1addac2f8b9550bc0581f3c416755ba0f81f5ef"
+  integrity sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^1.3.5"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.6"
+    use-callback-ref "^1.3.2"
+    use-sidecar "^1.1.2"
 
 react-hot-toast@^2.4.1:
   version "2.4.1"
@@ -11074,7 +11107,7 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-use-callback-ref@^1.3.0:
+use-callback-ref@^1.3.0, use-callback-ref@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.2.tgz#6134c7f6ff76e2be0b56c809b17a650c942b1693"
   integrity sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==


### PR DESCRIPTION
### What this PR does

This PR introduces some accessibility-related updates.
**Modal:**
- We introduce a full-screen modal variant, which will be used for the website navigation menu on mobile
- We enable using the modal with the escape key with the focus going back to the element that opened it
- We use the package `react-focus-lock` to lock focus within the modal when open.

**Hooks:**
We also move to DirtySwan two hooks we already use on the website (`useFocusWithin` and `useEscapeKey`), so they can be shared across repos. 

### How to test?

Go through our modal variants and check the following behaviors:
- Modal can be opened with space key
- Modal can be closed with esc key and the focus will go back to the element that opened it
- When open and tabbing through, the focus will remain within the focusable elements of the modal. 

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
