### PR TITLE
feat(multi-dropzone): [NoTicket] Add instructionsTextMobile

### DIFF
--- a/src/lib/components/multiDropzone/index.stories.tsx
+++ b/src/lib/components/multiDropzone/index.stories.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { MultiDropzone, MultiDropzoneProps } from '.';
 import { UploadedFile } from './types';
 
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+
 const story = {
   title: 'JSX/MultiDropzone',
   component: MultiDropzone,
@@ -11,26 +13,31 @@ const story = {
     },
     uploading: {
       defaultValue: false,
-      description: 'Property that allows to display component in an uploading state',
+      description:
+        'Property that allows to display component in an uploading state',
     },
     isCondensed: {
       defaultValue: false,
-      description: 'Property that allows to display component in a smaller layout',
+      description:
+        'Property that allows to display component in a smaller layout',
     },
     maxFiles: {
-      description: 'Property that allows to display the maximum number of files allowed',
+      description:
+        'Property that allows to display the maximum number of files allowed',
       table: {
         category: 'File Validation',
       },
     },
     maxSize: {
-      description: 'Property that allows to display the maximum size of files allowed',
+      description:
+        'Property that allows to display the maximum size of files allowed',
       table: {
         category: 'File Validation',
       },
     },
     accept: {
-      description: 'Property that allows to define which file types are accepted',
+      description:
+        'Property that allows to define which file types are accepted',
       table: {
         category: 'File Validation',
       },
@@ -54,17 +61,20 @@ const story = {
     },
   },
   args: {
-    uploadedFiles: [{
-      id: '123456789',
-      name: 'my-code-doesnt-work-i-have-no-idea-why-my-code-works.jpg'
-    }],
+    uploadedFiles: [
+      {
+        id: '123456789',
+        name: 'my-code-doesnt-work-i-have-no-idea-why-my-code-works.jpg',
+      },
+    ],
     uploading: false,
     isCondensed: false,
     textOverrides: {},
-    maxFiles: 0
+    maxFiles: 0,
   },
   parameters: {
-    componentSubtitle: 'MultiDropzone component allows upload of multiple documents / files.',
+    componentSubtitle:
+      'MultiDropzone component allows upload of multiple documents / files.',
   },
 };
 
@@ -96,11 +106,11 @@ export const MultiDropzoneStory = ({
   };
 
   return (
-    <MultiDropzone 
-      onFileSelect={handleOnFileSelect} 
-      onRemoveFile={handleOnRemoveFile} 
-      uploadedFiles={localFiles} 
-      uploading={uploading} 
+    <MultiDropzone
+      onFileSelect={handleOnFileSelect}
+      onRemoveFile={handleOnRemoveFile}
+      uploadedFiles={localFiles}
+      uploading={uploading}
       isCondensed={isCondensed}
       maxFiles={maxFiles}
       maxSize={maxSize}
@@ -109,7 +119,7 @@ export const MultiDropzoneStory = ({
   );
 };
 
-MultiDropzoneStory.storyName = "MultiDropzone";
+MultiDropzoneStory.storyName = 'MultiDropzone';
 
 export const UploadingState = () => (
   <MultiDropzone
@@ -147,7 +157,6 @@ export const UploadingState = () => (
     onRemoveFile={() => {}}
   />
 );
-
 
 export const CondensedView = () => (
   <MultiDropzone
@@ -269,9 +278,30 @@ export const I18nSupport = () => (
       instructionsText: 'Datei auswählen oder per Drag & Drop platzieren',
       supportsTextShort: 'Unterstützt werden',
       currentlyUploadingText:
-        'Bitte warten während die Datei hochgeladen wird...'
+        'Bitte warten während die Datei hochgeladen wird...',
     }}
   />
 );
+
+export const NonDesktopDevice = () => (
+  <MultiDropzone
+    uploadedFiles={[]}
+    onFileSelect={() => {}}
+    uploading={false}
+    onRemoveFile={() => {}}
+    textOverrides={{
+      instructionsTextMobile: 'Tippen Sie, um eine Datei auszuwählen',
+      currentlyUploadingText:
+        'Bitte warten, während die Datei hochgeladen wird...',
+    }}
+  />
+);
+
+NonDesktopDevice.parameters = {
+  viewport: {
+    viewports: INITIAL_VIEWPORTS,
+    defaultViewport: 'iphone6',
+  },
+};
 
 export default story;

--- a/src/lib/components/multiDropzone/index.tsx
+++ b/src/lib/components/multiDropzone/index.tsx
@@ -24,6 +24,7 @@ import {
 } from './types';
 
 import { getPlaceholder } from './utils';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
 
 interface MultiDropzoneProps {
   uploadedFiles: UploadedFile[];
@@ -93,6 +94,17 @@ const MultiDropzone = ({
     onDrop,
   });
 
+  const isNonDesktopDevice = useMediaQuery('BELOW_TABLET');
+
+  const instructionsTextDesktop =
+    textOverrides?.instructionsText || 'Choose file or drag & drop';
+  const instructionsTextMobile =
+    textOverrides?.instructionsTextMobile || 'Tap to choose file';
+
+  const instructionsText = isNonDesktopDevice
+    ? instructionsTextMobile
+    : instructionsTextDesktop;
+
   return (
     <div className={styles.container}>
       <div
@@ -121,7 +133,7 @@ const MultiDropzone = ({
           {uploading
             ? textOverrides?.currentlyUploadingText ||
               'Please wait while uploading file...'
-            : textOverrides?.instructionsText || 'Choose file or drag & drop'}
+            : instructionsText}
         </div>
         <div className="p-p--small tc-grey-500">
           {textOverrides?.supportsText || placeholder}

--- a/src/lib/components/multiDropzone/types.ts
+++ b/src/lib/components/multiDropzone/types.ts
@@ -1,21 +1,21 @@
-import { Accept } from "react-dropzone";
+import { Accept } from 'react-dropzone';
 
 export enum FileMimeTypes {
-  avi = "video/x-msvideo",
-  bmp = "image/bmp",
-  doc = "application/msword",
-  docx = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  heic = "image/heic",
-  jpeg = "image/jpeg",
-  jpg = "image/jpg",
-  mov = "video/quicktime",
-  mp4 = "video/mp4",
-  pdf = "application/pdf",
-  png = "image/png",
-  svg = "image/svg+xml",
-  tif = "image/tiff",
-  tiff = "image/tiff",
-  webp = "image/webp",
+  avi = 'video/x-msvideo',
+  bmp = 'image/bmp',
+  doc = 'application/msword',
+  docx = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  heic = 'image/heic',
+  jpeg = 'image/jpeg',
+  jpg = 'image/jpg',
+  mov = 'video/quicktime',
+  mp4 = 'video/mp4',
+  pdf = 'application/pdf',
+  png = 'image/png',
+  svg = 'image/svg+xml',
+  tif = 'image/tiff',
+  tiff = 'image/tiff',
+  webp = 'image/webp',
 }
 
 // mp4, mov, avi
@@ -34,7 +34,7 @@ export const IMAGE_FILES: FileType[] = [
   'png',
   'tiff',
   'webp',
-  'svg'
+  'svg',
 ];
 
 export interface UploadedFile {
@@ -47,13 +47,14 @@ export interface UploadedFile {
   showLoadingSpinner?: boolean;
 }
 
-export type AcceptType = "document" | "image" | "video" | Accept;
+export type AcceptType = 'document' | 'image' | 'video' | Accept;
 
 export interface TextOverrides {
   currentlyUploadingText?: string;
   fileTypeError?: string;
   fileTooLargeError?: string;
   instructionsText?: string;
+  instructionsTextMobile?: string;
   sizeUpToText?: string;
   supportsText?: string;
   supportsTextShort?: string;


### PR DESCRIPTION
### What this PR does

This PR makes it so that the upload component shows a different text on small devices, as they don't support drag and drop. It also exposes a new variable `instructionsTextMobile` to be able to customize this text.

![image](https://github.com/user-attachments/assets/ff2f6287-18ed-4367-b3b1-c7b368c124ad)

### Why is this needed?

This is needed to minimize confusion on smaller devices as to how to accomplish drag and drop.


### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [x] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [x] I have updated the task(s) status on Linear
- [x] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge
