### PR TITLE
fix(radio-checkbox): [NoTicket] remove fieldset style reset

### DIFF
--- a/src/lib/components/input/checkbox/styles.module.scss
+++ b/src/lib/components/input/checkbox/styles.module.scss
@@ -1,9 +1,5 @@
 .container {
   max-width: 100%;
-  border: 0;
-  margin: 0;
-  min-width: 0;
-  padding: 0.01em 0 0 0;
 }
 
 .narrow {

--- a/src/lib/components/input/radio/styles.module.scss
+++ b/src/lib/components/input/radio/styles.module.scss
@@ -1,9 +1,5 @@
 .container {
   max-width: 100%;
-  border: 0;
-  margin: 0;
-  min-width: 0;
-  padding: 0.01em 0 0 0;
 }
 
 .narrow {


### PR DESCRIPTION
### What this PR does

1. Removes the styling reset from the <fieldset> element in the radio and checkbox components. 

### Why is this needed?

The reset is already applied in src/lib/scss/private/_reset.scss and ends up conflicting with custom styling using `classNamesObj?.container`.

Solves:
NoTicket


### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
