### PR TITLE
fix(rebranding): Fix autocomplete address, disabled button and radio/checkbox styles

### DIFF
--- a/src/lib/components/autocompleteAddress/index.tsx
+++ b/src/lib/components/autocompleteAddress/index.tsx
@@ -270,6 +270,7 @@ const AutocompleteAddress = ({
                 placeholders?.manualAddressEntry || 'Search for address'
               }
               ref={autocompleteElement}
+              disabled={hasLoadedGoogleAPI === false}
             />
             {hasLoadedGoogleAPI === false && (
               <div

--- a/src/lib/components/autocompleteAddress/style.module.scss
+++ b/src/lib/components/autocompleteAddress/style.module.scss
@@ -57,7 +57,6 @@
   align-items: center;
 
   position: absolute !important;
-  background-color: rgba($ds-purple-600, 0.25);
 
   top: 0;
   left: 0;

--- a/src/lib/scss/private/components/_buttons.scss
+++ b/src/lib/scss/private/components/_buttons.scss
@@ -38,37 +38,13 @@
 
   &[disabled] {
     cursor: default;
-    opacity: 0.5;
+    opacity: 0.3;
     cursor: not-allowed;
   }
 
   &--icon-only {
     width: 48px;
     padding: 0;
-  }
-
-  &--primary {
-    @extend .p-btn;
-    background-color: $ds-neutral-200;
-    color: white;
-
-    &:hover {
-      background-color: $ds-neutral-300;
-
-      @include p-size-mobile {
-        background-color: $ds-neutral-300;
-      }
-    }
-
-    &[disabled] {
-      background-color: $ds-neutral-200;
-      opacity: 1;
-    }
-
-    &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px $ds-neutral-400;
-    }
   }
 
   &--secondary {

--- a/src/lib/scss/private/components/_input.scss
+++ b/src/lib/scss/private/components/_input.scss
@@ -89,7 +89,7 @@
       height: 16px;
       min-height: 16px;
 
-      border: 1px solid $ds-neutral-400;
+      border: 1px solid $ds-neutral-500;
       border-radius: 50%;
 
       background-color: white;
@@ -117,6 +117,10 @@
 .p-radio:focus-visible + label {
   border: 1px solid $ds-neutral-900;
   outline: 1px solid $ds-neutral-900;
+
+   &:before {
+    border: 1px solid $ds-neutral-900;
+   }
 }
 
 .p-radio:disabled {
@@ -147,7 +151,7 @@
       height: 16px;
       min-height: 16px;
 
-      border: 1px solid $ds-neutral-900;
+      border: 1px solid $ds-neutral-500;
       border-radius: 4px;
 
       background-color: white;
@@ -157,8 +161,8 @@
   }
 }
 
-.p-checkbox:focus,
-.p-radio:focus {
+.p-checkbox:active,
+.p-radio:active {
   & + label {
     &::before {
       outline: none;
@@ -173,6 +177,7 @@
     background-repeat: no-repeat;
     background-position: center;
     background-color: $ds-neutral-900;
+    border: 1px solid transparent;
   }
 }
 


### PR DESCRIPTION
### What this PR does
This PR fixes: 
- autocomplete address loading state:
<img width="673" height="129" alt="Screenshot 2025-09-30 at 09 56 41" src="https://github.com/user-attachments/assets/2dd530a2-1ba8-49f2-989d-e268db740807" />
<img width="644" height="129" alt="Screenshot 2025-09-30 at 10 01 56" src="https://github.com/user-attachments/assets/f66a9836-efef-4bae-b76e-219db925647b" />


- and radio checbkox styles that had the wrong border color
<img width="478" height="245" alt="Screenshot 2025-09-30 at 10 03 30" src="https://github.com/user-attachments/assets/9ad01463-cd60-4d6c-91c6-7e286ee355cf" />
<img width="460" height="255" alt="Screenshot 2025-09-30 at 10 02 37" src="https://github.com/user-attachments/assets/7a27946a-4856-41a6-b6d1-eb99c8eb3b65" />

- button disabled state opacity
<img width="208" height="113" alt="Screenshot 2025-09-30 at 10 03 20" src="https://github.com/user-attachments/assets/03e67501-cb18-4102-a8b1-35619e6e7a65" />

<img width="186" height="103" alt="Screenshot 2025-09-30 at 10 03 05" src="https://github.com/user-attachments/assets/66f3f7a1-c8af-444d-819a-7835756f251f" />

### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
