### PR TITLE
refactor(accordion): Add support to custom render answer

### DIFF
--- a/src/lib/components/accordion/index.stories.tsx
+++ b/src/lib/components/accordion/index.stories.tsx
@@ -17,6 +17,10 @@ const story = {
     items: {
       description: 'Accordion items to be displayed. Each item should have an id, question, and answer. Optionally, an icon can be added to the item. \n\nThe answer property accepts markdown.',
     },
+    renderAnswer: {
+      description: 'Function that allows you to render the answer in a custom way',
+      action: true,
+    },
     onClick: {
       description: 'Function that runs on click of the Accordion item',
       action: true,

--- a/src/lib/components/accordion/index.tsx
+++ b/src/lib/components/accordion/index.tsx
@@ -27,6 +27,7 @@ export interface AccordionProps {
   multiple?: boolean;
   onClick?: (item: AccordionItem) => void;
   variant?: 'default' | 'bordered';
+  renderAnswer?: (answer: ReactNode) => ReactNode;
 };
 
 const Accordion = ({
@@ -35,6 +36,7 @@ const Accordion = ({
   variant = 'default',
   multiple = false,
   onClick,
+  renderAnswer,
 }: AccordionProps) => {
   const [selectedQuestionId, setSelectedQuestionId] = useState<(string[])>([]);
   const isDefaultVariant = variant === 'default';
@@ -141,7 +143,7 @@ const Accordion = ({
                   },
                 )}
               >
-                  {answer}
+                  {renderAnswer ? renderAnswer(answer) : answer}
               </div>
             </AnimateHeight>
           </div>


### PR DESCRIPTION
### What this PR does
Add support to custom render answer, allowing to add, as an example, custom markdown or rich text components to render the content.

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
