### PR TITLE
fix(table): [PRO-7028] Remove vertical divider and left align action cells

### DIFF
--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
@@ -29,7 +29,7 @@ export const ButtonCell = ({
     <div
       className={
         classNames(
-          "w100 d-flex fd-column ai-center jc-center gap8",
+          "w100 d-flex fd-column ai-start jc-center gap8",
           className,
         )
       }

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
@@ -40,11 +40,11 @@ export const CTACell = ({
 
   return (
     <div
-      className={classNames(className, "ta-center")}
+      className={classNames(className, "ta-left")}
       data-cy={dataCy}
       data-testid={dataTestId}
     >
-      <div className="d-flex jc-center ai-center gap8">
+      <div className="d-flex ai-center gap8">
         {renderedIcon}
         <p className="p-h3">
           {title}

--- a/src/lib/components/table/components/TableCell/TableCell.module.scss
+++ b/src/lib/components/table/components/TableCell/TableCell.module.scss
@@ -28,16 +28,6 @@
   left: 0;
   z-index: 2;
   padding-left: 0;
-
-  &:after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    width: 1px;
-    background-color: $ds-neutral-100;
-  }
 }
 
 .selectedColumnTop {


### PR DESCRIPTION
### What this PR does

Two follow-up adjustments to the Table redesign shipped in 0.66.13, based on design review of the multi-plan table:

- Removes the vertical divider line that separated the sticky label column from the plan columns. It no longer exists in the new design.
- Left-aligns the action cells, matching the left alignment of all other cell content: the CTA cells (plan title, price, and call-to-action button) and the plan selection button cells were previously centered in their columns. The buttons keep their existing width constraints, anchored left.

<img width="1269" height="941" alt="Screenshot 2026-07-24 at 11 05 33" src="https://github.com/user-attachments/assets/dc674245-d5c9-46de-92ab-8d5bf17e9215" />
