### PR TITLE
fix(table): hide section bottom border while accordion is expanded

### DIFF
--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
@@ -38,6 +38,10 @@
     padding: 24px;
   }
 
+  &[aria-expanded='true'] {
+    border-bottom-color: transparent;
+  }
+
   &:hover {
     color: colors.$ds-neutral-700;
 

--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.tsx
@@ -74,6 +74,7 @@ export const AccordionItem = ({
       className={`d-flex fd-column ${styles.container} ${className}`}
     >
       <button
+        aria-expanded={isOpen}
         className={`d-flex ai-center jc-between ${styles.headerButton} ${headerClassName}`}
         onClick={handleClick}
         type="button"

--- a/src/lib/components/table/components/TableContents/TableContents.module.scss
+++ b/src/lib/components/table/components/TableContents/TableContents.module.scss
@@ -14,6 +14,10 @@
   border-bottom: 1px solid $ds-neutral-300;
   color: $ds-neutral-900;
   padding: 0;
+
+  &[aria-expanded='true'] {
+    border-bottom-color: transparent;
+  }
 }
 
 button.sectionButton {


### PR DESCRIPTION
## What

When a collapsible section is expanded, its header no longer shows the bottom divider — the border only separates sections while they are collapsed. 

https://github.com/user-attachments/assets/9d3f54d7-192d-405c-98f1-9a6cb39a865e
