### PR TITLE
fix(table): update CTA cell button max width to 176px

### DIFF
--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.module.scss
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.module.scss
@@ -1,3 +1,7 @@
+.button {
+  max-width: 176px;
+}
+
 .narrow {
   height: 40px;
   padding: 8px!important;

--- a/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
+++ b/src/lib/components/table/components/TableCell/CTACell/CTACell.tsx
@@ -59,7 +59,7 @@ export const CTACell = ({
           target: '_blank',
           rel: 'noopener noreferrer',
         }}
-        className={classNames('mt16 w100 wmx3', {
+        className={classNames('mt16 w100', styles.button, {
           'p-btn--primary': !grey,
           'p-btn--secondary-grey': grey,
           [styles.narrow]: narrow,


### PR DESCRIPTION
### What this PR does

Updates the Table CTA cell button max width from 212px (`wmx3` utility) to 176px, per the [Figma spec](https://www.figma.com/design/MKs4cbojdVOBKUxv7okb93/Dirty-Swan-Design-System?node-id=36559-6299).

<img width="1936" height="555" alt="Screenshot 2026-07-27 at 09 27 38" src="https://github.com/user-attachments/assets/5be19061-1f3a-44c3-8702-35aec153df35" />
