### PR TITLE
revert(autocomplete-address): Revert being able to switch back to search

### DIFF
--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -80,7 +80,6 @@ export interface AutocompleteAddressProps {
   manualAddressEntryTexts?: {
     preText?: string;
     cta?: string;
-    ctaSearch?: string;
   };
   countryCode?: string;
 }
@@ -259,7 +258,7 @@ const AutocompleteAddress = ({
         )}
       </div>
       <div className={`wmx8`}>
-        {!manualAddressEntry ? (
+        {manualAddressEntry === false ? (
           <div style={{ position: 'relative' }}>
             <Input
               className="w100"
@@ -344,20 +343,18 @@ const AutocompleteAddress = ({
           </>
         )}
       </div>
-      <div className="p-p mt8">
-        {manualAddressEntryTexts?.preText || 'Or '}
-        <button
-          className={'p-a p-p fw-bold c-pointer bg-transparent'}
-          onClick={() => {
-            manualAddressEntry ? setManualAddressEntry(false) : handleEnterAddressManually();
-          }}
-          type="button"
-        >
-          {manualAddressEntry
-            ? manualAddressEntryTexts?.ctaSearch || 'search for address'
-            : manualAddressEntryTexts?.cta || 'enter address manually'}
-        </button>
-      </div>
+      {manualAddressEntry === false && (
+        <div className="p-p mt8">
+          {manualAddressEntryTexts?.preText || 'Or '}
+          <button
+            className={'p-a p-p fw-bold c-pointer bg-transparent'}
+            onClick={handleEnterAddressManually}
+            type="button"
+          >
+            {manualAddressEntryTexts?.cta || 'enter address manually'}
+          </button>
+        </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
### What this PR does
Revert being able to switch back to search on autocomplete address
### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
