### PR TITLE
fix(table): Fix modal content overflowing on mobile

### DIFF
--- a/src/lib/components/table/Table.module.scss
+++ b/src/lib/components/table/Table.module.scss
@@ -27,3 +27,9 @@
   position: sticky;
   z-index: 9;
 }
+
+.modalContent {
+  @include p-size-mobile {
+    min-width: initial;
+  }
+}

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -203,7 +203,7 @@ const Table = ({
         title={infoModalData?.title}
         onClose={() => setInfoModalData(null)}
       >
-        <div className="pt8 p24 wmn6">
+        <div className={classNames(styles.modalContent, "pt8 p24 wmn6")}>
           {modalContentRenderer
             ? modalContentRenderer(infoModalData?.body)
             : infoModalData?.body}


### PR DESCRIPTION
### What this PR does

**Before:**
<img width="352" alt="Screenshot 2025-01-08 at 12 59 20" src="https://github.com/user-attachments/assets/22fd5460-3896-404b-b28a-76c4fa17b2e9" />

**After:**
<img width="350" alt="Screenshot 2025-01-08 at 12 58 40" src="https://github.com/user-attachments/assets/e5675658-d846-4ad1-b42b-6da0f8a17d54" />

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
