### PR TITLE
refactor(table): [PRO-7028] Show selected column

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -307,6 +307,7 @@ const story = {
     hideColumns: [],
     hideRows: [],
     hideTableNavigation: true,
+    showSelectedColumn: false,
   },
 };
 
@@ -324,6 +325,7 @@ export const TableStory = {
     title,
     activeSection,
     hideTableNavigation,
+    showSelectedColumn,
   }: TableProps) => {
     const [price, setPrice] = useState(999);
     return (
@@ -367,6 +369,7 @@ export const TableStory = {
           title={title}
           activeSection={activeSection}
           hideTableNavigation={hideTableNavigation}
+          showSelectedColumn={showSelectedColumn}
         />
       </div>
     );

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -47,6 +47,7 @@ export interface TableProps {
   title: string;
   activeSection?: number;
   hideTableNavigation?: boolean;
+  showSelectedColumn?: boolean;
 }
 
 const defaultTextOverrides = {
@@ -73,6 +74,7 @@ const Table = ({
   title,
   activeSection: externalActiveSection,
   hideTableNavigation = false,
+  showSelectedColumn = false,
 }: TableProps) => {
   const textOverrides = { ...defaultTextOverrides, ...definedTextOverrides };
   const isMobile = useMediaQuery('BELOW_MOBILE');
@@ -99,7 +101,7 @@ const Table = ({
   };
   const currentActiveSection = tableData?.[0]?.rows?.[0]?.[activeSection];
   const currentActiveSectionReplacements =
-    (currentActiveSection.cellId &&
+    (currentActiveSection?.cellId &&
       cellReplacements?.[currentActiveSection.cellId]) ||
     {};
 
@@ -133,7 +135,7 @@ const Table = ({
             />
           )}
 
-          {!hideTableNavigation && (
+          {!hideTableNavigation && currentActiveSection && (
             <TableControls
               activeSection={activeSection}
               columnsLength={columnsLength}
@@ -196,6 +198,7 @@ const Table = ({
           openModal={handleOpenModal}
           cellReplacements={cellReplacements}
           imageComponent={imageComponent}
+          selectedColumn={showSelectedColumn ? activeSection : undefined}
         />
       </div>
 

--- a/src/lib/components/table/components/TableCell/TableCell.module.scss
+++ b/src/lib/components/table/components/TableCell/TableCell.module.scss
@@ -42,6 +42,14 @@
   }
 }
 
+.selectedColumnTop {
+  border-radius: 16px 16px 0 0;
+}
+
+.selectedColumnBottom {
+  border-radius: 0 0 16px 16px;
+}
+
 .fixedCard {
   position: sticky;
   left: 0;

--- a/src/lib/components/table/components/TableCell/TableCell.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.tsx
@@ -13,6 +13,8 @@ type ExtraTableCellProps = {
   isFirstCellInRow?: boolean;
   isTopLeftCell?: boolean;
   isNavigation?: boolean;
+  isSelectedColumn?: boolean;
+  selectedColumnPosition?: 'top' | 'bottom' | 'middle';
   imageComponent?: (args: any) => JSX.Element;
   isBelowDesktop?: boolean;
 };
@@ -24,6 +26,8 @@ const TableCell = React.memo(
     isFirstCellInRow = false,
     isHeader = false,
     isNavigation = false,
+    isSelectedColumn = false,
+    selectedColumnPosition,
     isTopLeftCell = false,
     colSpan = 0,
     isBelowDesktop,
@@ -46,11 +50,13 @@ const TableCell = React.memo(
     return (
       <Tag
         {...scope}
-        className={classNames('bg-white py24 px8', styles.th, {
+        className={classNames(isSelectedColumn ? 'bg-orange-50' : 'bg-white', 'py24 px8', styles.th, {
           'ta-left': isFirstCellInRow,
           [styles.thNavigation]: isNavigation,
           [styles.fixedCell]: isFirstCellInRow && colSpan < 1 ,
           [styles.fixedCard]: cellProps.type === 'CARD',
+          [styles.selectedColumnTop]: selectedColumnPosition === 'top',
+          [styles.selectedColumnBottom]: selectedColumnPosition === 'bottom',
         })}
         colSpan={isBelowDesktop && cellProps.type === 'CARD' ? 2 : colSpan}
       >

--- a/src/lib/components/table/components/TableContents/TableContents.tsx
+++ b/src/lib/components/table/components/TableContents/TableContents.tsx
@@ -25,6 +25,7 @@ export interface TableContentsProps {
   title: string;
   cellReplacements?: CellReplacements;
   imageComponent?: (args: any) => JSX.Element;
+  selectedColumn?: number;
 }
 
 const TableContents = ({
@@ -43,6 +44,7 @@ const TableContents = ({
   title,
   cellReplacements,
   imageComponent,
+  selectedColumn,
 }: TableContentsProps) => {
   const [isSectionOpen, setOpenSection] = useState<number | null>(null);
   const lastToggledSection = useRef<number | null>(null);
@@ -147,6 +149,7 @@ const TableContents = ({
                 width={tableWidth}
                 cellReplacements={cellReplacements}
                 imageComponent={imageComponent}
+                selectedColumn={selectedColumn}
               />
             </Collapsible>
           </div>

--- a/src/lib/components/table/components/TableSection/TableSection.tsx
+++ b/src/lib/components/table/components/TableSection/TableSection.tsx
@@ -23,6 +23,7 @@ export interface TableSectionProps {
   width?: number | string;
   cellReplacements?: CellReplacements;
   imageComponent?: (args: any) => JSX.Element;
+  selectedColumn?: number;
 }
 
 const TableSection = ({
@@ -36,9 +37,20 @@ const TableSection = ({
   width,
   cellReplacements,
   imageComponent,
+  selectedColumn,
 }: TableSectionProps) => {
   const headerRow = tableCellRows?.[0];
   const isBelowDesktop = useMediaQuery('BELOW_DESKTOP');
+
+  const firstVisibleBodyRowIndex = tableCellRows.findIndex(
+    (_, index) => index > 0 && !hideRows.includes(index)
+  );
+
+  const lastVisibleRowIndex = tableCellRows.reduce(
+    (last, row, index) =>
+      index > 0 && !hideRows.includes(index) && row.length > 1 ? index : last,
+    -1
+  );
 
   const getModalTitleFromColumnHeader = (cellIndex: number) => {
     const firstCellInColumn = tableCellRows?.[0]?.[cellIndex];
@@ -114,6 +126,8 @@ const TableSection = ({
                     isHeader
                     isFirstCellInRow={isFirstCellInRow}
                     isTopLeftCell={isFirstCellInRow}
+                    isSelectedColumn={selectedColumn === cellIndex}
+                    selectedColumnPosition={selectedColumn === cellIndex ? 'top' : undefined}
                     {...cellProps}
                     imageComponent={imageComponent}
                   />
@@ -133,6 +147,14 @@ const TableSection = ({
                   const key = `${rowIndex}-${cellIndex}`;
                   const isFirstCellInRow = cellIndex === 0;
                   const titleFromRow = getModalTitleFromRowHeader(row);
+                  const isSelected = selectedColumn === cellIndex;
+
+                  const getSelectedColumnPosition = () => {
+                    if (!isSelected) return undefined;
+                    if (rowIndex === lastVisibleRowIndex) return 'bottom';
+                    if (hideHeader && rowIndex === firstVisibleBodyRowIndex) return 'top';
+                    return 'middle';
+                  };
 
                   const cellReplacementData =
                     (tableCellData.cellId &&
@@ -154,6 +176,8 @@ const TableSection = ({
                       <TableCell
                         isBelowDesktop={isBelowDesktop}
                         isFirstCellInRow={isFirstCellInRow}
+                        isSelectedColumn={isSelected}
+                        selectedColumnPosition={getSelectedColumnPosition()}
                         key={key}
                         {...cellProps}
                         imageComponent={imageComponent}


### PR DESCRIPTION
### What this PR does
Show selected column based on the combination of `activeSection` and `showSelectedColumn` props.

<img width="1061" height="671" alt="Screenshot 2026-07-22 at 11 38 03" src="https://github.com/user-attachments/assets/b18935a3-32e0-46f8-9c75-0e68fd413a7c" />


https://github.com/user-attachments/assets/b26c975e-7af6-48c2-8e16-1b014dd0bbf9



