### PR TITLE
fix(date-picker): [PRO-5799] Add missing indicator of current day

### DIFF
--- a/src/lib/components/dateSelector/components/datepicker.module.scss
+++ b/src/lib/components/dateSelector/components/datepicker.module.scss
@@ -93,6 +93,12 @@
   }
 }
 
+.today:not(.outside) {
+  .day_button {
+    border-color: $ds-orange-600;
+  }
+}
+
 .outside {
   color: $ds-neutral-400;
 }


### PR DESCRIPTION
### What this PR does
Add missing visual indicator of current day on date picker:
<img width="498" height="384" alt="Screenshot 2026-04-17 at 09 41 26" src="https://github.com/user-attachments/assets/1964cd3d-8f69-4591-bf97-3c2f8665a394" />
