### PR TITLE
feat(a11y): [SIDE-1442] group radio/checkbox buttons

### DIFF
--- a/src/lib/components/input/checkbox/index.stories.tsx
+++ b/src/lib/components/input/checkbox/index.stories.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from 'react';
 import { Checkbox, CheckboxProps } from '.';
 import { images } from '../../../util/images';
@@ -9,28 +8,36 @@ const story = {
   component: Checkbox,
   argTypes: {
     options: {
-      description: 'Object that contains the possible options for rendering in the input.',
+      description:
+        'Object that contains the possible options for rendering in the input.',
     },
     value: {
       description: 'Current checked values.',
+    },
+    fieldLegend: {
+      description:
+        'Accessibility property that describes the purpose of a group of checkbox buttons, read aloud by screen readers to provide context.',
     },
     onChange: {
       description: 'Function called everytime a value changes.',
       action: true,
       table: {
-        category: "Callbacks",
+        category: 'Callbacks',
       },
     },
     wide: {
-      description: 'Property that defines if options should fill 100% of available horizontal space',
-      defaultValue: false
+      description:
+        'Property that defines if options should fill 100% of available horizontal space',
+      defaultValue: false,
     },
     bordered: {
       control: 'boolean',
-      description: 'Property that defines if checkbox should show the border around each label',
+      description:
+        'Property that defines if checkbox should show the border around each label',
     },
     inlineLayout: {
-      description: 'Property that defines if options should show inline instead of block. Check inline checkbox options story for examples.',
+      description:
+        'Property that defines if options should show inline instead of block. Check inline checkbox options story for examples.',
     },
     className: {
       description: 'ClassNames for custom styling',
@@ -38,133 +45,144 @@ const story = {
   },
   args: {
     options: {
-      CAT:{
+      CAT: {
         title: 'Cat',
-        description: 'At least 1'
+        description: 'At least 1',
       },
-      DOG:{
+      DOG: {
         title: 'Dog',
-        description: 'At least 2'
+        description: 'At least 2',
       },
-      NONE:{
+      NONE: {
         title: 'None',
-        description: 'No pets'
-      }
+        description: 'No pets',
+      },
     },
+    fieldLegend: 'Owned pets',
     wide: false,
     bordered: true,
     inlineLayout: false,
     classNames: {
       container: '',
       label: '',
-      option: ''
+      option: '',
     },
     value: [],
-    className: ''
-  }
+    className: '',
+  },
 };
 
-export const CheckboxStory = ({ 
+export const CheckboxStory = ({
   onChange,
   options,
   wide,
   bordered,
   classNames,
   inlineLayout,
+  fieldLegend,
 }: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
   const handleOnChange = (newValue: string[]) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Checkbox 
+    <Checkbox
       wide={wide}
-      options={options} 
+      options={options}
       onChange={handleOnChange}
       value={checkedValues}
       bordered={bordered}
       classNames={classNames}
       inlineLayout={inlineLayout}
+      fieldLegend={fieldLegend}
     />
   );
-}
+};
 
-export const CheckboxWithCustomWrapperStyles = ({ onChange }: CheckboxProps<string>) => {
+export const CheckboxWithCustomWrapperStyles = ({
+  onChange,
+}: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
   const handleOnChange = (newValue: string[] = []) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Checkbox 
+    <Checkbox
       onChange={handleOnChange}
       value={checkedValues}
       options={{
         CAT1: 'Cat',
         DOG1: 'Dog',
-      }} 
-      classNames={{ container: "p32 bg-primary-300 br24 bs-lg" }}
+      }}
+      classNames={{ container: 'p32 bg-primary-300 br24 bs-lg' }}
     />
   );
-}
+};
 
-export const CheckboxWithCustomOptionStyles = ({ onChange }: CheckboxProps<string>) => {
+export const CheckboxWithCustomOptionStyles = ({
+  onChange,
+}: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
   const handleOnChange = (newValue: string[] = []) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Checkbox 
+    <Checkbox
       onChange={handleOnChange}
       value={checkedValues}
       options={{
         CAT2: 'Cat',
         DOG2: 'Dog',
-      }} 
-      classNames={{ option: "mb32 p24 bg-green-100 br12 bs-lg" }}
+      }}
+      classNames={{ option: 'mb32 p24 bg-green-100 br12 bs-lg' }}
     />
   );
-}
+};
 
-export const CheckboxWithCustomLabelStyles = ({ onChange }: CheckboxProps<string>) => {
+export const CheckboxWithCustomLabelStyles = ({
+  onChange,
+}: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
   const handleOnChange = (newValue: string[] = []) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Checkbox 
+    <Checkbox
       onChange={handleOnChange}
       value={checkedValues}
       options={{
         CAT3: 'Cat',
         DOG3: 'Dog',
-      }} 
-      classNames={{ label: "bg-grey-900 tc-white" }}
+      }}
+      classNames={{ label: 'bg-grey-900 tc-white' }}
     />
   );
-}
+};
 
-export const CheckboxWithInlineLayout = ({ onChange }: CheckboxProps<string>) => {
+export const CheckboxWithInlineLayout = ({
+  onChange,
+}: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
   const handleOnChange = (newValue: string[] = []) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Checkbox 
+    <Checkbox
       onChange={handleOnChange}
       value={checkedValues}
       options={{
@@ -174,45 +192,50 @@ export const CheckboxWithInlineLayout = ({ onChange }: CheckboxProps<string>) =>
         RABBIT: 'Rabbit',
         RAT: 'Rat',
         ANOTHER: 'Other',
-      }} 
-      classNames={{ option: "w30" }}
+      }}
+      classNames={{ option: 'w30' }}
       inlineLayout
       wide
     />
   );
-}
+};
 
-export const CheckboxWithCustomLabel = ({ onChange, wide, classNames, inlineLayout }: CheckboxProps<string>) => {
+export const CheckboxWithCustomLabel = ({
+  onChange,
+  wide,
+  classNames,
+  inlineLayout,
+}: CheckboxProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
 
   const handleOnChange = (newValue: string[] = []) => {
     setCheckedValues(newValue);
     onChange(newValue);
-  }
+  };
 
   return (
-    <Checkbox 
+    <Checkbox
       options={{
         BIGDOG: {
-          icon: () => <img src={images.bigDog} alt='' />,
+          icon: () => <img src={images.bigDog} alt="" />,
           title: 'Dog',
         },
-        FISH:{
-          icon: () => <img src={images.brokenAquarium} alt='' />,
+        FISH: {
+          icon: () => <img src={images.brokenAquarium} alt="" />,
           title: 'Fish',
         },
-        OTHER:{
-          icon: () => <img src={images.brokenGlass} alt='' />,
+        OTHER: {
+          icon: () => <img src={images.brokenGlass} alt="" />,
           title: 'Other',
-        }
-      }} 
+        },
+      }}
       onChange={handleOnChange}
       value={checkedValues}
-      classNames={{ option: "w30" }}
+      classNames={{ option: 'w30' }}
       inlineLayout
     />
   );
-}
+};
 
 CheckboxStory.storyName = 'Checkbox';
 

--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -20,6 +20,7 @@ export interface CheckboxProps<ValueType extends string> {
     label?: string;
     option?: string;
   };
+  fieldLegend?: string;
 }
 
 export const Checkbox = <ValueType extends string>({
@@ -30,6 +31,7 @@ export const Checkbox = <ValueType extends string>({
   inlineLayout = false,
   bordered = true,
   classNames: classNamesObj,
+  fieldLegend,
 }: CheckboxProps<ValueType> & {}) => {
   const hasNoneValue = Object.keys(options).includes('NONE');
 
@@ -72,7 +74,7 @@ export const Checkbox = <ValueType extends string>({
   };
 
   return (
-    <div
+    <fieldset
       className={classNames(
         classNamesObj?.container,
         styles.container,
@@ -85,6 +87,9 @@ export const Checkbox = <ValueType extends string>({
         }
       )}
     >
+      <legend className="sr-only">
+        {fieldLegend ?? 'Select one or more options'}
+      </legend>
       {entries.map(([currentValue, label]) => {
         const checked = value?.includes(currentValue);
         const customIcon = (label as CheckboxWithDescription)?.icon;
@@ -129,6 +134,6 @@ export const Checkbox = <ValueType extends string>({
           </div>
         );
       })}
-    </div>
+    </fieldset>
   );
 };

--- a/src/lib/components/input/checkbox/styles.module.scss
+++ b/src/lib/components/input/checkbox/styles.module.scss
@@ -1,5 +1,9 @@
 .container {
   max-width: 100%;
+  border: 0;
+  margin: 0;
+  min-width: 0;
+  padding: 0.01em 0 0 0;
 }
 
 .narrow {

--- a/src/lib/components/input/radio/index.stories.tsx
+++ b/src/lib/components/input/radio/index.stories.tsx
@@ -13,6 +13,14 @@ const story = {
     value: {
       description: 'Current checked values.',
     },
+    fieldLegend: {
+      description:
+        'Property that describes the purpose of a group of radio buttons, read aloud by screen readers to provide context.',
+    },
+    groupName: {
+      description:
+        'Property passed to each radio button. Informs the browser that the radio buttons belong to the same group, so only one can be selected',
+    },
     onChange: {
       description: 'Function called everytime a value changes.',
       action: true,
@@ -29,7 +37,8 @@ const story = {
         'Property that defines if options should show inline instead of block. Check inline radio options story for examples.',
     },
     inlineIcon: {
-      description: 'Property that defines if options should show inline with icon',
+      description:
+        'Property that defines if options should show inline with icon',
     },
     classNames: {
       description: 'ClassNames for custom styling',
@@ -57,6 +66,8 @@ const story = {
         description: 'No pets',
       },
     },
+    fieldLegend: 'Owned pets',
+    groupName: 'Pets',
     value: '',
     wide: false,
     classNames: {
@@ -68,7 +79,7 @@ const story = {
     inlineLayout: false,
     inlineIcon: false,
     disabled: false,
-  }
+  },
 };
 
 export const RadioStory = ({
@@ -79,6 +90,8 @@ export const RadioStory = ({
   inlineLayout,
   bordered,
   disabled,
+  fieldLegend,
+  groupName,
 }: RadioProps<string>) => {
   const [checkedValues, setCheckedValues] = useState<string>();
 
@@ -97,6 +110,8 @@ export const RadioStory = ({
       inlineLayout={inlineLayout}
       bordered={bordered}
       disabled={disabled}
+      fieldLegend={fieldLegend}
+      groupName={groupName}
     />
   );
 };

--- a/src/lib/components/input/radio/index.tsx
+++ b/src/lib/components/input/radio/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import { ReactNode } from 'react';
 
 import styles from './styles.module.scss';
+import generateId from '../../../util/generateId';
 export interface RadioWithDescription {
   title: ReactNode;
   description?: string;
@@ -23,6 +24,8 @@ export interface RadioProps<ValueType extends string> {
   };
   bordered?: boolean;
   disabled?: boolean;
+  fieldLegend?: string;
+  groupName?: string;
 }
 
 export const Radio = <ValueType extends string>({
@@ -35,14 +38,18 @@ export const Radio = <ValueType extends string>({
   classNames: classNamesObj,
   bordered = true,
   disabled = false,
+  fieldLegend,
+  groupName,
 }: RadioProps<ValueType>) => {
   const entries = Object.entries(options) as [
     ValueType,
     ReactNode | RadioWithDescription
   ][];
 
+  const name = groupName ?? generateId();
+
   return (
-    <div
+    <fieldset
       className={classNames(
         classNamesObj?.container,
         styles.container,
@@ -56,6 +63,7 @@ export const Radio = <ValueType extends string>({
         }
       )}
     >
+      <legend className="sr-only">{fieldLegend ?? 'Select an option'}</legend>
       {entries.map(([currentValue, label]) => {
         const checked = value === currentValue;
         const customIcon = (label as RadioWithDescription)?.icon;
@@ -81,6 +89,7 @@ export const Radio = <ValueType extends string>({
               checked={checked}
               data-testid={`radio-input-${currentValue}`}
               disabled={disabled}
+              name={name}
             />
 
             <label
@@ -118,6 +127,6 @@ export const Radio = <ValueType extends string>({
           </div>
         );
       })}
-    </div>
+    </fieldset>
   );
 };

--- a/src/lib/components/input/radio/styles.module.scss
+++ b/src/lib/components/input/radio/styles.module.scss
@@ -1,5 +1,9 @@
 .container {
   max-width: 100%;
+  border: 0;
+  margin: 0;
+  min-width: 0;
+  padding: 0.01em 0 0 0;
 }
 
 .narrow {


### PR DESCRIPTION
### What this PR does

1. Wraps radio and checkbox inputs in a `<fieldset>` to group related controls
2. Adds a visually hidden `<legend>` for screen reader context
3. Adds a `name` attribute to radio buttons belonging to the same group

### Why is this needed?

Improves accessibility by allowing screen readers to treat radio and checkbox options as a one labeled group.

![radio](https://github.com/user-attachments/assets/89a5b9d3-79ae-43bf-9f04-d0883635a219)

![radio-html](https://github.com/user-attachments/assets/443779d6-d8fb-4c97-a0e5-eeeb3e3c5e59)

Solves:
SIDE-1442

### How to test?

- Inspect the HTML of the corresponding Storybook components
- Use the components with a screen reader: listen for a group label being read and the number of options in the group.

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge
