### PR TITLE
fix(table): [NoTicket] quote table title variant and section spacing

### DIFF
--- a/src/lib/components/table/Table.stories.tsx
+++ b/src/lib/components/table/Table.stories.tsx
@@ -830,6 +830,164 @@ export const TwoPlanQuote = {
   name: 'Two Plan Quote',
 };
 
+const getPlanDetailsData = (
+  selectedPlan: number,
+  setSelectedPlan: (plan: number) => void
+): TableData => [
+  {
+    rows: [
+      [
+        { text: 'Choose plan', fontVariant: 'SUBTITLE' },
+        {
+          type: 'BUTTON',
+          buttonCaption: 'Basic',
+          price: '€99/mo',
+          isSelected: selectedPlan === 1,
+          onClick: () => setSelectedPlan(1),
+        },
+        {
+          type: 'BUTTON',
+          buttonCaption: 'Advanced',
+          price: '€150/mo',
+          isSelected: selectedPlan === 2,
+          onClick: () => setSelectedPlan(2),
+        },
+      ],
+      [
+        {
+          text: "General doctors' visits",
+          modalContent: 'Visits to general practitioners are covered in full.',
+        },
+        { text: 'Up to €2 million' },
+        { text: 'Up to €2 million' },
+      ],
+      [
+        {
+          text: 'Specialists',
+          modalContent: 'Specialist visits are covered with a referral.',
+        },
+        { text: '4 visits per year' },
+        { text: 'Unlimited visits' },
+      ],
+      [
+        { text: 'Documents (not in a safe)' },
+        { text: '20% of the insured sum', description: 'max €3,000' },
+        { text: '30% of the insured sum', description: 'max €5,000' },
+      ],
+    ],
+  },
+  {
+    section: {
+      title: 'Theft, fraud and robberies',
+    },
+    rows: [
+      [
+        { text: 'Burglary and vandalism' },
+        { checkmarkValue: true },
+        { checkmarkValue: true },
+      ],
+      [
+        { text: 'Valuables in bank safe deposits' },
+        { text: '5% of the insured sum' },
+        { text: '30% of the insured sum' },
+      ],
+      [
+        { text: 'Credit card misuse', description: 'E.g. after a robbery' },
+        { checkmarkValue: false },
+        { text: '€1,500', description: 'with a €150 deductible' },
+      ],
+    ],
+  },
+  {
+    section: {
+      title: 'Damage protection',
+    },
+    rows: [
+      [
+        { text: 'Weather damage', description: 'Rain, storm, hail or snow' },
+        { checkmarkValue: true },
+        { checkmarkValue: true },
+      ],
+      [
+        {
+          text: 'Weather damage due to negligence',
+          description: 'E.g. belongings damaged due to windows left open',
+        },
+        { checkmarkValue: false },
+        { text: '€5,000', description: 'with a €500 deductible' },
+      ],
+      [
+        { text: 'Rainwater pipe leaks (within building)' },
+        { checkmarkValue: false },
+        { checkmarkValue: true },
+      ],
+    ],
+  },
+  {
+    section: {
+      title: 'Loss & replacement',
+    },
+    rows: [
+      [
+        { text: 'Luggage while travelling' },
+        { text: 'Up to €2,000' },
+        { text: 'Up to €5,000' },
+      ],
+      [
+        { text: 'Keys and locks', modalContent: 'Replacement of home keys and locks after theft.' },
+        { checkmarkValue: true },
+        { checkmarkValue: true },
+      ],
+    ],
+  },
+  {
+    section: {
+      title: 'Accommodation & relocation costs',
+    },
+    rows: [
+      [
+        { text: 'Hotel costs', description: 'If your home is uninhabitable' },
+        { text: 'Up to 100 days' },
+        { text: 'Up to 200 days' },
+      ],
+      [
+        { text: 'Relocation costs' },
+        { checkmarkValue: false },
+        { checkmarkValue: true },
+      ],
+    ],
+  },
+];
+
+const PlanDetailsQuoteStory = () => {
+  const [selectedPlan, setSelectedPlan] = useState(1);
+
+  return (
+    <div style={{ maxWidth: 900 }}>
+      <p className="p-p tc-neutral-500 mb16">
+        Plan details table from the Sign-Ups designs: SUBTITLE top left cell,
+        plan selection buttons, selected column highlight, collapsible sections,
+        checkmarks, values with descriptions, and info modals.
+      </p>
+      <Table
+        tableData={getPlanDetailsData(selectedPlan, setSelectedPlan)}
+        title="Plan details"
+        collapsibleSections
+        showSelectedColumn
+        activeSection={selectedPlan}
+        onSelectionChanged={setSelectedPlan}
+        mobileNavigationMode="tabs"
+      />
+    </div>
+  );
+};
+
+export const PlanDetailsQuote = {
+  render: () => <PlanDetailsQuoteStory />,
+
+  name: 'Plan Details - Quote',
+};
+
 const threePlanWebsiteData: TableData = [
   {
     rows: [

--- a/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
+++ b/src/lib/components/table/components/TableCell/BaseCell/BaseCell.tsx
@@ -11,7 +11,7 @@ import { MiniProgressBar } from './MiniProgressBar/MiniProgressBar';
 import { TableInfoButton } from '../../../../comparisonTable';
 import { ModalFunction } from '../../../types';
 
-export type FontVariant = 'NORMAL' | 'TITLE' | 'PRICE';
+export type FontVariant = 'NORMAL' | 'TITLE' | 'SUBTITLE' | 'PRICE';
 
 const progressLookup: Record<string, number> = {
   '30%': 1,
@@ -152,6 +152,15 @@ export const BaseCell = ({
               <h2
                 aria-hidden
                 className="tc-grey-800 p-h2 p--serif"
+              >
+                {text}
+              </h2>
+            )}
+
+            {text && fontVariant === 'SUBTITLE' && (
+              <h2
+                aria-hidden
+                className="tc-grey-800 p-h4"
               >
                 {text}
               </h2>

--- a/src/lib/components/table/components/TableCell/TableCell.module.scss
+++ b/src/lib/components/table/components/TableCell/TableCell.module.scss
@@ -31,6 +31,10 @@
   vertical-align: top;
 }
 
+.subtitleCell {
+  vertical-align: middle;
+}
+
 .fixedCell {
   position: sticky;
   left: 0;

--- a/src/lib/components/table/components/TableCell/TableCell.test.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.test.tsx
@@ -88,4 +88,22 @@ describe('TableCell', () => {
       title: '',
     });
   });
+
+  it('renders the top left cell as a title by default', () => {
+    setup({ isTopLeftCell: true, text: 'Choose a plan' });
+
+    expect(screen.getByText('Choose a plan')).toHaveClass('p-h2');
+  });
+
+  it('lets fontVariant override the top left cell title', () => {
+    setup({
+      isTopLeftCell: true,
+      fontVariant: 'SUBTITLE',
+      text: 'Choose a plan',
+    });
+
+    const cellText = screen.getByText('Choose a plan');
+    expect(cellText).toHaveClass('p-h4');
+    expect(cellText).not.toHaveClass('p-h2');
+  });
 });

--- a/src/lib/components/table/components/TableCell/TableCell.tsx
+++ b/src/lib/components/table/components/TableCell/TableCell.tsx
@@ -53,6 +53,8 @@ const TableCell = React.memo(
         className={classNames(isSelectedColumn ? 'bg-orange-50' : 'bg-white', styles.th, {
           'ta-left': isFirstCellInRow,
           [styles.headerCell]: isHeader,
+          [styles.subtitleCell]:
+            !cellProps.type && cellProps.fontVariant === 'SUBTITLE',
           [styles.thNavigation]: isNavigation,
           [styles.navigationTitle]: isNavigation && isTopLeftCell,
           [styles.fixedCell]: isFirstCellInRow && colSpan < 1 ,
@@ -66,9 +68,7 @@ const TableCell = React.memo(
           <BaseCell
             {...cellProps}
             fontVariant={
-              isTopLeftCell
-                ? 'TITLE'
-                : cellProps.fontVariant ?? 'NORMAL'
+              cellProps.fontVariant ?? (isTopLeftCell ? 'TITLE' : 'NORMAL')
             }
           />
         )}

--- a/src/lib/components/table/components/TableContents/Collapsible.tsx
+++ b/src/lib/components/table/components/TableContents/Collapsible.tsx
@@ -7,6 +7,21 @@ interface CollapsibleProps {
   onTransitionEnd?: () => void;
 }
 
+const measureHeight = (element: Element) => {
+  let height = 0;
+
+  for (const child of Array.from(element.children)) {
+    const childStyles = getComputedStyle(child);
+
+    height +=
+      child.getBoundingClientRect().height +
+      (parseFloat(childStyles.marginTop) || 0) +
+      (parseFloat(childStyles.marginBottom) || 0);
+  }
+
+  return Math.ceil(height);
+};
+
 export const Collapsible = ({ children, isExpanded, onTransitionEnd }: CollapsibleProps) => {
   const [height, setHeight] = useState<number | undefined>();
 
@@ -15,24 +30,21 @@ export const Collapsible = ({ children, isExpanded, onTransitionEnd }: Collapsib
 
   useEffect(() => {
     if (!observerRef.current) {
-      observerRef.current = new ResizeObserver((entries) => {
-        entries.forEach((entry) => {
-          const scrollheight = entry.target.scrollHeight;
-
-          setHeight(scrollheight);
-        });
+      observerRef.current = new ResizeObserver(() => {
+        if (containerRef.current) {
+          setHeight(measureHeight(containerRef.current));
+        }
       });
     }
     if (containerRef.current) {
       observerRef.current.observe(containerRef.current);
-      const scrollheight = containerRef.current.scrollHeight;
-      setHeight(scrollheight);
+      Array.from(containerRef.current.children).forEach((child) => {
+        observerRef.current?.observe(child);
+      });
+      setHeight(measureHeight(containerRef.current));
     }
 
     return () => {
-      if (containerRef.current) {
-        observerRef.current?.unobserve(containerRef.current);
-      }
       observerRef.current?.disconnect();
     };
   }, [containerRef.current]);


### PR DESCRIPTION
### What this PR does

- Fix collapsed sections clipping their bottom spacing: expanded sections now animate to their exact content height, so the gap between a section body and the next section header is no longer cut off.
- New `SUBTITLE` font variant for the top-left header cell (bold 16px, vertically centered), opt-in via `fontVariant` on the cell or through `cellReplacements`, the default large serif title is unchanged
- New "Plan Details - Quote" story covering the Sign-Ups plan details table
- Tests for the new variant and the `fontVariant` override precedence

#### **Section spacing before:**
<img width="941" height="219" alt="Screenshot 2026-08-18 at 14 23 35" src="https://github.com/user-attachments/assets/dbb10de3-8b7b-41fa-a120-3c3ea65f23f9" />

<img width="962" height="517" alt="Screenshot 2026-08-18 at 14 44 10" src="https://github.com/user-attachments/assets/0a979be5-c5ff-43ee-a0c4-094d993ede2b" />

#### **Section spacing after:**
<img width="937" height="239" alt="Screenshot 2026-08-18 at 14 24 05" src="https://github.com/user-attachments/assets/73fb1f1b-df96-4502-9a1e-a317d7616b38" />

<img width="782" height="464" alt="Screenshot 2026-08-18 at 14 43 46" src="https://github.com/user-attachments/assets/da43a3d5-6424-4745-a106-975c4468a5ac" />


