### PR TITLE
refactor(address-autocomplete): [PRO-4082] Fix partial postal code prefill

### DIFF
--- a/src/lib/components/autocompleteAddress/util/index.test.ts
+++ b/src/lib/components/autocompleteAddress/util/index.test.ts
@@ -48,4 +48,39 @@ describe('geocoderAddressComponentToPartialAddress text', () => {
       expectedOutput
     );
   });
+
+  it('Should not populate postcode when postal_code_prefix is present in types', () => {
+    const input = [
+      {
+        long_name: 'Alte Jakobstraße',
+        short_name: 'Alte Jakobstraße',
+        types: ['route'],
+      },
+      {
+        long_name: 'Berlin',
+        short_name: 'Berlin',
+        types: ['locality', 'political'],
+      },
+      {
+        long_name: 'Germany',
+        short_name: 'DE',
+        types: ['country', 'political'],
+      },
+      {
+        long_name: '10',
+        short_name: '10',
+        types: ['postal_code', 'postal_code_prefix'],
+      },
+    ];
+
+    const expectedOutput = {
+      street: 'Alte Jakobstraße',
+      city: 'Berlin',
+      country: 'DE',
+    };
+
+    expect(geocoderAddressComponentToPartialAddress(input)).toEqual(
+      expectedOutput
+    );
+  });
 });

--- a/src/lib/components/autocompleteAddress/util/index.ts
+++ b/src/lib/components/autocompleteAddress/util/index.ts
@@ -46,6 +46,12 @@ export const geocoderAddressComponentToPartialAddress = (
     const type = value.types[0] as keyof typeof mapping;
     const mappedValue = mapping[type];
     if (mappedValue) {
+      const isPostalCodePrefix = value.types.includes(
+        'postal_code_prefix' as string
+      );
+      if (mappedValue.key === 'postcode' && isPostalCodePrefix) {
+        return;
+      }
       toReturn[mappedValue.key] = value[mappedValue.value];
     }
   });


### PR DESCRIPTION
### What this PR does
- Fix partial postal code autofill in the Address component when Google Maps API returns a postal_code_prefix instead of a full postal_code
- When the API response includes postal_code_prefix in the types array (e.g., "10" instead of "10179"), the postcode field is left empty for manual entry instead of being populated with an incomplete value

### How to test?
  - Verify existing test passes: full postal codes (e.g., 10967) still populate correctly
  - Verify new test passes: postal code prefixes (e.g., 10 with postal_code_prefix type) are not populated
  - Test on staging with "Alte Jakobstraße" address — postcode field should remain empty
  - Test with a specific address (e.g., "Kottbusser Damm 103A") — postcode should still autofill normally
