### PR TITLE
refactor: set latest tag when publishing npm package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,12 +33,13 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           scope: '@popsure'
+          package-manager-cache: false # never use caching in release builds
       - name: Set package version
         run: npm version $RELEASE_VERSION --no-git-tag-version --allow-same-version
       - name: Publish new version
         # No NODE_AUTH_TOKEN: npm authenticates via the OIDC token exchange.
         # Provenance attestations are generated automatically.
-        run: npm publish --access public
+        run: npm publish --access public --tag latest
       - name: Push new package.json version
         run: |
           git commit -am "Bumped package.json to $RELEASE_VERSION"


### PR DESCRIPTION
### What this PR does

1. Explicitly adds the `latest` tag when deploying the package
2. Sets the `package-manager-cache` to false as suggested by the [NPM documentation](https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)

### Why is this needed?

We have some stray higher versions of the package (27.00.xx) that were published by mistake.
NPM does not allow implicitly setting up a lower version as `latest` so we have explicitly pass this option.

