### PR TITLE
refactor(comparison-table): [PRO-4469] Allow opening multiple collapsible sections

### DIFF
--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
@@ -1,6 +1,7 @@
 import AnimateHeight from 'react-animate-height';
 
 import styles from './AccordionItem.module.scss';
+import { useState } from 'react';
 
 const ChevronSVG = ({ className }: { className?: string }) => (
   <svg
@@ -25,25 +26,16 @@ export const AccordionItem = ({
   children,
   className = '',
   headerClassName = '',
-  isOpen,
-  onOpen,
-  onClose,
   label,
 }: {
   children: React.ReactNode | string;
   className?: string;
   headerClassName?: string;
-  isOpen: boolean;
-  onOpen: () => void;
-  onClose: () => void;
   label: React.ReactNode;
 }) => {
+  const [isOpen, setIsOpen] = useState(false);
   const handleClick = () => {
-    if (!isOpen) {
-      onOpen();
-    } else {
-      onClose();
-    }
+    setIsOpen(!isOpen);
   };
 
   return (

--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -190,9 +190,6 @@ const ComparisonTable = <T extends { id: number }>(
                         )}
                         label={headerGroup.label}
                         headerClassName="p24 br8"
-                        isOpen={selectedSection === idString}
-                        onOpen={() => setSelectedSection(idString)}
-                        onClose={() => setSelectedSection('')}
                       >
                         <ScrollSyncPane>
                           <div


### PR DESCRIPTION
### What this PR does
Allow ComparisonTable component to open multiple collapsible sections independently from each other. This reflects what was done on the newer Table component.

https://github.com/user-attachments/assets/2c6fc7a0-e7c3-43c4-8b15-616ec537c0c5

Solves:
PRO-4469


### Checklist:

- [ ] I reviewed my own code
- [ ] The changes align with the designs I received  
  Or give a reason why this does not apply:
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected  
  Or give a reason why this does not apply:
- [ ] I have updated the task(s) status on Linear
- [ ] All new media is optimized (images, gifs, videos)

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge
