### PR TITLE
fix(use-media-query): Allow useMediaQuery with undefined window

### DIFF
--- a/src/lib/hooks/useMediaQuery.ts
+++ b/src/lib/hooks/useMediaQuery.ts
@@ -16,13 +16,14 @@ export type Breakpoint = typeof breakpointsArray[number];
 export type BreakpointData = { initialValue: boolean; queryString: string };
 
 export const breakpointLookup = (breakpoint: Breakpoint): BreakpointData => {
+  if (typeof window === 'undefined') {
+    return {
+      initialValue: false,
+      queryString: '',
+    };
+  }
+
   switch (breakpoint) {
-    case 'BELOW_MOBILE':
-    default:
-      return {
-        initialValue: window.innerWidth <= 544, // 34rem = 544px = mobile breakpoint}
-        queryString: '(max-width: 34rem)',
-      };
     case 'BELOW_TABLET':
       return {
         initialValue: window.innerWidth <= 720, // 45rem = 720px = tablet breakpoint
@@ -47,6 +48,12 @@ export const breakpointLookup = (breakpoint: Breakpoint): BreakpointData => {
       return {
         initialValue: window.innerWidth >= 1024, // 64rem = 1024px = desktop breakpoint
         queryString: '(min-width: 64rem)',
+      };
+    case 'BELOW_MOBILE':
+    default:
+      return {
+        initialValue: window.innerWidth <= 544, // 34rem = 544px = mobile breakpoint}
+        queryString: '(max-width: 34rem)',
       };
   }
 };


### PR DESCRIPTION
### What this PR does
Allow useMediaQuery with undefined window (e.g. when using Next.JS)
### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
