### PR TITLE
fix(table): [SIDE-1316] Fix first row hidden on scrolling to  anchor

### DIFF
--- a/src/lib/components/table/Table.module.scss
+++ b/src/lib/components/table/Table.module.scss
@@ -26,6 +26,7 @@
   display: flex;
   position: sticky;
   z-index: 9;
+  top: 0;
 }
 
 .modalContent {

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -138,7 +138,7 @@ const Table = ({
         <div
           aria-hidden
           className={styles.stickyHeader}
-          style={{ top: `${stickyHeaderTopOffset}px` }}
+          style={{ paddingTop: `${stickyHeaderTopOffset}px` }}
         >
           <div className={styles.container} ref={headerRef}>
             <TableSection

--- a/src/lib/components/table/components/TableControls/TableControls.module.scss
+++ b/src/lib/components/table/components/TableControls/TableControls.module.scss
@@ -6,6 +6,7 @@
   right: 0;
   min-height: 72px;
   z-index: 9;
+  top: 0;
 }
 
 .controlButton {

--- a/src/lib/components/table/components/TableControls/TableControls.tsx
+++ b/src/lib/components/table/components/TableControls/TableControls.tsx
@@ -26,7 +26,7 @@ const TableControls = ({
         'd-flex ai-center jc-between bg-white px8',
         styles.stickyHeader
       )}
-      style={{ top: `${stickyHeaderTopOffset}px` }}
+      style={{ paddingTop: `${stickyHeaderTopOffset}px` }}
     >
       <Button
         className={styles.controlButton}


### PR DESCRIPTION
### What this PR does
When scrolling using an anchor (`#anchor` on the URL) and `id="anchor"` on the HTML wrapper component, the component was scrolling including the header amount. This PR fixes that.

**Before:**

https://github.com/user-attachments/assets/bf78d7d7-3c65-42b3-9ac5-faefe505b81b

**After:**

https://github.com/user-attachments/assets/4d78f12a-a50c-46ac-afcd-fc3448d2eb82


Solves:
SIDE-1316


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
