### PR TITLE
fix(bottommodal.tsx): [SIDE-604] Use h2 header on mobile

### DIFF
--- a/src/lib/components/modal/bottomModal/index.tsx
+++ b/src/lib/components/modal/bottomModal/index.tsx
@@ -5,7 +5,7 @@ import { GenericModal } from '../genericModal';
 
 const BottomModal = ({ className, classNames, ...rest }: Props) => (
   <GenericModal
-    titleSize="small"
+    titleSize="default"
     classNames={{
       ...classNames,
       wrapper: classNamesUtil('w100', styles.wrapper, classNames?.wrapper),


### PR DESCRIPTION
### What this PR does

_Please include a summary of the change(s)._

1. Now using H2 mobile, with the BottomModal, by setting the titleSize to default

![Screenshot 2025-02-21 at 11 34 07](https://github.com/user-attachments/assets/a9c815d9-35c9-4668-a147-01374f229d9a)

### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
SIDE-604

### How to test?

Enter the BottomModal that is used in the mobile and it will show H2 insted of H4.


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
