### PR TITLE
fix(comparison-table): [NoTicket] remove left padding from first column and accordion header

### DIFF
--- a/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
+++ b/src/lib/components/comparisonTable/components/AccordionItem/AccordionItem.module.scss
@@ -1,5 +1,4 @@
 @use '../../../../scss/public/colors' as colors;
-@use '../../../../scss/public/grid' as *;
 
 .container {
   width: var(--growContent, min-content);
@@ -33,10 +32,6 @@
   position: relative;
   text-align: inherit;
   transition: color 0.3s ease-in-out, transform 0.2s ease-in-out;
-
-  @include p-size-tablet {
-    padding: 24px;
-  }
 
   &[aria-expanded='true'] {
     border-bottom-color: transparent;

--- a/src/lib/components/comparisonTable/components/Row/style.module.scss
+++ b/src/lib/components/comparisonTable/components/Row/style.module.scss
@@ -54,10 +54,6 @@ $cell-min-width: var(--cellWidth, 211px); // 195 + 16px
 
   &:first-child {
     padding: 16px 8px 16px 0;
-
-    @include p-size-tablet {
-      padding: 16px 8px 16px 16px;
-    }
   }
 
   color: $ds-neutral-900;
@@ -83,7 +79,7 @@ $cell-min-width: var(--cellWidth, 211px); // 195 + 16px
     flex: 1 0 $cell-min-width;
     width: $cell-min-width;
     &:first-child {
-      padding: 24px 8px 24px 24px;
+      padding: 24px 8px 24px 0;
     }
 
     padding: 24px 8px;


### PR DESCRIPTION
### What this PR does

1. Removes the 24px left padding from the first column cells of the `ComparisonTable` on tablet and up 
2. Removes the tablet-only `padding: 24px` override on the accordion section header button 

https://github.com/user-attachments/assets/41abb52e-ce2b-41b2-b91c-0b9c406dd153

### How to test?

Run storybook, open the ComparisonTable story with collapsible sections at desktop width, and check that the first column labels and the section header icons/titles align flush left with the card's content edge (no extra 24px indent). Mobile behavior is unchanged (left padding was already 0).

### Checklist:

- [x] I reviewed my own code
- [x] The changes align with the designs I received
- [ ] I have attached screenshot(s), video(s) or gif(s) showing that the solution is working as expected
- [ ] I have updated the task(s) status on Linear
  No Linear ticket — visual QA feedback
- [x] All new media is optimized (images, gifs, videos)
  No media added

### Browser support

My code works in the following browsers:

- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge