### PR TITLE
fix(input): [NoTicket] fix aria-errormessage usage

### DIFF
--- a/src/lib/components/input/index.tsx
+++ b/src/lib/components/input/index.tsx
@@ -5,15 +5,15 @@ import generateId from '../../util/generateId';
 import styles from './style.module.scss';
 
 // Something weird is going on with enterKeyHint that makes it a required field under certain circumstances. The & Omit<…> and & Pick<…> is a hacky way to go around that.
-export type InputProps =  Omit<JSX.IntrinsicElements['input'], 'enterKeyHint'> &
- Partial<Pick<JSX.IntrinsicElements['input'], 'enterKeyHint'>> & {
-  error?: string | boolean;
-  prefix?: string;
-  label?: string;
-  id?: string;
-  hideLabel?: boolean;
-  labelInsideInput?: boolean;
-};
+export type InputProps = Omit<JSX.IntrinsicElements['input'], 'enterKeyHint'> &
+  Partial<Pick<JSX.IntrinsicElements['input'], 'enterKeyHint'>> & {
+    error?: string | boolean;
+    prefix?: string;
+    label?: string;
+    id?: string;
+    hideLabel?: boolean;
+    labelInsideInput?: boolean;
+  };
 
 export const Input = React.forwardRef(
   (
@@ -54,18 +54,20 @@ export const Input = React.forwardRef(
             ref={ref}
             className={classnames(
               error ? 'p-input--error' : 'p-input',
-              (!label || labelInsideInput) && placeholder && placeholder.length > 0
+              (!label || labelInsideInput) &&
+                placeholder &&
+                placeholder.length > 0
                 ? styles.input
                 : styles['input--no-placeholder'],
               {
-                [styles['input--with-prefix']]: prefix, 
-                [styles['input--with-inside-label']]: labelInsideInput
+                [styles['input--with-prefix']]: prefix,
+                [styles['input--with-inside-label']]: labelInsideInput,
               }
             )}
             placeholder={label || labelInsideInput ? placeholder : ' '}
             disabled={disabled}
             aria-invalid={!!error}
-            aria-errormessage={error ? error : undefined}
+            aria-errormessage={error ? `${uniqueId}-error` : undefined}
             {...props}
           />
           {prefix && (
@@ -93,7 +95,10 @@ export const Input = React.forwardRef(
           )}
         </div>
         {error && (
-          <p className={`p-p--small tc-red-500 w100 ${styles.error}`}>
+          <p
+            id={`${uniqueId}-error`}
+            className={`p-p--small tc-red-500 w100 ${styles.error}`}
+          >
             {error}
           </p>
         )}


### PR DESCRIPTION
### What this PR does

1. This PR fixes how we set `aria-errormessage` in the Input component. 

### Why is this needed?

From https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage:
> There are two attributes you need to use: set [aria-invalid="true"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) to define the object as being in an error state, then add the aria-errormessage attribute with the value being the id of the element (or elements) containing the error message text for that object.

### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
