### PR TITLE
fix(comparison-table): [PRO-5532] Update section margin

### DIFF
--- a/src/lib/components/comparisonTable/index.tsx
+++ b/src/lib/components/comparisonTable/index.tsx
@@ -191,7 +191,7 @@ const ComparisonTable = <T extends { id: number }>(
                     {headerGroup.label && collapsibleSections ? (
                       <AccordionItem
                         className={classNames(
-                          'mt16',
+                          baseStyles['collapsible-section'],
                           classNameOverrides?.collapsibleSection
                         )}
                         label={headerGroup.label}

--- a/src/lib/components/comparisonTable/style.module.scss
+++ b/src/lib/components/comparisonTable/style.module.scss
@@ -39,6 +39,10 @@
   }
 }
 
+.collapsible-section {
+  margin-top: 6px;
+}
+
 .section + .section {
   margin-top: 48px;
 


### PR DESCRIPTION
### What this PR does
Update section margin for [Comparison Table component ](http://localhost:9009/?path=/docs/jsx-comparisontable--docs)to match Table component.

**Before:**
<img width="978" height="224" alt="Screenshot 2026-04-24 at 10 11 26" src="https://github.com/user-attachments/assets/ec5f2a1c-3f31-4c86-beca-975b4ef3a087" />

**After:**
<img width="961" height="297" alt="Screenshot 2026-04-24 at 10 11 20" src="https://github.com/user-attachments/assets/1532ea61-df67-4c35-9153-40d78e3c45fe" />

