### PR TITLE
refactor(card): [EPIC-709] disable hover and support active, focus statuses

### DIFF
--- a/src/lib/components/cards/card/index.stories.tsx
+++ b/src/lib/components/cards/card/index.stories.tsx
@@ -99,8 +99,9 @@ export const CardStory = ({
   titleVariant,
   verticalAlignment,
 }: CardProps) => (
-  <div className='d-flex p24 bg-grey-200'>
-    <Card
+  <div className='d-flex fd-column gap16 p24 bg-grey-200'>
+    {Array.from({ length: 10 }).map((_, index) => (
+      <Card
       as={as}
       classNames={classNames}
       description={description}
@@ -118,6 +119,7 @@ export const CardStory = ({
     >
       {children}
     </Card>
+    ))}
   </div>
 );
 

--- a/src/lib/components/cards/card/style.module.scss
+++ b/src/lib/components/cards/card/style.module.scss
@@ -9,13 +9,27 @@
   border-radius: 8px;
 
   &:hover {
-    outline: 1px solid $ds-primary-500;
+    outline: 1px solid $ds-grey-500;
     color: $ds-primary-500;
   }
 
+  &:active,
+  &:focus,
   &:focus-visible {
-    outline: 2px solid $ds-primary-500;
+    outline: 2px solid $ds-grey-900;
     color: $ds-primary-500;
+  }
+
+  @media (pointer: coarse) {
+    &:hover {
+      outline: none;
+    }
+
+    &:active,
+    &:focus {
+      outline: 2px solid $ds-grey-900;
+      color: $ds-primary-500;
+    }
   }
 }
 


### PR DESCRIPTION
### What this PR does

**Style and Accessibility Updates:**

* The card's hover and focus outlines have been updated: hover now uses a grey outline instead of primary color, and focus uses a darker grey outline for better accessibility contrast.
* Additional styles were added for coarse pointer devices (like touchscreens): hover outlines are removed, and active/focus states use the new grey outline and primary text color, improving the touch experience.

### FIgma

[link](https://www.figma.com/design/MKs4cbojdVOBKUxv7okb93/Dirty-Swan-Design-System?node-id=18661-99812&t=4d7UkDaiwvcKOoyA-0)

<img width="1358" height="210" alt="Screenshot 2025-08-08 at 11 26 49" src="https://github.com/user-attachments/assets/8a9862cb-d235-43f2-a682-458f7bda7f1a" />

### Why is this needed?

Mainly to disable hover state in mobile and support active and focus state.

Solves:
EPIC-709



### Checklist:

- [x] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
