### PR TITLE
chore(illustrations): Update CDN path to v2 version of illustrations

### DIFF
--- a/src/lib/components/cards/infoCard/index.tsx
+++ b/src/lib/components/cards/infoCard/index.tsx
@@ -24,7 +24,7 @@ export const InfoCard = ({
   ...cardProps
 }: InfoCardProps) => {
   const isIconType = topIconType === 'icon' || topIconType === 'iconWithBackground';
-  const isFloatingType = isIconType || topIconType === 'image';
+  const isFloatingType = isIconType;
 
   return (
     <Card
@@ -73,7 +73,7 @@ export const InfoCard = ({
           'mt40': topIcon && isFloatingType,
           [styles.bannerWrapper]: topIcon && topIconType === 'banner',
         }),
-        label: classNames({
+        label: classNames('d-flex jc-center', {
           [styles.floatingLabel]: topIcon && (isFloatingType || topIconType === 'banner'),
         }),
         title: classNames(

--- a/src/lib/components/cards/infoCard/style.module.scss
+++ b/src/lib/components/cards/infoCard/style.module.scss
@@ -40,15 +40,11 @@
 }
 
 .topIconImage {
-  position: absolute;
   width: 80px;
   height: 80px;
   border-radius: 12px;
   background-color: $ds-orange-200;
   overflow: hidden;
-
-  left: 50%;
-  transform: translateX(-50%) translateY(-80px);
 
   img {
     width: 100%;

--- a/src/lib/util/images/index.ts
+++ b/src/lib/util/images/index.ts
@@ -1,5 +1,5 @@
 const basePath = 'https://assets.cdn.feather-insurance.com/assets/images';
-const basePathIllustrations = `${basePath}/illustrations`;
+const basePathIllustrations = `${basePath}/illustrations/v2`;
 
 const images = {
   aid: `${basePath}/aid.svg`,
@@ -92,7 +92,7 @@ const illustrations = {
   mail: `${basePathIllustrations}/mail.svg`,
   medicine: `${basePathIllustrations}/medicine.svg`,
   mentalHealth: `${basePathIllustrations}/mental-health.svg`,
-  mentalIllness: `${basePathIllustrations}/mental-llness.svg`,
+  mentalIllness: `${basePathIllustrations}/mental-illness.svg`,
   miniJobExpat: `${basePathIllustrations}/minijob-expat.svg`,
   moneyIncome: `${basePathIllustrations}/money-income.svg`,
   movingTruck: `${basePathIllustrations}/moving-truck.svg`,


### PR DESCRIPTION
### What this PR does
Updates CDN path assets to use v2 version.

**Before:**
<img width="1041" height="553" alt="Screenshot 2026-05-28 at 13 27 20" src="https://github.com/user-attachments/assets/81ed7ca4-cd25-4711-bd22-e4e8dbdf78ea" />


**After:**
<img width="1112" height="731" alt="Screenshot 2026-05-28 at 13 27 14" src="https://github.com/user-attachments/assets/40ca5366-5951-4110-ae58-932b2122299a" />
