### PR TITLE
fix(input): [NoTicket] Fix value alignment with inside label

### DIFF
--- a/src/lib/components/input/style.module.scss
+++ b/src/lib/components/input/style.module.scss
@@ -77,6 +77,10 @@
   &--with-prefix {
     padding-left: 32px !important;
   }
+
+  &--with-inside-label {
+    padding-top: 9px;
+  }
 }
 
 .placeholder {


### PR DESCRIPTION
### What this PR does

This PR fixes an issue where the input value is misaligned if no placeholder is set and the label is shown inside the input.

## BEFORE:
![image](https://github.com/user-attachments/assets/3ccb49f7-c19f-4c86-b088-8bc23a51fe5c)

## AFTER:
![image](https://github.com/user-attachments/assets/a647f42c-e0a6-407d-98ae-e8aad61f8c86)


### How to test?

_Please include additional context on how to test this PR._


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
