### PR TITLE
refactor(button-cell): [PRO-7050] Update ButtonCell component styles

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -733,6 +733,91 @@ export const TwoPlanQuoteWebsite = {
   name: 'Two Plan - Website',
 };
 
+const twoPlanQuoteData: TableData = [
+  {
+    rows: [
+      [
+        { text: 'Select a plan' },
+        {
+          type: 'BUTTON',
+          buttonCaption: 'Basic',
+          price: '€99/mo',
+          isSelected: true,
+          onClick: () => {},
+        },
+        {
+          type: 'BUTTON',
+          buttonCaption: 'Advanced',
+          price: '€134/mo',
+          onClick: () => {},
+        },
+      ],
+      [
+        { text: 'Your contribution' },
+        { text: '€99', description: 'per month', fontVariant: 'PRICE' },
+        { text: '€134', description: 'per month', fontVariant: 'PRICE' },
+      ],
+      [
+        { text: 'Outpatient treatments', modalContent: 'Outpatient info' },
+        { checkmarkValue: true },
+        { checkmarkValue: true },
+      ],
+      [
+        { text: 'Inpatient treatments', modalContent: 'Inpatient info' },
+        { checkmarkValue: false },
+        { checkmarkValue: true },
+      ],
+      [
+        { text: 'Dental care', modalContent: 'Dental info' },
+        { text: '50%' },
+        { text: '80%' },
+      ],
+    ],
+  },
+  {
+    section: {
+      title: 'Coverage details',
+    },
+    rows: [
+      [
+        { text: 'Annual limit' },
+        { text: 'Up to €10,000' },
+        { text: 'Unlimited' },
+      ],
+      [
+        { text: 'Deductible' },
+        { text: '€500' },
+        { text: '€250' },
+      ],
+      [
+        { text: 'Preventive care' },
+        { checkmarkValue: true },
+        { checkmarkValue: true },
+      ],
+      [
+        { text: 'Alternative medicine' },
+        { checkmarkValue: false },
+        { checkmarkValue: true },
+      ],
+    ],
+  },
+];
+
+export const TwoPlanQuote = {
+  render: () => (
+    <div style={{ maxWidth: 900 }}>
+      <Table
+        tableData={twoPlanQuoteData}
+        title="Two plan quote"
+        collapsibleSections
+        showSelectedColumn
+      />
+    </div>
+  ),
+
+  name: 'Two Plan Quote',
+};
+
 const threePlanWebsiteData: TableData = [
   {
     rows: [

--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.module.scss
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.module.scss
@@ -2,21 +2,28 @@
 @use "../../../../../scss/public/colors" as *;
 
 .buttonCell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: calc(100% + 48px);
+  margin-left: -24px;
+  margin-right: -24px;
+  padding: 16px 24px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background-color: transparent;
   color: $ds-neutral-900;
-  border: 1px solid $ds-neutral-400;
+  cursor: pointer;
+  transition: border-color 0.3s ease-in-out, background-color 0.3s ease-in-out;
+  text-align: left;
 
-  transition: all 0.3s ease-in-out;
+  &:hover:not(:disabled):not(.selected) {
+    background-color: $ds-orange-50;
+  }
 
-  &:disabled {
-    border: none;
-    background-color: $ds-neutral-100;
-    color: $ds-neutral-900;
-    opacity: 1;
-    cursor: default;
-
-    &:hover {
-      background-color: $ds-neutral-100;
-    }
+  &:focus-visible {
+    outline: 1px solid $ds-neutral-900;
+    outline-offset: 0;
   }
 
   @include p-size-mobile {
@@ -24,15 +31,14 @@
   }
 }
 
-.withoutPrice {
-  height: 64px;
-}
-
-.withPrice {
-  height: 75px;
-}
-
 .selected {
-  transition: all 0.3 ease-in-out;
-  border: 2px solid $ds-neutral-900;
+  border: 1px solid $ds-neutral-900;
+  background-color: $ds-orange-50;
+}
+
+.disabled {
+  background-color: $ds-neutral-100;
+  cursor: default;
+  opacity: 1;
+  pointer-events: none;
 }

--- a/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
+++ b/src/lib/components/table/components/TableCell/ButtonCell/ButtonCell.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 
 import styles from './ButtonCell.module.scss';
-import { Button } from '../../../../button';
+import { CircleSelectedIcon, CircleUnselectedIcon } from '../../../../icon';
 import { ReactNode } from 'react';
 
 export type ButtonCellProps = {
@@ -27,29 +27,32 @@ export const ButtonCell = ({
 }: ButtonCellProps) => {
   return (
     <div
-      className={
-        classNames(
-          "w100 d-flex fd-column ai-start jc-center gap8",
-          className,
-        )
-      }
+      className={classNames(
+        "w100 d-flex fd-column ai-start jc-center gap8",
+        className,
+      )}
       data-cy={dataCy}
       data-testid={dataTestId}
     >
-      <Button
-        className={classNames('w100 wmx5 d-flex fd-column', styles.buttonCell, {
+      <button
+        className={classNames('w100 wmx5', styles.buttonCell, {
           [styles.selected]: isSelected,
-          [styles.withoutPrice]: !price,
-          [styles.withPrice]: !!price,
+          [styles.disabled]: disabled,
         })}
-        variant="filledWhite"
-        type="submit"
+        type="button"
         onClick={onClick}
         disabled={disabled}
       >
-        {buttonCaption}
-        {price && <span className="p-p">{price}</span>}
-      </Button>
+        <div className="d-flex fd-column ai-start">
+          <span className="p-p fw-bold">{buttonCaption}</span>
+          {price && <span className="p-p">{price}</span>}
+        </div>
+        {!disabled && (isSelected ? (
+          <CircleSelectedIcon size={16} />
+        ) : (
+          <CircleUnselectedIcon size={16} />
+        ))}
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
### What this PR does
  1. Refactored ButtonCell from using the Button component to a native <button> element with custom styles for a radio-button-like selection pattern
  2. Updated ButtonCell styles: replaced fixed height variants with a flexible layout using display: flex, added selected/disabled states, hover and focus-visible styles
  3. Added CircleSelectedIcon/CircleUnselectedIcon to visually indicate selection state, with caption and price displayed in a stacked layout
  4. Added a new TwoPlanQuote story showcasing the updated button cell in a two-plan comparison table

  Solves:
  PRO-7050

### How to test?
 Run Storybook and navigate to the Table component stories:
- [ButtonCell](http://localhost:9009/?path=/story/jsx-table-cells--button-cell-story)
- [Two Plan Quote example](http://localhost:9009/?path=/story/jsx-table--two-plan-quote)

<img width="410" height="534" alt="Screenshot 2026-08-04 at 10 33 44" src="https://github.com/user-attachments/assets/3e5d1fa5-dc82-486f-8653-97a4cde568ab" />
<img width="951" height="303" alt="Screenshot 2026-08-04 at 10 33 36" src="https://github.com/user-attachments/assets/626ed46b-4188-46b3-98a2-43ba8e3e266f" />

