### PR TITLE
chore(table): Add support to onClick on CTA and hide table rows prop

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -220,6 +220,9 @@ const story = {
     hideColumns: {
       subContent: 'This property allows to hide defined columns by index.',
     },
+    hideRows: {
+      subContent: 'This property allows to hide selected rows by index.',
+    },
     modalContentRenderer: {
       subContent: 'This property allows to render custom modal content.',
     },
@@ -250,6 +253,7 @@ const story = {
       hideDetails: 'Hide details',
     },
     hideColumns: [],
+    hideRows: [],
   },
 };
 
@@ -258,6 +262,7 @@ export const TableStory = ({
   tableData,
   hideColumns,
   hideDetails,
+  hideRows,
   stickyHeaderTopOffset,
   textOverrides,
   title,
@@ -296,6 +301,7 @@ export const TableStory = ({
         tableData={tableData}
         hideColumns={hideColumns}
         hideDetails={hideDetails}
+        hideRows={hideRows}
         stickyHeaderTopOffset={stickyHeaderTopOffset}
         textOverrides={textOverrides}
         title={title}

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -32,6 +32,7 @@ export interface TableProps {
   collapsibleSections?: boolean;
   hideColumns?: number[];
   hideDetails?: boolean;
+  hideRows?: number[];
   imageComponent?: (args: any) => JSX.Element;
   modalContentRenderer?: (content: ReactNode) => ReactNode;
   onModalOpen?: ModalFunction;
@@ -53,6 +54,7 @@ const Table = ({
   collapsibleSections,
   hideColumns = [],
   hideDetails,
+  hideRows = [],
   imageComponent,
   modalContentRenderer,
   onModalOpen,
@@ -145,6 +147,7 @@ const Table = ({
               cellReplacements={cellReplacements}
               className={className}
               hideColumns={hideColumns}
+              hideRows={hideRows}
               openModal={handleOpenModal}
               tableCellRows={[tableData?.[0]?.rows?.[0]]}
               title={title}
@@ -162,6 +165,7 @@ const Table = ({
           collapsibleSections={collapsibleSections}
           hideColumns={hideColumns}
           hideDetails={hideDetails}
+          hideRows={hideRows}
           isMobile={isMobile}
           shouldHideDetails={shouldHideDetails}
           openModal={handleOpenModal}

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 
 import styles from './CTACell.module.scss';
 import { IconRenderer } from '../../IconRenderer/IconRenderer';
+import { Button } from '../../../../button';
 
 export type CTACellProps = {
   title: ReactNode;
@@ -16,6 +17,7 @@ export type CTACellProps = {
   className?: string;
   dataTestId?: string;
   dataCy?: string;
+  onClick?: () => void;
 };
 
 export const CTACell = ({
@@ -30,6 +32,7 @@ export const CTACell = ({
   className,
   dataCy,
   dataTestId,
+  onClick,
 }: CTACellProps) => {
   const renderedIcon = (
     <IconRenderer icon={icon} imageComponent={imageComponent} />
@@ -49,18 +52,21 @@ export const CTACell = ({
         </p>
       </div>
 
-      <a
+      <Button
+        {...onClick ? { onClick } : {
+          as: 'a',
+          href: href,
+          target: '_blank',
+          rel: 'noopener noreferrer',
+        }}
         className={classNames('mt16 w100 wmx3', {
           'p-btn--primary': !grey,
           'p-btn--secondary-grey': grey,
           [styles.narrow]: narrow,
         })}
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
       >
         {buttonCaption}
-      </a>
+      </Button>
     </div>
   );
 };

--- a/src/lib/components/table/components/TableSection/TableSection.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.tsx
@@ -16,6 +16,7 @@ export interface TableSectionProps {
   className?: string;
   tableCellRows: TableCellRowData[];
   hideColumns?: number[];
+  hideRows?: number[];
   hideHeader?: boolean;
   openModal?: ModalFunction;
   title: string;
@@ -28,6 +29,7 @@ const TableSection = ({
   className,
   tableCellRows,
   hideColumns = [],
+  hideRows = [],
   hideHeader,
   openModal,
   title,
@@ -68,6 +70,11 @@ const TableSection = ({
   const isVisibleColumn = useCallback(
     (cellIndex: number) => !hideColumns.includes(cellIndex),
     [hideColumns]
+  );
+
+  const isVisibleRow = useCallback(
+    (rowIndex: number) => !hideRows.includes(rowIndex),
+    [hideRows]
   );
 
   return (
@@ -120,7 +127,7 @@ const TableSection = ({
       <tbody>
         {tableCellRows.map(
           (row, rowIndex) =>
-            rowIndex > 0 && (
+            rowIndex > 0 && isVisibleRow(rowIndex) && (
               <tr key={rowIndex} className={styles.tr}>
                 {row.map((tableCellData, cellIndex) => {
                   const key = `${rowIndex}-${cellIndex}`;


### PR DESCRIPTION
### What this PR does
- Adds support to onClick prop on table CTA elements
- allows hiding table row props by index

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
