### PR TITLE
fix(signature-pad): Fix canvas resizing issue and ensure drawing rema…

### DIFF
--- a/src/lib/components/signaturePad/index.tsx
+++ b/src/lib/components/signaturePad/index.tsx
@@ -37,6 +37,12 @@ class SignaturePad extends Component<SignaturePadProps, State> {
       onEnd: this.notifyOnChange,
     });
     this.resizeCanvas();
+
+    window.addEventListener('resize', this.resizeCanvas);
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('resize', this.resizeCanvas);
   }
 
   public render() {
@@ -85,6 +91,10 @@ class SignaturePad extends Component<SignaturePadProps, State> {
     this.canvas.width = this.canvas.offsetWidth * ratio;
     this.canvas.height = this.canvas.offsetHeight * ratio;
     this.canvas.getContext('2d').scale(ratio, ratio);
+
+    // Restore drawing after resizing
+    const data = this.signaturePad.toData();
+    this.signaturePad.fromData(data);
   }
 
   private clear() {


### PR DESCRIPTION
### **What this PR does**  
1. Listens for the `resize` event and calls `resizeCanvas()` to ensure correct alignment between the drawing and cursor.  
2. Prevents the canvas from clearing on resize by saving and restoring the drawing using `this.signaturePad.toData()` and `this.signaturePad.fromData(data)`.  
3. Enhances user experience by maintaining a smooth and responsive signature input.  

### **Why is this needed?**  
- Previously, resizing the window caused the drawing to shift away from the cursor because the canvas wasn’t dynamically resized.  
- Fixing that issue by calling `resizeCanvas()` introduced a new problem: the drawing was being cleared due to how browsers handle canvas resizing.  
- This PR restores the drawing after resizing, following the best practices outlined in [Signature Pad’s documentation](https://github.com/szimek/signature_pad?tab=readme-ov-file#handling-canvas-resize).  

### **How to test?**  
1. Draw on the canvas.  
2. Resize the window.  
3. The drawing should **stay in place** without shifting or clearing.  

### **Attachments**  

https://github.com/user-attachments/assets/c6f8d5fa-bc17-4674-911b-875b6bbbf9d6

### **Checklist**  
- [x] I reviewed my own code.  
- [ ] The changes align with the designs I received.  
- [x] I have attached screenshot(s), video(s), or gif(s) showing that the solution works as expected.  
- [ ] I have updated the task(s) status on Linear.  
- [x] All new media is optimized (images, gifs, videos).  

### **Browser support**  
My code works in the following browsers:  
- [x] Firefox  
- [x] Chrome  
- [ ] Safari  
- [ ] Edge 