### PR TITLE
refactor(autosuggestmultiselect): Add focus state and aria disabled to chip

### DIFF
--- a/src/lib/components/chip/index.tsx
+++ b/src/lib/components/chip/index.tsx
@@ -27,6 +27,7 @@ export default ({
       className={`c-pointer ${styles['chip-button-container']}`}
       type="button"
       onClick={() => onRemove(value)}
+      aria-label={`Remove ${value.value} option`}
     >
       <XIcon className={styles['chip-remove-button']} />
     </button>

--- a/src/lib/components/chip/style.module.scss
+++ b/src/lib/components/chip/style.module.scss
@@ -48,6 +48,11 @@
   &:hover {
     color: $ds-purple-500;
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--ds-primary-500);
+    border-radius: 2px;
+  }
 }
 
 .chip-remove-button {


### PR DESCRIPTION
### What this PR does
Add focus state and aria disabled to chip remove button
https://github.com/user-attachments/assets/2b3786e0-4cee-4819-b7b2-c51ec39a362f

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
