### PR TITLE
fix(checkbox): [NoTicket] update default legend text when only one option

### DIFF
--- a/src/lib/components/input/checkbox/index.tsx
+++ b/src/lib/components/input/checkbox/index.tsx
@@ -31,7 +31,7 @@ export const Checkbox = <ValueType extends string>({
   inlineLayout = false,
   bordered = true,
   classNames: classNamesObj,
-  fieldLegend = 'Select one or more options',
+  fieldLegend,
 }: CheckboxProps<ValueType> & {}) => {
   const hasNoneValue = Object.keys(options).includes('NONE');
 
@@ -73,6 +73,12 @@ export const Checkbox = <ValueType extends string>({
     return (label as CheckboxWithDescription).title !== undefined;
   };
 
+  const legend =
+    fieldLegend ??
+    (Object.keys(options).length > 1
+      ? 'Select one or more options'
+      : 'You may select this option');
+
   return (
     <fieldset
       className={classNames(
@@ -87,7 +93,7 @@ export const Checkbox = <ValueType extends string>({
         }
       )}
     >
-      <legend className="sr-only">{fieldLegend}</legend>
+      <legend className="sr-only">{legend}</legend>
       {entries.map(([currentValue, label]) => {
         const checked = value?.includes(currentValue);
         const customIcon = (label as CheckboxWithDescription)?.icon;


### PR DESCRIPTION
### What this PR does

Updates the default legend text for a checkbox group in case the field there's only one option.

### Why is this needed?

Now, if no custom legend text is provided and the radio field has only one option, the screen reader would read: `'Select one or more options'`.

Solves:
NoTicket
