### PR TITLE
refactor(table): Add support for custom modal titles

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -92,8 +92,15 @@ const initialData: TableData = [
         { text: '80%-100%' },
       ],
       [
-        { text: 'Operations', modalContent: 'Operations info' },
-        { checkmarkValue: true, modalContent: 'Operations info column 2' },
+        { text: 'Operations',
+          modalContent: 'Operations info',
+          modalTitle: 'Custom operations modal title'
+         },
+        { 
+          checkmarkValue: true,
+          modalContent: 'Operations info column 2',
+          modalTitle: 'Custom operations modal title column 2'
+        },
         { checkmarkValue: false },
         { checkmarkValue: true },
       ],

--- a/src/lib/components/table/components/TableSection/TableSection.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.tsx
@@ -125,11 +125,7 @@ const TableSection = ({
                 {row.map((tableCellData, cellIndex) => {
                   const key = `${rowIndex}-${cellIndex}`;
                   const isFirstCellInRow = cellIndex === 0;
-
                   const titleFromRow = getModalTitleFromRowHeader(row);
-                  const titleFromColumnOrRow =
-                    getModalTitleFromColumnHeader(cellIndex) ||
-                    getModalTitleFromRowHeader(row);
 
                   const cellReplacementData =
                     (tableCellData.cellId &&
@@ -141,9 +137,7 @@ const TableSection = ({
                     ...cellReplacementData,
                     ...{
                       openModal,
-                      modalTitle: isFirstCellInRow
-                        ? titleFromRow
-                        : titleFromColumnOrRow,
+                      modalTitle: tableCellData?.modalTitle || titleFromRow,
                       align: isFirstCellInRow ? 'left' : 'center',
                     },
                   } as TableCellData;

--- a/src/lib/components/table/types.ts
+++ b/src/lib/components/table/types.ts
@@ -7,6 +7,7 @@ import { CardCellProps } from './components/TableCell/CardCell/CardCell';
 type DefaultCellProps = {
   cellId?: string;
   colSpan?: number;
+  modalTitle?: ReactNode;
 };
 
 type BaseCellData = BaseCellProps & { type?: undefined } & DefaultCellProps;


### PR DESCRIPTION
### What this PR does
1. Add support for custom modal titles ([example on the operations row](http://localhost:9009/?path=/story/jsx-table--table-story))
2. Makes the default modal title show from row header instead of column header. As per the example below, we would now show `Select a plan` instead of `standard` if there was a modal on the second row.
<img width="615" alt="Screenshot 2025-02-03 at 09 12 22" src="https://github.com/user-attachments/assets/ecfb1180-f92c-4ddf-9acd-3904fc657685" />

Solves:
SIDE-1351

### How to test?
[Run storybook](https://dirtyswan.design/?path=/story/jsx-table--table-story) and update the table data to include `modalTitle`

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
