### PR TITLE
refactor(package-json): update repository url to fix provenance issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:getPopsure/dirtySwan.git"
+    "url": "git+https://github.com/getPopsure/dirty-swan.git"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
### What this PR does

1. Updates the package.json `registry.url` parameter to the correct package name (dirty-swan instead of dirtySwan) 
2. It also updates the protocol to git+https to bring it to npm's recommended canonical form

### Why is this needed?

Sigstore validates that package.json repository.url matches the repo the workflow runs in (getPopsure/dirty-swan). The old value pointed at a non-existent **dirtySwan** repo, so validation failed. The new git+https://…/dirty-swan.git normalizes to https://github.com/getPopsure/dirty-swan, exactly what provenance expects.