### PR TITLE
fix(date-selector): Show component full width on mobile screens

### DIFF
--- a/src/lib/components/dateSelector/style.module.scss
+++ b/src/lib/components/dateSelector/style.module.scss
@@ -4,6 +4,7 @@
   display: flex;
 
   @include p-size-mobile {
+    width: 100%;
     flex-direction: column;
   }
 }


### PR DESCRIPTION
### What this PR does
Show `DateSelector` component full width on mobile screens.

**Before:**
<img width="385" alt="Screenshot 2025-02-27 at 13 05 16" src="https://github.com/user-attachments/assets/515ad283-cb45-4291-9da6-1236438a522f" />

**After:**
<img width="394" alt="Screenshot 2025-02-27 at 13 05 10" src="https://github.com/user-attachments/assets/34ef05da-3158-4897-aff4-acea900d1573" />


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
