### PR TITLE
feat(tabs): Add Tabs component and use it on mobile Table header

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -939,6 +939,25 @@ export const ThreePlanQuoteWebsite = {
   name: 'Three Plan - Website',
 };
 
+export const TabsNavigationMobile = {
+  render: () => (
+    <div style={{ maxWidth: 900 }}>
+      <p className="p-p tc-neutral-500 mb16">
+        Resize the browser to a mobile width to see tabs instead of
+        left/right arrow buttons.
+      </p>
+      <Table
+        tableData={threePlanWebsiteData}
+        title="Tabs navigation (mobile)"
+        collapsibleSections
+        mobileNavigationMode="tabs"
+      />
+    </div>
+  ),
+
+  name: 'Tabs Navigation (Mobile)',
+};
+
 export const TableDataType = () => {
   return (
     <pre>

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -20,6 +20,7 @@ import {
   TableCellData,
   TableData,
 } from './types';
+import { Tabs, TabItem } from '../tabs/Tabs';
 
 export type { TableData } from './types';
 
@@ -49,6 +50,7 @@ export interface TableProps {
   hideTableNavigation?: boolean;
   hideStickyHeader?: boolean;
   showSelectedColumn?: boolean;
+  mobileNavigationMode?: 'arrows' | 'tabs';
 }
 
 const defaultTextOverrides = {
@@ -77,6 +79,7 @@ const Table = ({
   hideTableNavigation = false,
   hideStickyHeader = false,
   showSelectedColumn = false,
+  mobileNavigationMode = 'arrows',
 }: TableProps) => {
   const textOverrides = { ...defaultTextOverrides, ...definedTextOverrides };
   const isMobile = useMediaQuery('BELOW_MOBILE');
@@ -89,6 +92,8 @@ const Table = ({
 
   useScrollSync(headerRef, containerRef, !isMobile);
 
+  const useTabs = isMobile && mobileNavigationMode === 'tabs';
+
   const { activeSection, navigateTable, setActiveSection } = useTableNavigation(
     {
       enabled: isMobile,
@@ -97,11 +102,25 @@ const Table = ({
     }
   );
 
+  const headerRow = tableData?.[0]?.rows?.[0];
   const titleCell = {
     text: '',
-    ...(tableData?.[0]?.rows?.[0]?.[0] || {}),
+    ...(headerRow?.[0] || {}),
   };
-  const currentActiveSection = tableData?.[0]?.rows?.[0]?.[activeSection];
+  const currentActiveSection = headerRow?.[activeSection];
+
+  const mobileTabs: TabItem[] = useTabs
+    ? headerRow
+        ?.slice(1)
+        .map((cell, index) => {
+          let label = '';
+          if (!cell.type) label = String(cell.text || '');
+          else if (cell.type === 'CTA') label = String(cell.title || '');
+          else if (cell.type === 'BUTTON') label = String(cell.buttonCaption || '');
+          return { id: String(index), label };
+        }) ?? []
+    : [];
+
   const currentActiveSectionReplacements =
     (currentActiveSection?.cellId &&
       cellReplacements?.[currentActiveSection.cellId]) ||
@@ -127,7 +146,7 @@ const Table = ({
     <div className={classNames(styles.wrapper, 'bg-white')}>
       {isMobile ? (
         <>
-          {titleCell?.text && (
+          {!useTabs && titleCell?.text && (
             <TableCell
               {...titleCell}
               align="left"
@@ -138,27 +157,44 @@ const Table = ({
           )}
 
           {!hideTableNavigation && currentActiveSection && (
-            <TableControls
-              activeSection={activeSection}
-              columnsLength={columnsLength}
-              navigateTable={navigateTable}
-              stickyHeaderTopOffset={stickyHeaderTopOffset}
-            >
-              <TableCell
-                {...(isBaseCell(currentActiveSection)
-                  ? {
-                      openModal: (body: ReactNode) =>
-                        handleOpenModal({
-                          body,
-                          title: currentActiveSection?.text,
-                        }),
-                    }
-                  : {})}
-                {...activeCellProps}
-                imageComponent={imageComponent}
-                isNavigation
-              />
-            </TableControls>
+            useTabs ? (
+              <div
+                className={classNames(
+                  'bg-white',
+                  styles.stickyHeader
+                )}
+                style={{ top: `${stickyHeaderTopOffset}px` }}
+              >
+                <Tabs
+                  tabs={mobileTabs}
+                  activeIndex={activeSection - 1}
+                  onTabChange={(index) => setActiveSection(index)}
+                  className="mb16"
+                />
+              </div>
+            ) : (
+              <TableControls
+                activeSection={activeSection}
+                columnsLength={columnsLength}
+                navigateTable={navigateTable}
+                stickyHeaderTopOffset={stickyHeaderTopOffset}
+              >
+                <TableCell
+                  {...(isBaseCell(currentActiveSection)
+                    ? {
+                        openModal: (body: ReactNode) =>
+                          handleOpenModal({
+                            body,
+                            title: currentActiveSection?.text,
+                          }),
+                      }
+                    : {})}
+                  {...activeCellProps}
+                  imageComponent={imageComponent}
+                  isNavigation
+                />
+              </TableControls>
+            )
           )}
         </>
       ) : (
@@ -203,6 +239,7 @@ const Table = ({
           cellReplacements={cellReplacements}
           imageComponent={imageComponent}
           selectedColumn={showSelectedColumn ? activeSection : undefined}
+          showHeader={useTabs}
         />
       </div>
 

--- a/src/lib/components/table/components/TableContents/TableContents.tsx
+++ b/src/lib/components/table/components/TableContents/TableContents.tsx
@@ -25,6 +25,7 @@ export interface TableContentsProps {
   cellReplacements?: CellReplacements;
   imageComponent?: (args: any) => JSX.Element;
   selectedColumn?: number;
+  showHeader?: boolean;
 }
 
 const TableContents = ({
@@ -44,6 +45,7 @@ const TableContents = ({
   cellReplacements,
   imageComponent,
   selectedColumn,
+  showHeader = false,
 }: TableContentsProps) => {
   const [isSectionOpen, setOpenSection] = useState<number | null>(null);
   const lastToggledSection = useRef<number | null>(null);
@@ -147,7 +149,7 @@ const TableContents = ({
                 }
                 hideColumns={hideColumns}
                 hideRows={sectionHideRows}
-                hideHeader
+                hideHeader={!showHeader}
                 openModal={openModal}
                 title={`${title}${
                   section?.title ? ` - ${section.title}` : ''

--- a/src/lib/components/tabs/Tabs.module.scss
+++ b/src/lib/components/tabs/Tabs.module.scss
@@ -1,0 +1,26 @@
+@use '../../scss/public/colors' as *;
+@use '../../scss/public/font-weight' as *;
+
+.tabs {
+  display: flex;
+  column-gap: 24px;
+}
+
+.tab {
+  border: none;
+  border-bottom: 2px solid transparent;
+  font-weight: $p-font-weight-bold;
+  padding: 0 0 4px;
+  color: $ds-neutral-500;
+
+  &:hover, &Active {
+    color: $ds-neutral-900;
+    border-bottom-color: $ds-neutral-900;
+  }
+
+  &:focus-visible {
+    outline: 1px solid $ds-neutral-900;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}

--- a/src/lib/components/tabs/Tabs.stories.tsx
+++ b/src/lib/components/tabs/Tabs.stories.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { Tabs, TabsProps } from './Tabs';
+
+const story = {
+  title: 'JSX/Tabs',
+  component: Tabs,
+  argTypes: {
+    tabs: {
+      description: 'Array of tab items with id and label',
+    },
+    activeIndex: {
+      description: 'The currently active tab index',
+    },
+    onTabChange: {
+      action: true,
+      table: {
+        category: 'Callbacks',
+      },
+    },
+    className: {
+      description: 'Optional CSS class to apply to the tabs container',
+    },
+  },
+  args: {
+    tabs: [
+      { id: 'basic', label: 'Basic' },
+      { id: 'standard', label: 'Standard' },
+      { id: 'premium', label: 'Premium' },
+    ],
+    activeIndex: 0,
+  },
+  parameters: {
+    componentSubtitle:
+      'A horizontal tab bar for switching between content sections.',
+  },
+};
+
+export const Default = {
+  render: ({ tabs, activeIndex, onTabChange }: TabsProps) => {
+    const [index, setIndex] = useState(activeIndex);
+
+    const handleChange = (newIndex: number) => {
+      onTabChange?.(newIndex);
+      setIndex(newIndex);
+    };
+
+    return <Tabs tabs={tabs} activeIndex={index} onTabChange={handleChange} />;
+  },
+
+  name: 'Default',
+};
+
+export const TwoTabs = {
+  render: () => {
+    const [index, setIndex] = useState(0);
+
+    return (
+      <Tabs
+        tabs={[
+          { id: 'monthly', label: 'Monthly' },
+          { id: 'yearly', label: 'Yearly' },
+        ]}
+        activeIndex={index}
+        onTabChange={setIndex}
+      />
+    );
+  },
+
+  name: 'Two Tabs',
+};
+
+export const ManyTabs = {
+  render: () => {
+    const [index, setIndex] = useState(0);
+
+    return (
+      <Tabs
+        tabs={[
+          { id: 'overview', label: 'Overview' },
+          { id: 'coverage', label: 'Coverage' },
+          { id: 'pricing', label: 'Pricing' },
+          { id: 'reviews', label: 'Reviews' },
+          { id: 'faq', label: 'FAQ' },
+        ]}
+        activeIndex={index}
+        onTabChange={setIndex}
+      />
+    );
+  },
+
+  name: 'Many Tabs',
+};
+
+export default story;

--- a/src/lib/components/tabs/Tabs.tsx
+++ b/src/lib/components/tabs/Tabs.tsx
@@ -1,0 +1,65 @@
+import classNames from 'classnames';
+import { KeyboardEvent, useCallback, useRef } from 'react';
+
+import styles from './Tabs.module.scss';
+
+export interface TabItem {
+  id: string;
+  label: string;
+}
+
+export interface TabsProps {
+  tabs: TabItem[];
+  activeIndex: number;
+  onTabChange: (index: number) => void;
+  className?: string;
+}
+
+const Tabs = ({ tabs, activeIndex, onTabChange, className }: TabsProps) => {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const setTabRef = useCallback(
+    (index: number) => (el: HTMLButtonElement | null) => {
+      tabRefs.current[index] = el;
+    },
+    []
+  );
+
+  const handleKeyDown = (e: KeyboardEvent, index: number) => {
+    const count = tabs.length;
+    let nextIndex: number | null = null;
+
+    if (e.key === 'ArrowRight') nextIndex = (index + 1) % count;
+    if (e.key === 'ArrowLeft') nextIndex = (index - 1 + count) % count;
+
+    if (nextIndex !== null) {
+      e.preventDefault();
+      onTabChange(nextIndex);
+      tabRefs.current[nextIndex]?.focus({ preventScroll: true });
+    }
+  };
+
+  return (
+    <div className={classNames(styles.tabs, className)} role="tablist">
+      {tabs.map((tab, index) => (
+        <button
+          ref={setTabRef(index)}
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-selected={activeIndex === index}
+          tabIndex={activeIndex === index ? 0 : -1}
+          className={classNames('p-p bg-transparent c-pointer', styles.tab, {
+            [styles.tabActive]: activeIndex === index,
+          })}
+          onClick={() => onTabChange(index)}
+          onKeyDown={(e) => handleKeyDown(e, index)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export { Tabs };

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -54,6 +54,7 @@ import { Toaster, toast } from './components/toast';
 import { IconWrapperProps } from './components/icon/IconWrapper';
 import { Accordion, AccordionProps } from './components/accordion';
 import { Table, TableData, TableProps } from './components/table/Table';
+import { Tabs, TabsProps, TabItem } from './components/tabs/Tabs';
 import { useEscapeKey } from './hooks/useEscapeKey';
 import { useFocusWithin } from './hooks/useFocusWithin';
 import { useMediaQuery } from './hooks/useMediaQuery';
@@ -107,6 +108,7 @@ export {
   illustrations,
   Spinner,
   Table,
+  Tabs,
   Toggle,
   Toaster,
   toast,
@@ -139,6 +141,8 @@ export type {
   UploadStatus,
   CardProps,
   IconWrapperProps,
+  TabItem,
+  TabsProps,
   TableData,
   TableProps,
 };


### PR DESCRIPTION
### What this PR does
  1. Adds a new Tabs component (src/lib/components/tabs/) with full keyboard navigation and ARIA tablist support
  2. Integrates Tabs into the Table component as an alternative mobile navigation mode via a new mobileNavigationMode prop ('arrows' | 'tabs')
  3. Exports Tabs, TabsProps, and TabItem from the library index

###  Why is this needed?
  On mobile, the Table component currently uses left/right arrow buttons to navigate between columns. This adds a tab-based navigation alternative that gives users a clearer overview of all available columns at a glance, improving discoverability and usability on mobile devices.

###  How to test?
  - Open the Tabs stories in Storybook (JSX/Tabs) to verify the standalone component (Default, Two Tabs, Many Tabs)
  - Open the Table > Tabs Navigation (Mobile) story, resize the browser to a mobile width, and verify:
    - Tabs appear instead of arrow navigation
    - Clicking a tab switches the visible column
    - Keyboard navigation (ArrowLeft/ArrowRight) works between tabs
    - The tabs container sticks to the top when scrolling
  - Verify that existing Table stories still use arrow navigation by default (no regression)

### Preview
<img width="354" height="378" alt="Screenshot 2026-08-04 at 14 56 12" src="https://github.com/user-attachments/assets/4a44f23e-23a1-4c2f-9a3a-f5763f63ffb6" />
<img width="1074" height="305" alt="Screenshot 2026-08-04 at 14 55 36" src="https://github.com/user-attachments/assets/ea30b032-e2c6-4a59-9666-fbdfefdec810" />

