### PR TITLE
refactor(multidropzone): [SIDE-1445] add focus states and aria-live

### DIFF
--- a/src/lib/components/multiDropzone/UploadFileCell/index.tsx
+++ b/src/lib/components/multiDropzone/UploadFileCell/index.tsx
@@ -5,6 +5,7 @@ import styles from './style.module.scss';
 import { FileIcon, Trash2Icon, EyeVisionIcon } from '../../icon/icons';
 import { Color } from '../../../models/styles';
 import { UploadStatus, UploadedFile } from '../types';
+import { Button } from '../../button';
 
 interface Props {
   uploadStatus: UploadStatus;
@@ -94,35 +95,40 @@ const UploadFileCell: React.FC<Props> = ({
         ) : (
           <>
             {isComplete && (
-              <a
-                className={styles['view-icon']}
+              <Button
+                as="a"
                 href={previewUrl}
                 target="_blank"
                 rel="noopener noreferrer"
+                hideLabel
+                variant="filledWhite"
+                className={classnames('mr16', styles.button)}
+                leftIcon={
+                  <EyeVisionIcon noMargin color={'grey-500'} size={24} />
+                }
               >
-                <EyeVisionIcon
-                  color={'grey-500'}
-                  size={24}
-                  className={styles.icon}
-                />
-              </a>
+                Preview file
+              </Button>
             )}
 
             {onRemoveFile && (
-              <button
-                type="button"
+              <Button
                 onClick={() => onRemoveFile(id)}
-                className={classnames(styles['remove-icon'], {
-                  [styles.disabled]: uploading,
-                })}
+                disabled={uploading}
                 data-testid="remove-button"
+                className={styles.button}
+                leftIcon={
+                  <Trash2Icon
+                    color={hasError ? 'red-500' : 'grey-500'}
+                    size={24}
+                    noMargin
+                  />
+                }
+                hideLabel
+                variant="filledWhite"
               >
-                <Trash2Icon
-                  color={hasError ? 'red-500' : 'grey-500'}
-                  size={24}
-                  className={styles.icon}
-                />
-              </button>
+                Delete file
+              </Button>
             )}
           </>
         )}

--- a/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
+++ b/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
@@ -88,7 +88,6 @@
   -webkit-appearance: none;
   -moz-appearance: none;
 
-  &:focus,
   &:focus-visible {
     outline: 2px solid $ds-grey-900;
     border-radius: 2px;

--- a/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
+++ b/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
@@ -87,6 +87,13 @@
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
+
+  &:focus,
+  &:focus-visible {
+    outline: 2px solid $ds-grey-900;
+    border-radius: 2px;
+    outline-offset: 2px;
+  }
 }
 
 .remove-icon {

--- a/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
+++ b/src/lib/components/multiDropzone/UploadFileCell/style.module.scss
@@ -27,10 +27,6 @@
   align-items: center;
 }
 
-.icon {
-  margin: 0px;
-}
-
 .main-icon {
   margin-right: 16px;
 }
@@ -64,45 +60,25 @@
 
 .cell-right-section {
   display: flex;
-  justify-content: flex-end;
-  min-width: 32px;
-  margin-left: 16px;
 }
 
 .cell-right-section-complete {
   min-width: 64px;
 }
 
-.view-icon,
-.remove-icon {
-  cursor: pointer;
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  color: inherit;
-  text-align: inherit;
-  outline: none;
-  box-shadow: none;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
+.button {
+  width: 32px;
+
+  div span span {
+    min-width: 24px !important;
+    height: 24px !important;
+  }
 
   &:focus-visible {
     outline: 2px solid $ds-grey-900;
     border-radius: 2px;
     outline-offset: 2px;
   }
-}
-
-.remove-icon {
-  margin-left: 16px;
-}
-
-.disabled {
-  pointer-events: none;
-  cursor: default;
-  opacity: 0.3;
 }
 
 @keyframes appear-down {

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -62,12 +62,13 @@ const MultiDropzone = ({
     (acceptedFiles: File[], filesRejected: FileRejection[]) => {
       onFileSelect(acceptedFiles);
 
-      const messageForScreenReader = getStatusMessage(
+      const messageForScreenReader = getStatusMessage({
         acceptedFiles,
         filesRejected,
-        { fileList, maxSize },
-        textOverrides
-      );
+        fileList,
+        maxSize,
+        textOverrides,
+      });
       setStatusMessage(messageForScreenReader);
 
       setErrors((previousErrors) => [

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -10,6 +10,7 @@ import {
   formatAcceptFileList,
   getErrorMessage,
   getFormattedAcceptObject,
+  getStatusMessage,
   getUploadStatus,
 } from './utils';
 
@@ -61,23 +62,13 @@ const MultiDropzone = ({
     (acceptedFiles: File[], filesRejected: FileRejection[]) => {
       onFileSelect(acceptedFiles);
 
-      let message = '';
-      if (acceptedFiles.length > 0) {
-        const fileNames = acceptedFiles.map((file) => file.name).join(', ');
-        message += `File${
-          acceptedFiles.length > 1 ? 's' : ''
-        } uploaded: ${fileNames}`;
-      }
-      if (filesRejected.length > 0) {
-        const firstError = filesRejected[0]?.errors[0];
-        const rejectionMsg = getErrorMessage(
-          firstError,
-          { fileList, maxSize },
-          textOverrides
-        );
-        message += `Could not upload ${filesRejected[0]?.file.name}: ${rejectionMsg}`;
-      }
-      setStatusMessage(message);
+      const messageForScreenReader = getStatusMessage(
+        acceptedFiles,
+        filesRejected,
+        { fileList, maxSize },
+        textOverrides
+      );
+      setStatusMessage(messageForScreenReader);
 
       setErrors((previousErrors) => [
         ...previousErrors,

--- a/src/lib/components/multiDropzone/style.module.scss
+++ b/src/lib/components/multiDropzone/style.module.scss
@@ -1,4 +1,5 @@
 @use '../../scss/public/grid' as *;
+@use "../../scss/public/colors" as *;
 
 .container {
   background-color: transparent;
@@ -10,6 +11,18 @@
   background-color: white;
 
   transition: all 0.6s ease-in-out;
+
+  &:focus,
+  &:focus-visible {
+    outline: 2px solid $ds-grey-900;
+    border-radius: 2px;
+    outline-offset: 2px;
+  }
+
+  &:hover {
+    background-color: var(--ds-primary-100);
+    transition: 0.5s ease;
+  }
 }
 
 .img {
@@ -20,15 +33,6 @@
 
 .textInline {
   display: inline-flex;
-}
-
-.dropzoneContainer:focus {
-  outline: none;
-}
-
-.dropzoneContainer:hover {
-  background-color: var(--ds-primary-100);
-  transition: 0.5s ease;
 }
 
 .dropzoneContainerDisabled {

--- a/src/lib/components/multiDropzone/style.module.scss
+++ b/src/lib/components/multiDropzone/style.module.scss
@@ -12,7 +12,6 @@
 
   transition: all 0.6s ease-in-out;
 
-  &:focus,
   &:focus-visible {
     outline: 2px solid $ds-grey-900;
     border-radius: 2px;

--- a/src/lib/components/multiDropzone/utils/index.test.ts
+++ b/src/lib/components/multiDropzone/utils/index.test.ts
@@ -1,53 +1,56 @@
 import { ErrorCode } from 'react-dropzone';
-import { 
+import {
   formatAcceptFileList,
   getErrorMessage,
-  getFormattedAcceptObject, 
-  getUploadStatus 
+  getFormattedAcceptObject,
+  getStatusMessage,
+  getUploadStatus,
 } from '.';
 
 const documentsAccept = {
   'application/msword': ['.doc'],
   'application/pdf': ['.pdf'],
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx']
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [
+    '.docx',
+  ],
 };
 
 const imagesAccept = {
-  'image/heic': [".heic"],
-  'image/bmp': [".bmp"],
-  'image/jpeg': [".jpeg"],
-  'image/jpg': [".jpg"],
-  'image/png': [".png"],
-  'image/svg+xml': [".svg"],
-  'image/tiff': [".tiff"],
-  'image/webp': [".webp"]
+  'image/heic': ['.heic'],
+  'image/bmp': ['.bmp'],
+  'image/jpeg': ['.jpeg'],
+  'image/jpg': ['.jpg'],
+  'image/png': ['.png'],
+  'image/svg+xml': ['.svg'],
+  'image/tiff': ['.tiff'],
+  'image/webp': ['.webp'],
 };
 
 describe('getUploadStatus', () => {
   it('Should return error status if error is passed', () => {
-    expect(getUploadStatus(0, "Error message")).toEqual("ERROR");
+    expect(getUploadStatus(0, 'Error message')).toEqual('ERROR');
   });
 
   it("Should return uploading status if progress hasn't finished", () => {
-    expect(getUploadStatus(50)).toEqual("UPLOADING");
+    expect(getUploadStatus(50)).toEqual('UPLOADING');
   });
 
-  it("Should return complete status if progress has finished", () => {
-    expect(getUploadStatus(100)).toEqual("COMPLETE");
+  it('Should return complete status if progress has finished', () => {
+    expect(getUploadStatus(100)).toEqual('COMPLETE');
   });
 });
 
 describe('getFormattedAcceptObject', () => {
   it('Should return image accept object if is of type image', () => {
-    expect(getFormattedAcceptObject("image")).toEqual(imagesAccept);
+    expect(getFormattedAcceptObject('image')).toEqual(imagesAccept);
   });
 
   it('Should return documents accept object if is of type document', () => {
-    expect(getFormattedAcceptObject("document")).toEqual(documentsAccept);
+    expect(getFormattedAcceptObject('document')).toEqual(documentsAccept);
   });
 
   it('Should return accept object if it is manually defined', () => {
-    const accept = { "application/pdf": [".pdf"] };
+    const accept = { 'application/pdf': ['.pdf'] };
 
     expect(getFormattedAcceptObject(accept)).toEqual(accept);
   });
@@ -55,61 +58,141 @@ describe('getFormattedAcceptObject', () => {
 
 describe('formatAcceptFileList', () => {
   it('Should return empty object if accept is empty', () => {
-    expect(formatAcceptFileList({})).toEqual("");
+    expect(formatAcceptFileList({})).toEqual('');
   });
 
   it('Should return documents list if documents accept is passed', () => {
-    expect(formatAcceptFileList(documentsAccept)).toEqual("DOC, PDF, DOCX");
+    expect(formatAcceptFileList(documentsAccept)).toEqual('DOC, PDF, DOCX');
   });
 
   it('Should return images list if images accept is passed', () => {
-    expect(formatAcceptFileList(imagesAccept)).toEqual("HEIC, BMP, JPEG, JPG, PNG, SVG, TIFF, WEBP"); 
+    expect(formatAcceptFileList(imagesAccept)).toEqual(
+      'HEIC, BMP, JPEG, JPG, PNG, SVG, TIFF, WEBP'
+    );
   });
 
   it('Should return extension based on accept passed', () => {
-    const accept = { 
-      "application/pdf": [".pdf"],
-      "image/jpg": [".jpg"]
+    const accept = {
+      'application/pdf': ['.pdf'],
+      'image/jpg': ['.jpg'],
     };
 
-    expect(formatAcceptFileList(accept)).toEqual("PDF, JPG");
+    expect(formatAcceptFileList(accept)).toEqual('PDF, JPG');
   });
 });
 
 describe('getErrorMessage', () => {
   it('Should return default error message', () => {
-    const defaultMessage = "Default Error Message.";
+    const defaultMessage = 'Default Error Message.';
 
     expect(
-      getErrorMessage({
-        code: "UNKNOWN",
-        message: defaultMessage
-      }, { 
-        fileList: "" 
-      })
+      getErrorMessage(
+        {
+          code: 'UNKNOWN',
+          message: defaultMessage,
+        },
+        {
+          fileList: '',
+        }
+      )
     ).toEqual(defaultMessage);
   });
 
   it('Should return default FileInvalidType default message', () => {
-    const fileList = "JPG, PDF";
+    const fileList = 'JPG, PDF';
 
     expect(
-      getErrorMessage({
-        code: ErrorCode.FileInvalidType,
-        message: ""
-      }, { fileList })
+      getErrorMessage(
+        {
+          code: ErrorCode.FileInvalidType,
+          message: '',
+        },
+        { fileList }
+      )
     ).toEqual(`File type must be ${fileList}`);
   });
 
   it('Should return FileInvalidType with textOverride message', () => {
-    const fileTypeError = "File Invalid Error";
-    const fileList = "JPG, PDF";
-    
+    const fileTypeError = 'File Invalid Error';
+    const fileList = 'JPG, PDF';
+
     expect(
-      getErrorMessage({
-        code: ErrorCode.FileInvalidType,
-        message: ""
-      }, { fileList }, { fileTypeError })
+      getErrorMessage(
+        {
+          code: ErrorCode.FileInvalidType,
+          message: '',
+        },
+        { fileList },
+        { fileTypeError }
+      )
     ).toEqual(`${fileTypeError} ${fileList}`);
+  });
+});
+
+describe('getStatusMessage', () => {
+  it('returns accepted file message for multiple files', () => {
+    const acceptedFiles = [
+      new File([''], 'photo.jpg'),
+      new File([''], 'invoice.pdf'),
+    ];
+
+    const result = getStatusMessage({
+      acceptedFiles,
+      filesRejected: [],
+      maxSize: 5000000,
+    });
+
+    expect(result).toBe('Files uploaded: photo.jpg, invoice.pdf.');
+  });
+
+  it('returns rejection message for invalid file type with default text', () => {
+    const filesRejected = [
+      {
+        file: new File([''], 'script.exe'),
+        errors: [
+          { code: ErrorCode.FileInvalidType, message: 'Invalid file type' },
+        ],
+      },
+    ];
+
+    const result = getStatusMessage({
+      acceptedFiles: [],
+      filesRejected,
+      maxSize: 5000000,
+      fileList: 'PDF, JPG',
+    });
+
+    expect(result).toBe(
+      'Could not upload script.exe: File type must be PDF, JPG.'
+    );
+  });
+
+  it('returns rejection message for file too large with default text', () => {
+    const filesRejected = [
+      {
+        file: new File([''], 'video.mov'),
+        errors: [{ code: ErrorCode.FileTooLarge, message: 'Too big' }],
+      },
+    ];
+
+    const result = getStatusMessage({
+      acceptedFiles: [],
+      filesRejected,
+      maxSize: 1048576,
+    });
+
+    expect(result).toBe(
+      'Could not upload video.mov: File is too large. It must be less than 1 MB.'
+    );
+  });
+
+  it('returns fallback when no files are accepted or rejected', () => {
+    const result = getStatusMessage({
+      acceptedFiles: [],
+      filesRejected: [],
+      maxSize: 1000000,
+    });
+
+    expect(result).toBe('');
   });
 });

--- a/src/lib/components/multiDropzone/utils/index.ts
+++ b/src/lib/components/multiDropzone/utils/index.ts
@@ -1,17 +1,20 @@
-import { Accept, ErrorCode, FileError } from "react-dropzone";
-import { formatBytes } from "../../../util/formatBytes";
-import { 
-  AcceptType, 
-  DOCUMENT_FILES, 
+import { Accept, ErrorCode, FileError, FileRejection } from 'react-dropzone';
+import { formatBytes } from '../../../util/formatBytes';
+import {
+  AcceptType,
+  DOCUMENT_FILES,
   FileMimeTypes,
   FileType,
-  IMAGE_FILES, 
+  IMAGE_FILES,
   TextOverrides,
   UploadStatus,
-  VIDEO_FILES
-} from "../types";
+  VIDEO_FILES,
+} from '../types';
 
-export const getUploadStatus = (progress: number, error?: string): UploadStatus => {
+export const getUploadStatus = (
+  progress: number,
+  error?: string
+): UploadStatus => {
   if (error) {
     return 'ERROR';
   }
@@ -23,7 +26,7 @@ export const getUploadStatus = (progress: number, error?: string): UploadStatus 
   return 'COMPLETE';
 };
 
-const formatMimeType = (values: FileType[]): Accept  => {
+const formatMimeType = (values: FileType[]): Accept => {
   const formatedValues = {} as Accept;
 
   values.forEach((value) => {
@@ -36,17 +39,17 @@ const formatMimeType = (values: FileType[]): Accept  => {
 export const DOCUMENT_FILES_ACCEPT = formatMimeType(DOCUMENT_FILES);
 export const IMAGE_FILES_ACCEPT = formatMimeType(IMAGE_FILES);
 export const VIDEO_FILES_ACCEPT = formatMimeType(VIDEO_FILES);
-  
+
 export const getFormattedAcceptObject = (accept: AcceptType = {}): Accept => {
-  if (accept === "document") {
+  if (accept === 'document') {
     return DOCUMENT_FILES_ACCEPT;
-  };
+  }
 
-  if (accept === "image") {
+  if (accept === 'image') {
     return IMAGE_FILES_ACCEPT;
-  };
+  }
 
-  if (accept === "video") {
+  if (accept === 'video') {
     return VIDEO_FILES_ACCEPT;
   }
 
@@ -57,17 +60,16 @@ export const getFormattedAcceptObject = (accept: AcceptType = {}): Accept => {
   return {
     ...DOCUMENT_FILES_ACCEPT,
     ...IMAGE_FILES_ACCEPT,
-    ...VIDEO_FILES_ACCEPT
+    ...VIDEO_FILES_ACCEPT,
   };
-}
-  
-export const formatAcceptFileList = (accept: Accept): string => (
+};
+
+export const formatAcceptFileList = (accept: Accept): string =>
   Object.values(accept)
     .reduce((acc, value) => [...acc, ...value], [])
-    .join(", ")
+    .join(', ')
     .replace(/\./g, '')
-    .toUpperCase()
-);
+    .toUpperCase();
 
 export const getPlaceholder = (
   textOverrides?: TextOverrides,
@@ -78,28 +80,79 @@ export const getPlaceholder = (
     maxSize && maxSize > 0
       ? `${textOverrides?.sizeUpToText || 'up to'} ${formatBytes(maxSize)}`
       : '';
-  
-      const isAcceptString = 
-    typeof accept === 'string' && 
-    ['video', 'image', 'document'].includes(accept)
-  
-  const defaultPlaceholder = `${textOverrides?.supportsTextShort || 'Supports images, videos and documents'} ${maxSizePlaceholder}`;
-  const acceptPlaceholder = `${textOverrides?.supportsTextShort || `Supports ${accept}s ${maxSizePlaceholder}`}`;
+
+  const isAcceptString =
+    typeof accept === 'string' &&
+    ['video', 'image', 'document'].includes(accept);
+
+  const defaultPlaceholder = `${
+    textOverrides?.supportsTextShort || 'Supports images, videos and documents'
+  } ${maxSizePlaceholder}`;
+  const acceptPlaceholder = `${
+    textOverrides?.supportsTextShort ||
+    `Supports ${accept}s ${maxSizePlaceholder}`
+  }`;
 
   return isAcceptString ? acceptPlaceholder : defaultPlaceholder;
-}
+};
 
 export const getErrorMessage = (
   { code, message }: FileError,
-  { fileList = "", maxSize }: { fileList?: string, maxSize?: number },
-  textOverrides?: TextOverrides,
+  { fileList = '', maxSize }: { fileList?: string; maxSize?: number },
+  textOverrides?: TextOverrides
 ): string => {
   switch (code) {
     case ErrorCode.FileInvalidType:
-      return `${textOverrides?.fileTypeError || "File type must be"} ${fileList}`;
+      return `${
+        textOverrides?.fileTypeError || 'File type must be'
+      } ${fileList}`;
     case ErrorCode.FileTooLarge:
-      return `${textOverrides?.fileTooLargeError || "File is too large. It must be less than"} ${formatBytes(maxSize || 0)}.`;
+      return `${
+        textOverrides?.fileTooLargeError ||
+        'File is too large. It must be less than'
+      } ${formatBytes(maxSize || 0)}.`;
     default:
       return message;
   }
-}
+};
+
+export const getStatusMessage = ({
+  acceptedFiles,
+  filesRejected,
+  fileList,
+  maxSize,
+  textOverrides,
+}: {
+  acceptedFiles: File[];
+  filesRejected: FileRejection[];
+  fileList?: string;
+  maxSize?: number;
+  textOverrides?: TextOverrides;
+}): string => {
+  let message = '';
+  if (acceptedFiles.length > 0) {
+    const fileNames = acceptedFiles.map((file) => file.name).join(', ');
+    message += `File${
+      acceptedFiles.length > 1 ? 's' : ''
+    } uploaded: ${fileNames}. `;
+  }
+
+  if (filesRejected.length > 0) {
+    const rejectionMessages = filesRejected.map((rejection) => {
+      const firstError = rejection.errors[0];
+      const rejectionMessage = getErrorMessage(
+        firstError,
+        { fileList, maxSize },
+        textOverrides
+      );
+      return `Could not upload ${rejection.file.name}: ${
+        rejectionMessage.endsWith('.')
+          ? rejectionMessage
+          : `${rejectionMessage}.`
+      }`;
+    });
+
+    message += rejectionMessages.join('');
+  }
+  return message.trim();
+};


### PR DESCRIPTION
### What this PR does

Updates Multidropzone component
1. Adding focus state for the input
2. Adding focus states for the view and delete buttons
3. Adding a section with an upload status message which will be read by screen readers.


![image 32](https://github.com/user-attachments/assets/17c0340c-25a4-4e75-a082-e6632e9a1507)

![image 35](https://github.com/user-attachments/assets/8d472119-129b-4fc2-b936-26c7f1bb31a9)
![image 34](https://github.com/user-attachments/assets/feaec720-2aa2-4551-9c66-f2a0e9d832f5)

![image 31](https://github.com/user-attachments/assets/39dd162c-ade3-4bfc-bb53-00983fde96a2)

### Why is this needed?

Please include relevant motivation and context of why this PR is necessary, sentry/linear/notion/...

Solves:
SIDE-1445

### How to test?

Use the multidropzone component with a keyboard and screen reader:
- you should see focus states for the input and the view and delete buttons
- the screen reader should read aloud if uploading a file was successful or failed.

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge
