### PR TITLE
chore(colors): Update auxiliary colors

### DIFF
--- a/src/lib/components/badge/index.tsx
+++ b/src/lib/components/badge/index.tsx
@@ -25,7 +25,7 @@ const getVariantClassNames = (variant: Variant) => ({
   neutral: 'bg-white',
   neutral200: 'bg-neutral-100',
   neutral300: 'bg-grey-300',
-  warning: 'bg-yellow-100',
+  warning: 'bg-yellow-200',
   error: 'bg-red-100',
   success: 'bg-green-100',
   primary: 'bg-purple-300',

--- a/src/lib/scss/public/colors/default.scss
+++ b/src/lib/scss/public/colors/default.scss
@@ -10,17 +10,19 @@ $ds-purple-700: #6A65AE;
 $ds-purple-800: #484676;
 $ds-purple-900: #32334B;
 
-$ds-blue-100: #e5f0ff;
-$ds-blue-300: #b0cdf3;
-$ds-blue-500: #8bb4ea;
-$ds-blue-700: #5f7ba0;
-$ds-blue-900: #2d394a;
+$ds-blue-100: #E5F0FF;
+$ds-blue-200: #DAE8FC;
+$ds-blue-300: #B0CDF3;
+$ds-blue-500: #8BB4EA;
+$ds-blue-700: #5F7BA0;
+$ds-blue-900: #2D394A;
 
-$ds-red-100: #fedede;
-$ds-red-300: #faa0a0;
-$ds-red-500: #e55454;
-$ds-red-700: #c64848;
-$ds-red-900: #4b2525;
+$ds-red-100: #FEE6E6;
+$ds-red-200: #FED7D7;
+$ds-red-300: #FAA0A0;
+$ds-red-500: #E55454;
+$ds-red-700: #C64848;
+$ds-red-900: #4B2525;
 
 $ds-neutral-50: #f9f9fd;
 $ds-neutral-100: #f7f7fd;
@@ -40,17 +42,19 @@ $ds-grey-600: #696970;
 $ds-grey-700: #4c4c53;
 $ds-grey-900: #26262e;
 
-$ds-green-100: #e4ffe6;
-$ds-green-300: #c4f5c8;
-$ds-green-500: #84de8a;
-$ds-green-700: #5b985f;
-$ds-green-900: #354a2d;
+$ds-green-100: #E6FAF1;
+$ds-green-200: #D5F6E7;
+$ds-green-300: #AAEACC;
+$ds-green-500: #85DCB4;
+$ds-green-700: #599278;
+$ds-green-900: #2B4639;
 
-$ds-yellow-100: #fff8e3;
-$ds-yellow-300: #fae3a5;
-$ds-yellow-500: #f7ce5c;
-$ds-yellow-700: #cc9e21;
-$ds-yellow-900: #4a3d10;
+$ds-yellow-100: #FEFAEC;
+$ds-yellow-200: #FCF3D1;
+$ds-yellow-300: #F6E7AC;
+$ds-yellow-500: #F0D26F;
+$ds-yellow-700: #C5A33E;
+$ds-yellow-900: #483D18;
 
 $ds-white: #fff;
 $ds-transparent: transparent;
@@ -59,6 +63,7 @@ $colors: (
   'white': #fff,
   'transparent': transparent,
   'blue-100': $ds-blue-100,
+  'blue-200': $ds-blue-200,
   'blue-300': $ds-blue-300,
   'blue-500': $ds-blue-500,
   'blue-700': $ds-blue-700,
@@ -74,6 +79,7 @@ $colors: (
   'purple-800': $ds-purple-800,
   'purple-900': $ds-purple-900,
   'red-100': $ds-red-100,
+  'red-200': $ds-red-200,
   'red-300': $ds-red-300,
   'red-500': $ds-red-500,
   'red-700': $ds-red-700,
@@ -92,6 +98,7 @@ $colors: (
   'green-700': $ds-green-700,
   'green-900': $ds-green-900,
   'yellow-100': $ds-yellow-100,
+  'yellow-200': $ds-yellow-200,
   'yellow-300': $ds-yellow-300,
   'yellow-500': $ds-yellow-500,
   'yellow-700': $ds-yellow-700,

--- a/src/lib/scss/public/demo.tsx
+++ b/src/lib/scss/public/demo.tsx
@@ -64,52 +64,62 @@ const colors = [
   {
     name: 'Blue 100',
     code: 'blue-100',
-    hex: '#e5f0ff',
+    hex: '#E5F0FF',
+  },
+  {
+    name: 'Blue 200',
+    code: 'blue-200',
+    hex: '#DAE8FC',
   },
   {
     name: 'Blue 300',
     code: 'blue-300',
-    hex: '#b0cdf3',
+    hex: '#B0CDF3',
   },
   {
     name: 'Blue 500',
     code: 'blue-500',
-    hex: '#8bb4ea',
+    hex: '#8BB4EA',
   },
   {
     name: 'Blue 700',
     code: 'blue-700',
-    hex: '#5f7ba0',
+    hex: '#5F7BA0',
   },
   {
     name: 'Blue 900',
     code: 'blue-900',
-    hex: '#2d394a',
+    hex: '#2D394A',
   },
   {
     name: 'Red 100',
     code: 'red-100',
-    hex: '#fedede',
+    hex: '#FEE6E6',
+  },
+  {
+    name: 'Red 200',
+    code: 'red-200',
+    hex: '#FED7D7',
   },
   {
     name: 'Red 300',
     code: 'red-300',
-    hex: '#faa0a0',
+    hex: '#FAA0A0',
   },
   {
     name: 'Red 500',
     code: 'red-500',
-    hex: '#e55454',
+    hex: '#E55454',
   },
   {
     name: 'Red 700',
     code: 'red-700',
-    hex: '#c64848',
+    hex: '#C64848',
   },
   {
     name: 'Red 900',
     code: 'red-900',
-    hex: '#4b2525',
+    hex: '#4B2525',
   },
   {
     name: 'Grey 100',
@@ -154,52 +164,62 @@ const colors = [
   {
     name: 'Green 100',
     code: 'green-100',
-    hex: '#e4ffe6',
+    hex: '#E6FAF1',
+  },
+  {
+    name: 'Green 200',
+    code: 'green-200',
+    hex: '#D5F6E7',
   },
   {
     name: 'Green 300',
     code: 'green-300',
-    hex: '#c4f5c8',
+    hex: '#AAEACC',
   },
   {
     name: 'Green 500',
     code: 'green-500',
-    hex: '#84de8a',
+    hex: '#85DCB4',
   },
   {
     name: 'Green 700',
     code: 'green-700',
-    hex: '#5b985f',
+    hex: '#599278',
   },
   {
     name: 'Green 900',
     code: 'green-900',
-    hex: '#354a2d',
+    hex: '#2B4639',
   },
   {
     name: 'Yellow 100',
     code: 'yellow-100',
-    hex: '#fff8e3',
+    hex: '#FEFAEC',
+  },
+  {
+    name: 'Yellow 200',
+    code: 'yellow-200',
+    hex: '#FCF3D1',
   },
   {
     name: 'Yellow 300',
     code: 'yellow-300',
-    hex: '#fae3a5',
+    hex: '#F6E7AC',
   },
   {
     name: 'Yellow 500',
     code: 'yellow-500',
-    hex: '#f7ce5c',
+    hex: '#F0D26F',
   },
   {
     name: 'Yellow 700',
     code: 'yellow-700',
-    hex: '#cc9e21',
+    hex: '#C5A33E',
   },
   {
     name: 'Yellow 900',
     code: 'yellow-900',
-    hex: '#4a3d10',
+    hex: '#483D18',
   },
 ];
 


### PR DESCRIPTION
### What this PR does
Update auxiliary colors.
**Preview (Before/After):**
<img width="1079" height="202" alt="Screenshot 2025-09-08 at 11 58 06" src="https://github.com/user-attachments/assets/1da5fb0b-1e2d-49b8-a99d-586998fc421a" />
<img width="1049" height="167" alt="Screenshot 2025-09-08 at 11 47 40" src="https://github.com/user-attachments/assets/000970f5-8fab-497c-a6dc-9fe1efd87757" />

<img width="1058" height="806" alt="Screenshot 2025-09-08 at 11 58 20" src="https://github.com/user-attachments/assets/cce0d3db-de21-44d2-9095-c1cf30e50f37" />
<img width="1119" height="200" alt="Screenshot 2025-09-08 at 11 46 02" src="https://github.com/user-attachments/assets/41ff47ae-cafc-470b-8ecd-b00d4eca9294" />



### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
