### PR TITLE
fix(table): [PRO-7028] Top align header row cells

### DIFF
--- a/src/lib/components/table/components/TableCell/TableCell.module.scss
+++ b/src/lib/components/table/components/TableCell/TableCell.module.scss
@@ -23,6 +23,10 @@
   }
 }
 
+.headerCell {
+  vertical-align: top;
+}
+
 .fixedCell {
   position: sticky;
   left: 0;

--- a/src/lib/components/table/components/TableCell/TableCell.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.tsx
@@ -52,6 +52,7 @@ const TableCell = React.memo(
         {...scope}
         className={classNames(isSelectedColumn ? 'bg-orange-50' : 'bg-white', styles.th, {
           'ta-left': isFirstCellInRow,
+          [styles.headerCell]: isHeader,
           [styles.thNavigation]: isNavigation,
           [styles.fixedCell]: isFirstCellInRow && colSpan < 1 ,
           [styles.fixedCard]: cellProps.type === 'CARD',


### PR DESCRIPTION
### What this PR does

Aligns the table header row cells to the top of the row instead of vertically centering them. In multi-plan tables, the top-left title (e.g. "Our plans") previously floated in the vertical middle of the tall header row; it now sits at the top, on the same line as the plan titles (e.g. "Expat health") in the CTA cells, as the design specifies.

<img width="1363" height="314" alt="Screenshot 2026-07-24 at 12 43 54" src="https://github.com/user-attachments/assets/14b2981a-2ffb-4b70-8d3a-4f476a3d524f" />
