### PR TITLE
fix(table): [PRO-6028] Fix icon container in table section showing for undefined icons

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -118,7 +118,6 @@ const initialData: TableData = [
   },
   {
     section: {
-      icon: <DentalPlusIcon size={20} noMargin />,
       title: 'Dental',
     },
     rows: [

--- a/src/lib/components/table/components/TableContents/TableContents.tsx
+++ b/src/lib/components/table/components/TableContents/TableContents.tsx
@@ -84,9 +84,9 @@ const TableContents = ({
           : isSectionOpen === index || isFirstSection;
         const isVisible = hideDetails ? !shouldHideDetails : true;
 
-        const renderedIcon = (
+        const renderedIcon = section.icon ? (
           <IconRenderer icon={section.icon} imageComponent={imageComponent} width={20} />
-        );
+        ) : null;
 
         // Calculate section-specific hideRows based on global offset
         const sectionHideRows = hideRows


### PR DESCRIPTION
### What this PR does
Fix icon container in table section showing for undefined icons.

**Before:**
<img width="1030" height="251" alt="Screenshot 2026-07-07 at 12 13 55" src="https://github.com/user-attachments/assets/3c37adb9-3080-4934-a152-adf37756078f" />

**After:**
<img width="1020" height="267" alt="Screenshot 2026-07-07 at 12 13 19" src="https://github.com/user-attachments/assets/d15b7bcd-5d88-4ed6-b3fb-2938c9d55cf6" />

Solves:
PRO-6028

